### PR TITLE
Add titati hardware interface for real robot control

### DIFF
--- a/rl_sar/README.md
+++ b/rl_sar/README.md
@@ -362,14 +362,15 @@ sudo ifconfig can0 txqueuelen 1000
 Build the standalone executables that run directly on the robot controller PC:
 
 ```bash
-./build.sh -m rl_sar
+./build.sh -m
 ```
 
+The CMake target relies on LibTorch. Make sure `Torch_DIR` points to your LibTorch installation before running the build. If the variable is missing CMake will stop with `TorchConfig.cmake` not found; follow the preparation section above to install LibTorch and export `Torch_DIR` on both the master and slave control PCs.
 The build places the hardware tools in `cmake_build/bin/`, most importantly `rl_real_titati` (RL controller) and `titati_motor_test` (diagnostics).
 
 #### Smoke tests before running RL
 
-1. **Verify feedback** – stream the raw joint state to confirm the CAN wiring:
+1. **Verify feedback** – stream the raw joint state to confirm the CAN wiring (run once on both the master and the slave controller PCs if you keep the factory dual-computer setup):
 
     ```bash
     ./cmake_build/bin/titati_motor_test --mode monitor
@@ -393,7 +394,7 @@ The build places the hardware tools in `cmake_build/bin/`, most importantly `rl_
 #### Running the RL policy on hardware
 
 1. Copy the trained TorchScript policy to `rl_sar/src/rl_sar/policy/titati/<YOUR_CONFIG>/` and update `config.yaml` as usual.
-2. Launch the real-time controller with the appropriate CAN interface mapping:
+2. Launch the real-time controller with the appropriate CAN interface mapping. Keep the vendor `titati_canfd_router` process running on the slave controller (or execute the RPC sequence manually) so that both MCU boards stay in `FORCE_DIRECT` mode while the RL policy is active:
 
     ```bash
     ./cmake_build/bin/rl_real_titati --can can0

--- a/rl_sar/README.md
+++ b/rl_sar/README.md
@@ -343,6 +343,70 @@ Pull the code and compile it. The process is the same as above.
 
 <details>
 
+<summary>Titati quadruped (Click to expand)</summary>
+
+#### Preparing the CAN FD interface
+
+The Titati stack assumes a CAN FD interface named `can0`. Bring the bus up before starting any controller (adjust the interface name if you are using a USB-CAN adapter that enumerates differently):
+
+```bash
+sudo systemctl stop tita-bringup.service  # stop any previously running vendor service
+sudo ip link set can0 down
+sudo ip link set can0 up type can bitrate 1000000 sample-point 0.80 \
+    dbitrate 8000000 dsample-point 0.80 fd on restart-ms 100
+sudo ifconfig can0 txqueuelen 1000
+```
+
+#### Building the hardware binaries
+
+Build the standalone executables that run directly on the robot controller PC:
+
+```bash
+./build.sh -m rl_sar
+```
+
+The build places the hardware tools in `cmake_build/bin/`, most importantly `rl_real_titati` (RL controller) and `titati_motor_test` (diagnostics).
+
+#### Smoke tests before running RL
+
+1. **Verify feedback** – stream the raw joint state to confirm the CAN wiring:
+
+    ```bash
+    ./cmake_build/bin/titati_motor_test --mode monitor
+    ```
+
+2. **Exercise each actuator** – apply a small deflection to every joint one-by-one (press `Ctrl+C` at any time to stop):
+
+    ```bash
+    ./cmake_build/bin/titati_motor_test --mode scan --offset 0.12 --rate 400
+    ```
+
+3. **Check an individual joint or torque channel** – for example, move hip #3 by +0.2 rad or apply 3 Nm on joint #5:
+
+    ```bash
+    ./cmake_build/bin/titati_motor_test --mode single --joint 3 --offset 0.2
+    ./cmake_build/bin/titati_motor_test --mode torque --joint 5 --torque 3.0
+    ```
+
+    All diagnostics accept `--can`, `--feedback-can`, and `--command-can` so you can point the tool at any CAN FD interface (for example `--can can1`).
+
+#### Running the RL policy on hardware
+
+1. Copy the trained TorchScript policy to `rl_sar/src/rl_sar/policy/titati/<YOUR_CONFIG>/` and update `config.yaml` as usual.
+2. Launch the real-time controller with the appropriate CAN interface mapping:
+
+    ```bash
+    ./cmake_build/bin/rl_real_titati --can can0
+    # or, when the feedback and command buses are split
+    ./cmake_build/bin/rl_real_titati --feedback-can can0 --command-can can1
+    ```
+
+3. During operation press `M` or `Esc` on the keyboard to engage the built-in **soft e-stop**. The controller immediately streams zero torques, hands control back to the MCU, and disables the Titati SDK mode. Press `K` to re-arm the drives once the situation is safe.
+
+</details>
+
+<details>
+
 <summary>Deeprobotics Lite3 (Click to expand)</summary>
 
 Deeprobotics Lite3 can be connected using wireless method.

--- a/rl_sar/src/rl_sar/CMakeLists.txt
+++ b/rl_sar/src/rl_sar/CMakeLists.txt
@@ -352,6 +352,13 @@ if(NOT USE_CMAKE)
     endif()
 endif()
 
+add_executable(titati_motor_test src/titati_motor_test.cpp)
+target_link_libraries(titati_motor_test
+    titati_robot
+    yaml-cpp
+)
+target_compile_features(titati_motor_test PRIVATE cxx_std_17)
+
 if(NOT USE_CMAKE)
     if($ENV{ROS_DISTRO} MATCHES "noetic")
         catkin_install_python(PROGRAMS

--- a/rl_sar/src/rl_sar/CMakeLists.txt
+++ b/rl_sar/src/rl_sar/CMakeLists.txt
@@ -119,6 +119,18 @@ target_include_directories(l4w4_sdk INTERFACE
 )
 target_link_libraries(l4w4_sdk INTERFACE Threads::Threads)
 
+# titati_robot sdk
+add_library(titati_robot STATIC
+    library/thirdparty/titati_robot/src/tita_robot.cpp
+    library/thirdparty/titati_robot/src/can_receiver.cpp
+    library/thirdparty/titati_robot/src/can_sender.cpp
+)
+target_include_directories(titati_robot PUBLIC
+    library/thirdparty/titati_robot/include
+)
+target_link_libraries(titati_robot PUBLIC Threads::Threads)
+target_compile_features(titati_robot PUBLIC cxx_std_17)
+
 # Lite3_MotionSDK
 add_library(lite3_motionsdk SHARED IMPORTED)
 set_target_properties(lite3_motionsdk PROPERTIES
@@ -318,6 +330,25 @@ if(NOT USE_CMAKE)
             geometry_msgs
         )
         install(TARGETS rl_real_l4w4 DESTINATION lib/${PROJECT_NAME})
+    endif()
+endif()
+
+add_executable(rl_real_titati src/rl_real_titati.cpp)
+target_link_libraries(rl_real_titati
+    titati_robot
+    rl_sdk
+    observation_buffer
+    yaml-cpp
+)
+if(NOT USE_CMAKE)
+    if($ENV{ROS_DISTRO} MATCHES "noetic")
+        target_link_libraries(rl_real_titati ${catkin_LIBRARIES})
+    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+        ament_target_dependencies(rl_real_titati
+            rclcpp
+            geometry_msgs
+        )
+        install(TARGETS rl_real_titati DESTINATION lib/${PROJECT_NAME})
     endif()
 endif()
 

--- a/rl_sar/src/rl_sar/include/rl_real_titati.hpp
+++ b/rl_sar/src/rl_sar/include/rl_real_titati.hpp
@@ -16,7 +16,11 @@
 #include "fsm.hpp"
 
 #include "tita_robot/tita_robot.hpp"
+#include <atomic>
 #include <csignal>
+#include <mutex>
+#include <string>
+#include <vector>
 
 #if defined(USE_ROS1) && defined(USE_ROS)
 #include <ros/ros.h>
@@ -37,7 +41,7 @@ class RL_Real : public RL
 #endif
 {
 public:
-    RL_Real();
+    RL_Real(const std::string &feedback_can_interface = "can0", const std::string &command_can_interface = "can0");
     ~RL_Real();
 
 private:
@@ -47,6 +51,10 @@ private:
     void SetCommand(const RobotCommand<double> *command) override;
     void RunModel();
     void RobotControl();
+    void EngageEstop(const std::string &source);
+    void ReleaseEstop(const std::string &source);
+    void ApplyZeroTorque();
+    void ClearCommandQueues();
 
     // loop
     std::shared_ptr<LoopFunc> loop_keyboard;
@@ -66,9 +74,15 @@ private:
 
     // titati interface
     std::unique_ptr<tita_robot> titati_robot_;
+    std::string feedback_can_interface_;
+    std::string command_can_interface_;
     std::vector<double> joint_positions_;
     std::vector<double> joint_velocities_;
     std::vector<double> joint_torques_;
+    std::vector<double> zero_torque_cmd_;
+    std::atomic<bool> estop_engaged_{false};
+    std::atomic<bool> motors_sdk_enabled_{false};
+    std::mutex command_mutex_;
 
     // others
     int motiontime = 0;

--- a/rl_sar/src/rl_sar/include/rl_real_titati.hpp
+++ b/rl_sar/src/rl_sar/include/rl_real_titati.hpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2024-2025 Ziqi Fan
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef RL_REAL_TITATI_HPP
+#define RL_REAL_TITATI_HPP
+
+// #define PLOT
+// #define CSV_LOGGER
+// #define USE_ROS
+
+#include "rl_sdk.hpp"
+#include "observation_buffer.hpp"
+#include "loop.hpp"
+#include "fsm.hpp"
+
+#include "tita_robot/tita_robot.hpp"
+#include <csignal>
+
+#if defined(USE_ROS1) && defined(USE_ROS)
+#include <ros/ros.h>
+#include <geometry_msgs/Twist.h>
+#elif defined(USE_ROS2) && defined(USE_ROS)
+#include <rclcpp/rclcpp.hpp>
+#include <geometry_msgs/msg/twist.hpp>
+#endif
+
+#ifdef PLOT
+#include "matplotlibcpp.h"
+namespace plt = matplotlibcpp;
+#endif
+
+class RL_Real : public RL
+#if defined(USE_ROS2) && defined(USE_ROS)
+    , public rclcpp::Node
+#endif
+{
+public:
+    RL_Real();
+    ~RL_Real();
+
+private:
+    // rl functions
+    torch::Tensor Forward() override;
+    void GetState(RobotState<double> *state) override;
+    void SetCommand(const RobotCommand<double> *command) override;
+    void RunModel();
+    void RobotControl();
+
+    // loop
+    std::shared_ptr<LoopFunc> loop_keyboard;
+    std::shared_ptr<LoopFunc> loop_control;
+    std::shared_ptr<LoopFunc> loop_rl;
+#ifdef PLOT
+    std::shared_ptr<LoopFunc> loop_plot;
+#endif
+
+#ifdef PLOT
+    // plot
+    const int plot_size = 100;
+    std::vector<int> plot_t;
+    std::vector<std::vector<double>> plot_real_joint_pos, plot_target_joint_pos;
+    void Plot();
+#endif
+
+    // titati interface
+    std::unique_ptr<tita_robot> titati_robot_;
+    std::vector<double> joint_positions_;
+    std::vector<double> joint_velocities_;
+    std::vector<double> joint_torques_;
+
+    // others
+    int motiontime = 0;
+
+#if defined(USE_ROS1) && defined(USE_ROS)
+    geometry_msgs::Twist cmd_vel;
+    ros::Subscriber cmd_vel_subscriber;
+    void CmdvelCallback(const geometry_msgs::Twist::ConstPtr &msg);
+#elif defined(USE_ROS2) && defined(USE_ROS)
+    geometry_msgs::msg::Twist cmd_vel;
+    rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_subscriber;
+    void CmdvelCallback(const geometry_msgs::msg::Twist::SharedPtr msg);
+#endif
+};
+
+#endif // RL_REAL_TITATI_HPP

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_robot/include/protocol/can_utils.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_robot/include/protocol/can_utils.hpp
@@ -1,0 +1,468 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__CAN_UTILS_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__CAN_UTILS_HPP_
+
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "linux/can.h"
+#include "linux/can/error.h"
+#include "linux/can/raw.h"
+#include "socket_can_receiver.hpp"
+#include "socket_can_sender.hpp"
+
+#define C_END "\033[m"
+// #define C_RED "\033[0;32;31m"
+#define C_RED "\033[0;31m"
+#define C_YELLOW "\033[1;33m"
+
+#ifdef GCC_OPTIMIZE_03
+#pragma GCC optimize("O3")
+#else
+#pragma GCC optimize("O0")
+#endif
+namespace can_device
+{
+namespace socket_can
+{
+using can_std_callback = std::function<void(std::shared_ptr<struct can_frame> recv_frame)>;
+using can_fd_callback = std::function<void(std::shared_ptr<struct canfd_frame> recv_frame)>;
+class CanRxDev
+{
+public:
+  explicit CanRxDev(
+    const std::string & interface, const std::string & name, can_std_callback recv_callback,
+    bool is_block, int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    init(interface, name, false, recv_callback, nullptr, is_block, nano_timeout);
+  }
+  explicit CanRxDev(
+    const std::string & interface, const std::string & name, can_fd_callback recv_callback,
+    bool is_block, int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    init(interface, name, true, nullptr, recv_callback, is_block, nano_timeout);
+  }
+
+  ~CanRxDev()
+  {
+    ready_ = false;
+    isthreadrunning_ = false;
+    if (main_T_ != nullptr) {
+      main_T_->join();
+    }
+    main_T_ = nullptr;
+    receiver_ = nullptr;
+  }
+
+  bool is_ready() { return ready_; }
+  bool is_timeout() { return is_timeout_; }
+  void set_filter(const struct can_filter filter[], size_t s)
+  {
+    if (receiver_ != nullptr) {
+      receiver_->set_filter(filter, s);
+    }
+  }
+
+  std::shared_ptr<canfd_frame> wait_for_can_data_block()
+  {
+    can_device::socket_can::CanId receive_id{};
+    std::string can_type;
+    if (canfd_) {
+      can_type = "FD";
+      rx_fd_frame_ = std::make_shared<struct canfd_frame>();
+    } else {
+      can_type = "STD";
+      rx_std_frame_ = std::make_shared<struct can_frame>();
+    }
+    if (receiver_ != nullptr) {
+      try {
+        bool result =
+          canfd_ ? receiver_->receive(rx_fd_frame_, std::chrono::nanoseconds(nano_timeout_))
+                 : receiver_->receive(rx_std_frame_, std::chrono::nanoseconds(nano_timeout_));
+        if (result) {
+          is_timeout_ = false;
+          return rx_fd_frame_;
+        } else {
+          return nullptr;
+        }
+      } catch (const std::exception & ex) {
+        if (ex.what()[0] == '$') {
+          is_timeout_ = true;
+          return nullptr;
+        }
+      }
+    } else {
+      isthreadrunning_ = false;
+      printf(
+        C_RED
+        "[CAN_RX %s][ERROR][%s] Error receiving CAN %s message: %s, "
+        "no receiver init\r\n" C_END,
+        can_type.c_str(), name_.c_str(), can_type.c_str(), interface_.c_str());
+    }
+    return nullptr;
+  }
+
+#ifdef COMMON_PROTOCOL_TEST
+  bool testing_setcandata(can_frame frame)
+  {
+    if (can_std_callback_ != nullptr) {
+      can_std_callback_(std::make_shared<struct can_frame>(frame));
+      return true;
+    }
+    return false;
+  }
+  bool testing_setcandata(canfd_frame frame)
+  {
+    if (can_fd_callback_ != nullptr) {
+      can_fd_callback_(std::make_shared<struct canfd_frame>(frame));
+      return true;
+    }
+    return false;
+  }
+#endif  // COMMON_PROTOCOL_TEST
+
+private:
+  bool ready_;
+  bool canfd_;
+  bool is_timeout_;
+  bool extended_frame_;
+  bool isthreadrunning_;
+  int64_t nano_timeout_;
+  std::string name_;
+  std::string interface_;
+  can_std_callback can_std_callback_;
+  can_fd_callback can_fd_callback_;
+  std::unique_ptr<std::thread> main_T_;
+  std::shared_ptr<struct can_frame> rx_std_frame_;
+  std::shared_ptr<struct canfd_frame> rx_fd_frame_;
+  std::unique_ptr<can_device::socket_can::SocketCanReceiver> receiver_;
+  uint8_t can_id_offset_ = 0;
+  void init(
+    const std::string & interface, const std::string & name, bool canfd_on,
+    can_std_callback std_callback, can_fd_callback fd_callback, bool is_block, int64_t nano_timeout)
+  {
+    name_ = name;
+    interface_ = interface;
+    canfd_ = canfd_on;
+    nano_timeout_ = nano_timeout;
+    is_timeout_ = false;
+    interface_ = interface;
+    can_std_callback_ = std_callback;
+    can_fd_callback_ = fd_callback;
+    try {
+      receiver_ = std::make_unique<can_device::socket_can::SocketCanReceiver>(interface_, canfd_);
+      if (!is_block) {
+        isthreadrunning_ = true;
+        ready_ = true;
+        main_T_ = std::make_unique<std::thread>(std::bind(&CanRxDev::main_recv_func, this));
+      }
+    } catch (const std::exception & ex) {
+      printf(
+        C_RED "[CAN_RX][ERROR][%s] %s receiver creat error! %s\r\n" C_END, name_.c_str(),
+        interface_.c_str(), ex.what());
+      return;
+    }
+  }
+
+  bool wait_for_can_data()
+  {
+    can_device::socket_can::CanId receive_id{};
+    std::string can_type;
+    if (canfd_) {
+      can_type = "FD";
+      rx_fd_frame_ = std::make_shared<struct canfd_frame>();
+    } else {
+      can_type = "STD";
+      rx_std_frame_ = std::make_shared<struct can_frame>();
+    }
+
+    if (receiver_ != nullptr) {
+      try {
+        bool result =
+          canfd_ ? receiver_->receive(rx_fd_frame_, std::chrono::nanoseconds(nano_timeout_))
+                 : receiver_->receive(rx_std_frame_, std::chrono::nanoseconds(nano_timeout_));
+        if (result) {
+          is_timeout_ = false;
+        }
+        return result;
+      } catch (const std::exception & ex) {
+        if (ex.what()[0] == '$') {
+          is_timeout_ = true;
+          return false;
+        }
+        printf(
+          C_RED "[CAN_RX %s][ERROR][%s] Error receiving CAN %s message: %s - %s\n" C_END,
+          can_type.c_str(), name_.c_str(), can_type.c_str(), interface_.c_str(), ex.what());
+      }
+    } else {
+      isthreadrunning_ = false;
+      printf(
+        C_RED
+        "[CAN_RX %s][ERROR][%s] Error receiving CAN %s message: %s, "
+        "no receiver init\r\n" C_END,
+        can_type.c_str(), name_.c_str(), can_type.c_str(), interface_.c_str());
+    }
+    return false;
+  }
+
+  void main_recv_func()
+  {
+#ifdef DEBUG_LOG
+    printf("[CAN_RX][INFO][%s] Start recv thread: %s\r\n", interface_.c_str(), name_.c_str());
+#endif  // DEBUG_LOG
+    while (isthreadrunning_ && ready_) {
+      if (wait_for_can_data()) {
+        if (!canfd_ && can_std_callback_ != nullptr) {
+          can_std_callback_(rx_std_frame_);
+        } else if (canfd_ && can_fd_callback_ != nullptr) {
+          can_fd_callback_(rx_fd_frame_);
+        }
+      }
+    }
+#ifdef DEBUG_LOG
+    printf("[CAN_RX][INFO][%s] Exit recv thread: %s\r\n", interface_.c_str(), name_.c_str());
+#endif  // DEBUG_LOG
+  }
+};
+
+class CanTxDev
+{
+public:
+  explicit CanTxDev(
+    const std::string & interface, const std::string & name, bool extended_frame, bool canfd_on,
+    int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    can_id_offset_ = can_id_offset;
+    ready_ = false;
+    name_ = name;
+    nano_timeout_ = nano_timeout;
+    is_timeout_ = false;
+    canfd_on_ = canfd_on;
+    interface_ = interface;
+    extended_frame_ = extended_frame;
+    try {
+      sender_ = std::make_unique<can_device::socket_can::SocketCanSender>(interface_, canfd_on_);
+    } catch (const std::exception & ex) {
+      printf(
+        C_RED "[CAN_TX][ERROR][%s] %s sender creat error! %s\r\n" C_END, name_.c_str(),
+        interface_.c_str(), ex.what());
+      return;
+    }
+    ready_ = true;
+  }
+
+  ~CanTxDev()
+  {
+    ready_ = false;
+    sender_ = nullptr;
+  }
+
+  bool send_can_message(struct can_frame & tx_frame)
+  {
+    return send_can_message(&tx_frame, nullptr);
+  }
+  bool send_can_message(struct canfd_frame & tx_frame)
+  {
+    return send_can_message(nullptr, &tx_frame);
+  }
+
+  bool is_ready() { return ready_; }
+  bool is_timeout() { return is_timeout_; }
+
+private:
+  bool ready_;
+  bool canfd_on_;
+  bool is_timeout_;
+  bool extended_frame_;
+  int64_t nano_timeout_;
+  std::string name_;
+  std::string interface_;
+  std::unique_ptr<can_device::socket_can::SocketCanSender> sender_;
+  uint8_t can_id_offset_;
+
+  bool send_can_message(struct can_frame * std_frame, struct canfd_frame * fd_frame)
+  {
+    bool self_fd = (fd_frame != nullptr);
+    std::string can_type = self_fd ? "FD" : "STD";
+    if (canfd_on_ != self_fd) {
+      printf(
+        C_RED
+        "[CAN_TX %s][ERROR][%s] Error sending CAN message: %s - "
+        "Not support can/canfd frame mixed\r\n" C_END,
+        can_type.c_str(), name_.c_str(), interface_.c_str());
+      return false;
+    }
+    canid_t * canid = self_fd ? &fd_frame->can_id : &std_frame->can_id;
+
+    bool result = true;
+    can_device::socket_can::CanId send_id =
+      extended_frame_
+        ? can_device::socket_can::CanId(
+            *canid, can_device::socket_can::FrameType::DATA, can_device::socket_can::ExtendedFrame)
+        : can_device::socket_can::CanId(
+            *canid, can_device::socket_can::FrameType::DATA, can_device::socket_can::StandardFrame);
+    if (sender_ != nullptr) {
+      try {
+        if (self_fd) {
+          sender_->send_fd(
+            fd_frame->data, (fd_frame->len == 0) ? 64 : fd_frame->len, send_id,
+            std::chrono::nanoseconds(nano_timeout_));
+          is_timeout_ = false;
+        } else {
+          sender_->send(
+            std_frame->data, (std_frame->can_dlc == 0) ? 8 : std_frame->can_dlc, send_id,
+            std::chrono::nanoseconds(nano_timeout_));
+          is_timeout_ = false;
+        }
+      } catch (const std::exception & ex) {
+        if (ex.what()[0] == '$') {
+          is_timeout_ = true;
+          return false;
+        }
+        result = false;
+        printf(
+          C_RED "[CAN_TX %s][ERROR][%s] Error sending CAN message: %s - %s\r\n" C_END,
+          can_type.c_str(), name_.c_str(), interface_.c_str(), ex.what());
+      }
+    } else {
+      result = false;
+      printf(
+        C_RED "[CAN_TX %s][ERROR][%s] Error sending CAN message: %s - No device\r\n" C_END,
+        can_type.c_str(), name_.c_str(), interface_.c_str());
+    }
+    return result;
+  }
+};
+
+class CanDev
+{
+public:
+  explicit CanDev(
+    const std::string & interface, const std::string & name, bool extended_frame,
+    can_std_callback recv_callback, bool is_block, int64_t nano_timeout = -1,
+    uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    name_ = name;
+    send_only_ = false;
+    tx_op_ = std::make_unique<CanTxDev>(
+      interface, name_, extended_frame, false, nano_timeout, can_id_offset_);
+    rx_op_ = std::make_unique<CanRxDev>(
+      interface, name_, recv_callback, is_block, nano_timeout, can_id_offset_);
+  }
+  explicit CanDev(
+    const std::string & interface, const std::string & name, bool extended_frame,
+    can_fd_callback recv_callback, bool is_block, int64_t nano_timeout = -1,
+    uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    name_ = name;
+    send_only_ = false;
+    tx_op_ = std::make_unique<CanTxDev>(
+      interface, name_, extended_frame, true, nano_timeout, can_id_offset_);
+    rx_op_ = std::make_unique<CanRxDev>(
+      interface, name_, recv_callback, is_block, nano_timeout, can_id_offset_);
+  }
+  explicit CanDev(
+    const std::string & interface, const std::string & name, bool extended_frame, bool canfd_on,
+    int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    name_ = name;
+    send_only_ = true;
+    tx_op_ = std::make_unique<CanTxDev>(
+      interface, name_, extended_frame, canfd_on, nano_timeout, can_id_offset_);
+  }
+
+  ~CanDev()
+  {
+    rx_op_ = nullptr;
+    tx_op_ = nullptr;
+  }
+
+  std::shared_ptr<canfd_frame> receive_can_message_block()
+  {
+    return rx_op_->wait_for_can_data_block();
+  }
+
+  bool send_can_message(struct can_frame & tx_frame)
+  {
+#ifdef COMMON_PROTOCOL_TEST
+    if (rx_op_ != nullptr) {
+      return rx_op_->testing_setcandata(tx_frame);
+    }
+    return false;
+#else
+    if (tx_op_ != nullptr) {
+      return tx_op_->send_can_message(tx_frame);
+    }
+    return false;
+#endif  // COMMON_PROTOCOL_TEST
+  }
+
+  bool send_can_message(struct canfd_frame & tx_frame)
+  {
+#ifdef COMMON_PROTOCOL_TEST
+    if (rx_op_ != nullptr) {
+      return rx_op_->testing_setcandata(tx_frame);
+    }
+    return false;
+#else
+    if (tx_op_ != nullptr) {
+      return tx_op_->send_can_message(tx_frame);
+    }
+    return false;
+#endif  // COMMON_PROTOCOL_TEST
+  }
+
+  void set_filter(const struct can_filter filter[], size_t s)
+  {
+    if (rx_op_ != nullptr) {
+      rx_op_->set_filter(filter, s);
+    }
+  }
+  bool is_send_only() { return send_only_; }
+  bool is_ready()
+  {
+    bool result = (tx_op_ == nullptr) ? false : tx_op_->is_ready();
+    if (send_only_) {
+      return result;
+    } else {
+      return result && ((rx_op_ == nullptr) ? false : rx_op_->is_ready());
+    }
+  }
+  bool is_rx_timeout() { return rx_op_->is_timeout(); }
+  bool is_tx_timeout() { return tx_op_->is_timeout(); }
+
+private:
+  bool send_only_;
+  std::string name_;
+  std::unique_ptr<CanRxDev> rx_op_;
+  std::unique_ptr<CanTxDev> tx_op_;
+  uint8_t can_id_offset_ = 0;
+};
+
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__CAN_UTILS_HPP_

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_robot/include/protocol/socket_can_common.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_robot/include/protocol/socket_can_common.hpp
@@ -1,0 +1,122 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_COMMON_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_COMMON_HPP_
+
+#include <linux/can.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <sys/time.h>
+
+#include <chrono>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+
+#define GCC_OPTIMIZE_03
+
+#ifdef GCC_OPTIMIZE_03
+#pragma GCC optimize("O3")
+#else
+#pragma GCC optimize("O0")
+#endif
+
+namespace can_device
+{
+namespace socket_can
+{
+inline bool bind_can_socket(int & fd, const std::string & interface, const bool canfd_on = false)
+{
+  if (interface.length() >= static_cast<std::string::size_type>(IFNAMSIZ)) {
+    throw std::domain_error{"CAN interface name too long"};
+    return false;
+  }
+
+  fd = socket(PF_CAN, static_cast<int32_t>(SOCK_RAW), CAN_RAW);
+  if (0 > fd) {
+    throw std::runtime_error{"Failed to open CAN socket"};
+    return false;
+  }
+
+  // Make it non-blocking so we can use timeouts
+
+  struct ifreq ifr;
+  (void)strncpy(&ifr.ifr_name[0U], interface.c_str(), IFNAMSIZ - 1);
+  ifr.ifr_name[IFNAMSIZ - 1] = '\0';
+  ifr.ifr_ifindex = if_nametoindex(ifr.ifr_name);
+  if (!ifr.ifr_ifindex) {
+    perror("if_nametoindex");
+    return false;
+  }
+
+  struct sockaddr_can addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.can_family = AF_CAN;
+  addr.can_ifindex = ifr.ifr_ifindex;
+
+  if (canfd_on) {
+    if (ioctl(fd, SIOCGIFMTU, &ifr) < 0) {
+      throw std::runtime_error{"Failed to set CAN FD socket name via ioctl()"};
+      return false;
+    }
+    if (ifr.ifr_mtu != CANFD_MTU) {
+      throw std::runtime_error{"Interface does not support CAN FD"};
+      return false;
+    }
+    int _canfd_on = canfd_on ? 1 : 0;
+    auto ret = setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FD_FRAMES, &_canfd_on, sizeof(_canfd_on));
+    if (ret) {
+      throw std::runtime_error{"error whem enable canfd"};
+      return false;
+    }
+  }
+
+  /* disable default receive filter on this RAW socket */
+  /* This is obsolete as we do not read from the socket at all, but for */
+  /* this reason we can remove the receive list in the Kernel to save a */
+  /* little (really a very little!) CPU usage.                          */
+  setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FILTER, NULL, 0);
+
+  if (0 > bind(fd, (struct sockaddr *)&addr, sizeof(addr))) {
+    throw std::runtime_error{"Failed to bind CAN socket"};
+    return false;
+  }
+
+  return true;
+}
+
+inline struct timeval to_timeval(const std::chrono::nanoseconds timeout) noexcept
+{
+  const auto count = timeout.count();
+  constexpr auto BILLION = 1'000'000'000LL;
+  struct timeval c_timeout;
+  c_timeout.tv_sec = static_cast<decltype(c_timeout.tv_sec)>(count / BILLION);
+  c_timeout.tv_usec = static_cast<decltype(c_timeout.tv_usec)>((count % BILLION) * (0.001));
+
+  return c_timeout;
+}
+
+inline fd_set single_set(int32_t file_descriptor) noexcept
+{
+  fd_set descriptor_set;
+  FD_ZERO(&descriptor_set);
+  FD_SET(file_descriptor, &descriptor_set);
+
+  return descriptor_set;
+}
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_COMMON_HPP_

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_robot/include/protocol/socket_can_id.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_robot/include/protocol/socket_can_id.hpp
@@ -1,0 +1,188 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_ID_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_ID_HPP_
+
+#include <linux/can.h>
+
+#include <stdexcept>
+#include <utility>
+
+#include "visibility_control.hpp"
+
+namespace can_device
+{
+namespace socket_can
+{
+using IdT = uint32_t;
+using LengthT = uint32_t;
+
+constexpr std::size_t MAX_DATA_LENGTH = 64U;
+
+static_assert(
+  MAX_DATA_LENGTH == sizeof(std::declval<struct canfd_frame>().data),
+  "Unexpected CAN frame data size");
+static_assert(std::is_same<IdT, canid_t>::value, "Underlying type of CanId is incorrect");
+constexpr IdT EXTENDED_MASK = CAN_EFF_FLAG;
+constexpr IdT REMOTE_MASK = CAN_RTR_FLAG;
+constexpr IdT ERROR_MASK = CAN_ERR_FLAG;
+constexpr IdT EXTENDED_ID_MASK = CAN_EFF_MASK;
+constexpr IdT STANDARD_ID_MASK = CAN_SFF_MASK;
+
+class SOCKETCAN_PUBLIC SocketCanTimeout : public std::runtime_error
+{
+public:
+  explicit SocketCanTimeout(const char * const what) : runtime_error{what} {};
+};  // class SocketCanTimeout
+
+enum class FrameType : uint32_t { DATA, ERROR, REMOTE };
+
+struct StandardFrame_
+{
+};
+
+constexpr StandardFrame_ StandardFrame;
+
+struct ExtendedFrame_
+{
+};
+
+constexpr ExtendedFrame_ ExtendedFrame;
+
+class SOCKETCAN_PUBLIC CanId
+{
+public:
+  CanId() = default;
+  explicit CanId(const IdT raw_id, const LengthT data_length = 0U)
+  : m_id{raw_id}, m_data_length{data_length}
+  {
+    (void)frame_type();
+  }
+
+  CanId(const IdT id, FrameType type, StandardFrame_) : CanId{id, type, false} {}
+  CanId(const IdT id, FrameType type, ExtendedFrame_) : CanId{id, type, true} {}
+
+  CanId & standard() noexcept
+  {
+    m_id = m_id & (~EXTENDED_MASK);
+    return *this;
+  }
+
+  CanId & extended() noexcept
+  {
+    m_id = m_id | EXTENDED_MASK;
+    return *this;
+  }
+
+  CanId & error_frame() noexcept
+  {
+    m_id = m_id & (~REMOTE_MASK);
+    m_id = m_id | ERROR_MASK;
+    return *this;
+  }
+
+  CanId & remote_frame() noexcept
+  {
+    m_id = m_id & (~ERROR_MASK);
+    m_id = m_id | REMOTE_MASK;
+    return *this;
+  }
+
+  CanId & data_frame() noexcept
+  {
+    m_id = m_id & (~ERROR_MASK);
+    m_id = m_id & (~REMOTE_MASK);
+    return *this;
+  }
+
+  CanId & frame_type(const FrameType type)
+  {
+    switch (type) {
+      case FrameType::DATA:
+        (void)data_frame();
+        break;
+      case FrameType::ERROR:
+        (void)error_frame();
+        break;
+      case FrameType::REMOTE:
+        (void)remote_frame();
+        break;
+      default:
+        throw std::logic_error{"CanId: No such type"};
+    }
+    return *this;
+  }
+
+  CanId & identifier(const IdT id)
+  {
+    constexpr auto MAX_EXTENDED = 0x1FBF'FFFFU;
+    constexpr auto MAX_STANDARD = 0x7FFU;
+
+    static_assert(MAX_EXTENDED <= EXTENDED_ID_MASK, "Max extended id value is wrong");
+    static_assert(MAX_STANDARD <= STANDARD_ID_MASK, "Max standed id value is wrong");
+    const auto max_id = is_extended() ? MAX_EXTENDED : MAX_STANDARD;
+    if (max_id < id) {
+      throw std::domain_error{"CanId would be truncated!"};
+    }
+    m_id = m_id & (~EXTENDED_ID_MASK);
+    m_id = m_id | id;
+    return *this;
+  }
+
+  IdT identifier() const noexcept
+  {
+    const auto mask = is_extended() ? EXTENDED_ID_MASK : STANDARD_ID_MASK;
+    return m_id & mask;
+  }
+
+  IdT get() const noexcept { return m_id; }
+
+  bool is_extended() const noexcept { return (m_id & EXTENDED_MASK) == EXTENDED_MASK; }
+
+  FrameType frame_type() const
+  {
+    const auto is_error = (m_id & ERROR_MASK) == ERROR_MASK;
+    const auto is_remote = (m_id & REMOTE_MASK) == REMOTE_MASK;
+    if (is_error && is_remote) {
+      throw std::domain_error{"CanId has both bit 29 and 30 set! Inconsistent"};
+    }
+    if (is_error) {
+      return FrameType::ERROR;
+    }
+    if (is_remote) {
+      return FrameType::REMOTE;
+    }
+    return FrameType::DATA;
+  }
+
+  LengthT length() const noexcept { return m_data_length; }
+  IdT m_id{};
+
+private:
+  SOCKETCAN_LOCAL CanId(const IdT id, FrameType type, bool is_extended)
+  {
+    if (is_extended) {
+      (void)extended();
+    }
+    (void)frame_type(type);
+    (void)identifier(id);
+  }
+
+  LengthT m_data_length{};
+};  // class CanId
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_ID_HPP_

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_robot/include/protocol/socket_can_receiver.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_robot/include/protocol/socket_can_receiver.hpp
@@ -1,0 +1,145 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_RECEIVER_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_RECEIVER_HPP_
+#include <linux/can.h>
+#include <linux/can/raw.h>
+#include <sys/socket.h>
+#include <unistd.h>  // for close()
+
+#include <chrono>
+#include <cstring>
+#include <memory>
+#include <string>
+
+#include "socket_can_common.hpp"
+#include "socket_can_id.hpp"
+#include "visibility_control.hpp"
+
+namespace can_device
+{
+namespace socket_can
+{
+// using target_can_device = static_cast<std::string>(TARGET_CAN_DEVICE);
+
+class SOCKETCAN_PUBLIC SocketCanReceiver
+{
+public:
+  explicit SocketCanReceiver(
+    const std::string & interface = "can0", bool canfd_on = false)
+  {
+    if (!bind_can_socket(fd_, interface, canfd_on)) {
+      printf("bind_can_socket failed!\r\n");
+      return;
+    }
+  }
+
+  ~SocketCanReceiver() noexcept { (void)close(fd_); }
+
+  bool receive(
+    std::shared_ptr<struct can_frame> rx_frame,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero())
+  {
+    wait(timeout);
+
+    struct canfd_frame frame;
+    memset(&frame, 0, sizeof(frame));
+    const auto nbytes = read(fd_, &frame, sizeof(frame));
+
+    if (nbytes < 0) {
+      throw std::runtime_error{strerror(errno)};
+    }
+    if (static_cast<std::size_t>(nbytes) < CAN_MTU) {
+      throw std::logic_error{"read: incomplete CAN frame"};
+    }
+    if (static_cast<std::size_t>(nbytes) != CAN_MTU) {
+      throw std::logic_error{"Message was wrong size"};
+    }
+
+    auto receive_id = CanId{frame.can_id, frame.len};
+    if (receive_id.frame_type() == can_device::socket_can::FrameType::DATA) {
+      rx_frame->can_id = receive_id.standard().get();
+      rx_frame->can_id = receive_id.length();
+      std::memcpy(rx_frame->data, frame.data, sizeof(rx_frame->data));
+      return true;
+    }
+    return false;
+  }
+
+  bool receive(
+    std::shared_ptr<struct canfd_frame> rx_frame,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero())
+  {
+    wait(timeout);
+
+    struct canfd_frame frame;
+    const auto nbytes = read(fd_, &frame, sizeof(frame));
+
+    uint8_t except_len = CAN_MTU - 8 + frame.len;
+    if (nbytes < 0) {
+      throw std::runtime_error{strerror(errno)};
+    }
+    if (static_cast<std::size_t>(nbytes) < except_len) {
+      throw std::runtime_error{"read: incomplete CAN frame"};
+    }
+
+    auto receive_id = CanId{frame.can_id, frame.len};
+    if (receive_id.frame_type() == can_device::socket_can::FrameType::DATA) {
+      rx_frame->can_id = receive_id.standard().get();
+      rx_frame->len = receive_id.length();
+      std::memcpy(rx_frame->data, frame.data, sizeof(rx_frame->data));
+      return true;
+    }
+    return false;
+  }
+
+  void set_filter(const struct can_filter filter[], size_t s)
+  {
+    setsockopt(fd_, SOL_CAN_RAW, CAN_RAW_FILTER, filter, s);
+  }
+
+private:
+  SOCKETCAN_LOCAL void wait(const std::chrono::nanoseconds timeout) const
+  {
+    if (decltype(timeout)::zero() < timeout) {
+      auto c_timeout = to_timeval(timeout);
+      auto read_set = single_set(fd_);
+
+      if (0 == select(fd_ + 1, &read_set, NULL, NULL, &c_timeout)) {
+        throw SocketCanTimeout{"$CAN Receive Timeout 1"};
+      }
+
+      if (!FD_ISSET(fd_, &read_set)) {
+        throw SocketCanTimeout{"$CAN Receive Timeout 2"};
+      }
+    } else {
+      auto read_set = single_set(fd_);
+
+      if (0 == select(fd_ + 1, &read_set, NULL, NULL, NULL)) {
+        throw SocketCanTimeout{"$CAN Receive Timeout 1"};
+      }
+
+      if (!FD_ISSET(fd_, &read_set)) {
+        throw SocketCanTimeout{"CAN Receive Timeout 2"};
+      }
+    }
+  }
+
+  int32_t fd_;
+};  // class SocketCanReceiver
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_RECEIVER_HPP_

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_robot/include/protocol/socket_can_sender.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_robot/include/protocol/socket_can_sender.hpp
@@ -1,0 +1,168 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_SENDER_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_SENDER_HPP_
+
+#include <linux/can.h>
+#include <linux/can/raw.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <stdexcept>
+#include <string>
+
+#include "socket_can_common.hpp"
+#include "socket_can_id.hpp"
+#include "visibility_control.hpp"
+
+namespace can_device
+{
+namespace socket_can
+{
+class SOCKETCAN_PUBLIC SocketCanSender
+{
+public:
+  explicit SocketCanSender(
+    const std::string & interface = "can0", bool canfd_on = false,
+    const CanId & default_id = CanId{})
+  : m_default_id{default_id}
+  {
+    if (!bind_can_socket(fd_, interface, canfd_on)) {
+      printf("bind_can_socket failed\r\n");
+      return;
+    }
+  }
+  ~SocketCanSender() noexcept
+  {
+    (void)close(fd_);
+    // I'm destructing--there's not much else I can do on an error
+    // seem not good
+  }
+
+  void send(
+    const void * const data, const std::size_t Length,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    send(data, Length, m_default_id, timeout);
+  }
+
+  void send(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    if (length > MAX_DATA_LENGTH) {
+      throw std::domain_error{"Size is too large to send via CAN"};
+    }
+    send_impl(data, length, id, timeout);
+  }
+
+  template <typename T, typename = std::enable_if_t<!std::is_pointer<T>::value>>
+  void send(
+    const T & data, const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    send(data, m_default_id, timeout);
+  }
+
+  template <typename T, typename = std::enable_if<!std::is_pointer<T>::value>>
+  void send(
+    const T & data, const CanId id,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    static_assert(sizeof(data) <= MAX_DATA_LENGTH, "Data type too large for CAN");
+    send_impl(reinterpret_cast<const char *>(&data), sizeof(data), id, timeout);
+  }
+
+  void send_fd(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    if (length > MAX_DATA_LENGTH) {
+      throw std::domain_error{"Size is too large to send via CAN"};
+    }
+    send_fd_impl(data, length, id, timeout);
+  }
+
+  CanId default_id() const noexcept { return m_default_id; }
+
+private:
+  void send_impl(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout) const
+  {
+    // (void)data;
+    // (void)length;
+    // (void)id;
+    (void)timeout;
+
+    struct can_frame data_frame;
+    data_frame.can_id = id.get();
+
+    data_frame.can_dlc = static_cast<decltype(data_frame.can_dlc)>(length);
+
+    (void)std::memcpy(static_cast<void *>(&data_frame.data[0U]), data, length);
+
+    if (write(fd_, &data_frame, static_cast<int>(CAN_MTU)) != static_cast<int>(CAN_MTU)) {
+      throw std::runtime_error{strerror(errno)};
+    }
+  }
+
+  void send_fd_impl(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout) const
+  {
+    // (void)data;
+    // (void)length;
+    // (void)id;
+    (void)timeout;
+
+    struct canfd_frame data_frame;
+    memset(&data_frame, 0, sizeof(data_frame));
+    data_frame.can_id = id.get();
+    data_frame.flags = CANFD_FDF | CANFD_BRS;
+    data_frame.len = static_cast<decltype(data_frame.len)>(length);
+    std::memcpy(static_cast<void *>(&data_frame.data[0U]), data, length);
+    if (write(fd_, &data_frame, CANFD_MTU) != CANFD_MTU) {
+      throw std::runtime_error{strerror(errno)};
+    }
+  }
+
+  SOCKETCAN_LOCAL void wait(const std::chrono::nanoseconds timeout) const
+  {
+    if (decltype(timeout)::zero() < timeout) {
+      auto c_timeout = to_timeval(timeout);
+      auto write_set = single_set(fd_);
+
+      // wait
+      if (0 == select(fd_ + 1, NULL, &write_set, NULL, &c_timeout)) {
+        throw SocketCanTimeout{"$CAN Send Timeout [1]"};
+      }
+
+      if (!FD_ISSET(fd_, &write_set)) {
+        throw SocketCanTimeout{"$CAN Send Timeout [2]"};
+      }
+    } else {
+      // do nothing
+      // auto write_set = single_set(fd_);
+    }
+  }
+
+  int32_t fd_;
+  CanId m_default_id;
+};
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_SENDER_HPP_

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_robot/include/protocol/visibility_control.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_robot/include/protocol/visibility_control.hpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__VISIBILITY_CONTROL_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__VISIBILITY_CONTROL_HPP_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+#ifdef __GNUC__
+#define SOCKETCAN_EXPORT __attribute__((dllexport))
+#define SOCKETCAN_IMPORT __attribute__((dllimport))
+#else
+#define SOCKETCAN_EXPORT __declspec(dllexport)
+#define SOCKETCAN_IMPORT __declspec(dllimport)
+#endif
+#ifdef SOCKETCAN_BUILDING_LIBRARY
+#define SOCKETCAN_PUBLIC SOCKETCAN_EXPORT
+#else
+#define SOCKETCAN_PUBLIC SOCKETCAN_IMPORT
+#endif
+#define SOCKETCAN_PUBLIC_TYPE SOCKETCAN_PUBLIC
+#define SOCKETCAN_LOCAL
+#else
+#define SOCKETCAN_EXPORT __attribute__((visibility("default")))
+#define SOCKETCAN_IMPORT
+#if __GNUC__ >= 4
+#define SOCKETCAN_PUBLIC __attribute__((visibility("default")))
+#define SOCKETCAN_LOCAL __attribute__((visibility("hidden")))
+#else
+#define SOCKETCAN_PUBLIC
+#define SOCKETCAN_LOCAL
+#endif
+#define SOCKETCAN_PUBLIC_TYPE
+#endif
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__VISIBILITY_CONTROL_HPP_

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_robot/include/tita_robot/can_receiver.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_robot/include/tita_robot/can_receiver.hpp
@@ -1,0 +1,116 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MOTORS_CAN__MOTORS_CAN_API_HPP_
+#define MOTORS_CAN__MOTORS_CAN_API_HPP_
+
+#include <algorithm>
+#include <atomic>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "protocol/can_utils.hpp"
+namespace can_device
+{
+#define PACKED __attribute__((__packed__))
+#define GRAVITY 9.81f
+#define CAN_ID_MOTOR_IN 0x108
+#define CAN_ID_IMU1 0x118
+#define CAN_ID_STATE 0x102
+
+  struct api_motor_in_t
+  {
+    uint32_t timestamp;
+    float position;
+    float velocity;
+    float torque;
+  } PACKED;
+  /* 44 bytes */
+  struct api_imu_data_t
+  {
+    uint32_t timestamp;
+    float accl[3];
+    float gyro[3];
+    float quaternion[4]; // x y z w
+    float temperature;
+  } PACKED;
+  
+  struct api_motor_status_t
+  {
+    uint32_t timestamp;
+    uint16_t key;
+    uint8_t value[8];
+  } PACKED;
+
+  class MotorsImuCanReceiveApi
+  {
+  public:
+    MotorsImuCanReceiveApi(size_t size)
+    {
+      if(size % 8 == 0) leg_dof_ = 4;
+      else if(size % 6 == 0) leg_dof_ = 3;
+      leg_num_ = size / leg_dof_;
+      register_motors_device_can_filter();
+      api_motor_in_t default_motor_in;
+      std::memset(&default_motor_in, 0x00U, sizeof(api_motor_in_t));
+      motors_in_.resize(size, default_motor_in);
+      std::memset(&imu_data_, 0x00U, sizeof(api_imu_data_t));
+    }
+    ~MotorsImuCanReceiveApi() {}
+    const std::vector<api_motor_in_t> *get_motors_in() const { return &motors_in_; }
+    const api_imu_data_t *get_imu_data() const { return &imu_data_; }
+    const api_motor_status_t *get_motors_status() const { return &motors_status_; }
+
+  private:
+#define MIN_TIME_OUT_US 1'000L     // 1ms
+#define MAX_TIME_OUT_US 3'000'000L // 3s
+#define CAN_MASK_AS_MOTORS_INFO (0x7E0U)
+    std::string motors_can_interface = "can0";
+    std::string motors_can_name = "motors_can";
+    bool motors_can_extended_frame = false;
+    bool motors_can_rx_is_block = false;
+    int64_t motors_timeout_us = MAX_TIME_OUT_US;
+    uint8_t motors_can_id_offset = 0x00U;
+
+    void register_motors_device_can_filter();
+    can_device::socket_can::can_fd_callback motors_can_receive_callback =
+        std::bind(&MotorsImuCanReceiveApi::board_can_data_callback, this, std::placeholders::_1);
+
+    std::shared_ptr<can_device::socket_can::CanDev> motors_can_receive_api =
+        std::make_shared<can_device::socket_can::CanDev>(
+            motors_can_interface, motors_can_name, motors_can_extended_frame, motors_can_receive_callback,
+            motors_can_rx_is_block, motors_timeout_us, motors_can_id_offset);
+
+    void board_can_data_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+    void motors_data_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+    void imu_data_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+    void motors_status_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+
+    std::vector<api_motor_in_t> motors_in_;
+    api_imu_data_t imu_data_;
+    api_motor_status_t motors_status_;
+
+    mutable std::shared_mutex motors_in_mutex_, imu_mutex_;
+    size_t leg_dof_{4}, leg_num_{2};
+  };
+} // namespace can_device
+
+#endif // MOTORS_CAN__MOTORS_CAN_API_HPP_

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_robot/include/tita_robot/can_receiver.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_robot/include/tita_robot/can_receiver.hpp
@@ -63,11 +63,15 @@ namespace can_device
   class MotorsImuCanReceiveApi
   {
   public:
-    MotorsImuCanReceiveApi(size_t size)
+    MotorsImuCanReceiveApi(size_t size, std::string interface = "can0")
+      : motors_can_interface(std::move(interface))
     {
       if(size % 8 == 0) leg_dof_ = 4;
       else if(size % 6 == 0) leg_dof_ = 3;
       leg_num_ = size / leg_dof_;
+      motors_can_receive_api = std::make_shared<can_device::socket_can::CanDev>(
+        motors_can_interface, motors_can_name, motors_can_extended_frame, motors_can_receive_callback,
+        motors_can_rx_is_block, motors_timeout_us, motors_can_id_offset);
       register_motors_device_can_filter();
       api_motor_in_t default_motor_in;
       std::memset(&default_motor_in, 0x00U, sizeof(api_motor_in_t));
@@ -94,10 +98,7 @@ namespace can_device
     can_device::socket_can::can_fd_callback motors_can_receive_callback =
         std::bind(&MotorsImuCanReceiveApi::board_can_data_callback, this, std::placeholders::_1);
 
-    std::shared_ptr<can_device::socket_can::CanDev> motors_can_receive_api =
-        std::make_shared<can_device::socket_can::CanDev>(
-            motors_can_interface, motors_can_name, motors_can_extended_frame, motors_can_receive_callback,
-            motors_can_rx_is_block, motors_timeout_us, motors_can_id_offset);
+    std::shared_ptr<can_device::socket_can::CanDev> motors_can_receive_api;
 
     void board_can_data_callback(std::shared_ptr<struct canfd_frame> recv_frame);
     void motors_data_callback(std::shared_ptr<struct canfd_frame> recv_frame);

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_robot/include/tita_robot/can_sender.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_robot/include/tita_robot/can_sender.hpp
@@ -1,0 +1,120 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MOTORS_CAN__MOTORS_CAN_SEND_API_HPP_
+#define MOTORS_CAN__MOTORS_CAN_SEND_API_HPP_
+
+#include <algorithm>
+#include <atomic>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "protocol/can_utils.hpp"
+
+namespace can_device
+{
+
+#define CAN_ID_SEND_MOTORS (0x120U)
+#define CAN_ID_CHANNEL_INPUT (0x12DU)
+#define CAN_ID_RPC_REQUEST (0x170U)
+
+  enum ApiRpcKey
+  {
+    RPC_UNDEFINED = 0x000,
+    GET_MODEL_INFO = 0x100,
+    GET_SERIAL_NUMBER = 0x101,
+    SET_READY_NEXT = 0x200,
+    SET_BOARDCAST = 0x201,
+    SET_INPUT_MODE = 0x221,
+    SET_STAND_MODE = 0x222,
+    SET_HEAD_MODE = 0x223,
+    SET_JUMP = 0x231,
+    SET_MOTOR_ZERO = 0x280,
+  };
+  struct ChannelInput
+  {
+    uint32_t timestamp;
+    float forward;
+    float yaw;
+    float pitch;
+    float roll;
+    float height;
+    float split;
+    float tilt;
+    float forward_accel;
+    float yaw_accel;
+  };
+  struct RpcRequest
+  {
+    uint32_t timestamp;
+    uint16_t key;
+    uint32_t value;
+  };
+  struct motor_out
+  {
+    uint32_t timestamp;
+    float position;
+    float kp;
+    float velocity;
+    float kd;
+    float torque;
+  };
+
+  class MotorsCanSendApi
+  {
+  public:
+    MotorsCanSendApi(size_t size)
+    {
+      if (size % 8 == 0)
+        leg_dof_ = 4;
+      else if (size % 6 == 0)
+        leg_dof_ = 3;
+      leg_num_ = size / leg_dof_;
+    }
+    ~MotorsCanSendApi() = default;
+    bool send_motors_can(std::vector<motor_out> motors);
+    bool send_command_can_channel_input(ChannelInput data);
+    bool send_command_can_rpc_request(RpcRequest data);
+
+  private:
+#define MIN_TIME_OUT_US 1'000L     // 1ms
+#define MAX_TIME_OUT_US 3'000'000L // 3s
+    std::string can_interface = "can0";
+    std::string can_name = "motors_can_send";
+    int64_t timeout_us = MAX_TIME_OUT_US;
+    uint8_t can_id_offset = 0x00U;
+    bool can_extended_frame = false;
+    bool can_fd_mode = true;
+
+    std::shared_ptr<can_device::socket_can::CanDev> can_send_api_ =
+        std::make_shared<can_device::socket_can::CanDev>(
+            can_interface, can_name, can_extended_frame, can_fd_mode, timeout_us, can_id_offset);
+
+    inline uint32_t get_current_time()
+    {
+      struct timeval tv;
+      gettimeofday(&tv, NULL);
+      return std::move(tv.tv_sec * 1000000 + tv.tv_usec);
+    }
+    size_t leg_dof_{4}, leg_num_{2};
+  };
+} // namespace can_device
+
+#endif // MOTORS_CAN__MOTORS_CAN_SEND_API_HPP_

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_robot/include/tita_robot/can_sender.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_robot/include/tita_robot/can_sender.hpp
@@ -80,13 +80,16 @@ namespace can_device
   class MotorsCanSendApi
   {
   public:
-    MotorsCanSendApi(size_t size)
+    MotorsCanSendApi(size_t size, std::string interface = "can0")
+      : can_interface(std::move(interface))
     {
       if (size % 8 == 0)
         leg_dof_ = 4;
       else if (size % 6 == 0)
         leg_dof_ = 3;
       leg_num_ = size / leg_dof_;
+      can_send_api_ = std::make_shared<can_device::socket_can::CanDev>(
+        can_interface, can_name, can_extended_frame, can_fd_mode, timeout_us, can_id_offset);
     }
     ~MotorsCanSendApi() = default;
     bool send_motors_can(std::vector<motor_out> motors);
@@ -103,9 +106,7 @@ namespace can_device
     bool can_extended_frame = false;
     bool can_fd_mode = true;
 
-    std::shared_ptr<can_device::socket_can::CanDev> can_send_api_ =
-        std::make_shared<can_device::socket_can::CanDev>(
-            can_interface, can_name, can_extended_frame, can_fd_mode, timeout_us, can_id_offset);
+    std::shared_ptr<can_device::socket_can::CanDev> can_send_api_;
 
     inline uint32_t get_current_time()
     {

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_robot/include/tita_robot/tita_robot.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_robot/include/tita_robot/tita_robot.hpp
@@ -1,0 +1,154 @@
+#include "can_receiver.hpp"
+#include "can_sender.hpp"
+
+class tita_robot
+{
+public:
+    enum ReadyNext
+    {
+        READY_WAITING = 0x00U,
+        AUTO_LOCOMOTION = 0x01U,
+        FORCE_LOCOMOTION = 0x02U,
+        FORCE_DIRECT = 0x03U,
+        MOTOR_ZERO_CAL = 0x04U,
+        BOOT_RECOVERY_MODE = 0x05U,
+        ESTOP_MODE = 0x06U,
+    };
+    struct ChannelInput
+    {
+        uint32_t timestamp;
+        float forward;
+        float yaw;
+        float pitch;
+        float roll;
+        float height;
+        float split;
+        float tilt;
+        float forward_accel;
+        float yaw_accel;
+    };
+    tita_robot(size_t num_motors)
+    {
+        // Initialize the CAN receiver
+        can_receiver_ = std::make_unique<can_device::MotorsImuCanReceiveApi>(num_motors);
+        can_sender_ = std::make_unique<can_device::MotorsCanSendApi>(num_motors);
+        motor_num_ = num_motors;
+    }
+
+    /**
+     * @brief Get the current joint positions in joint space.
+     * @return std::vector<double>: current joint positions in radians.
+     */
+    std::vector<double> get_joint_q() const;
+
+    /**
+     * @brief Get the current joint velocities in joint space.
+     * @return std::vector<double>: current joint velocities in radians per second.
+     */
+    std::vector<double> get_joint_v() const;
+
+    /**
+     * @brief Get the current joint torques in joint space.
+     * @return std::vector<double>: current joint torques in Newton meters.
+     */
+    std::vector<double> get_joint_t() const;
+
+    /**
+     * @brief Get the current joint status.
+     * @note Joints status now is in bool value, true means the joint is online(TODO).
+     * @return std::vector<uint8_t>: current joint status.
+     */
+    std::vector<uint8_t> get_joint_status() const;
+
+    /**
+     * @brief Get the current imu quaternion of mcu.
+     * @note Quaternion sequence is x y z w.
+     * @return std::array<double, 4>: current quaternion.
+     */
+    std::array<double, 4> get_imu_quaternion() const; // x y z w
+
+    /**
+     * @brief Get the current imu acceleration of mcu.
+     * @return std::array<double, 3>: current acceleration.
+     */
+    std::array<double, 3> get_imu_acceleration() const;
+
+    /**
+     * @brief Get the current imu angular velocity of mcu.
+     * @return std::array<double, 3>: current angular velocity.
+     */
+    std::array<double, 3> get_imu_angular_velocity() const;
+
+    /**
+     * @brief Set the target joint feed-forward torques.
+     * @param t the target joint feed-forward torques.
+     * @return return true if the target is set successfully.
+     */
+    bool set_target_joint_t(const std::vector<double> &t);
+
+    /**
+     * @brief MIT control method. Set the target joint positions, velocities, kp, kd and feed-forward torques of the
+     motors.
+     * @param q the target joint positions in radians.
+     * @param v the target joint velocities in radians per second.
+     * @param kp the target joint proportional gains.
+     * @param kd the target joint derivative gains.
+     * @param t the target joint feed-forward torques.
+     *
+     * @return return true if the target is set successfully
+     */
+    bool set_target_joint_mit(const std::vector<double> &q, const std::vector<double> &v, const std::vector<double> &kp, const std::vector<double> &kd, const std::vector<double> &t);
+
+    // /**
+    //  * @brief Set mcu board control mode, maybe remove in the future.
+    //  * @param mode the target mcu mode, option: READY_WAITING AUTO_LOCOMOTION FORCE_DIRECT.
+    //  *
+    //  * @return return true if the target is set successfully
+    //  */
+    // bool set_board_mode(ReadyNext mode);
+    /**
+     * @brief Set mcu board can direct drive motors, default is auto_locomotion(use mcu control).
+     * @param if_sdk true means use control motors sdk, false means use mcu control.
+     *
+     * @return return true if the target is set successfully
+     */
+    bool set_motors_sdk(bool if_sdk);
+    /**
+     * @brief Set rc input to mcu. Only used in board mode is AUTO_LOCOMOTION.
+     * @param forward the target forward.
+     * @param yaw the target yaw.
+     * @param pitch the target pitch.
+     * @param roll the target roll.
+     * @param height the target height.
+     * @param split the target split.
+     * @param tilt the target tilt.
+     * @param forward_accel the target forward acceleration.
+     * @param yaw_accel the target yaw acceleration.
+     * @return return true if the target is set successfully
+     */
+    bool set_rc_input(ChannelInput input);    
+    /**
+     * @brief Set rc input to mcu. Only used in board mode is AUTO_LOCOMOTION.
+     * @param stand true if stand.
+     * @return return true if the target is set successfully
+     */
+    bool set_robot_stand(bool stand);
+
+    /**
+     * @brief Set rc input to mcu. Only used in board mode is AUTO_LOCOMOTION.
+     * @param jump true to start robot charge, then false change to start jump.
+     * @return return true if the target is set successfully
+     */
+    bool set_robot_jump(bool jump);
+    /**
+     * @brief Set rc input to mcu. Only used in board mode is AUTO_LOCOMOTION.
+     * @return return true if the target is set successfully
+     */
+    bool set_robot_stop();
+private:
+    std::unique_ptr<can_device::MotorsImuCanReceiveApi> can_receiver_;
+    std::unique_ptr<can_device::MotorsCanSendApi> can_sender_;
+    size_t motor_num_;
+};
+
+// class tita_robot

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_robot/include/tita_robot/tita_robot.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_robot/include/tita_robot/tita_robot.hpp
@@ -27,12 +27,12 @@ public:
         float forward_accel;
         float yaw_accel;
     };
-    tita_robot(size_t num_motors)
+    tita_robot(size_t num_motors, std::string feedback_interface = "can0", std::string command_interface = "can0")
+        : motor_num_(num_motors)
     {
-        // Initialize the CAN receiver
-        can_receiver_ = std::make_unique<can_device::MotorsImuCanReceiveApi>(num_motors);
-        can_sender_ = std::make_unique<can_device::MotorsCanSendApi>(num_motors);
-        motor_num_ = num_motors;
+        // Initialize the CAN receiver and sender
+        can_receiver_ = std::make_unique<can_device::MotorsImuCanReceiveApi>(num_motors, std::move(feedback_interface));
+        can_sender_ = std::make_unique<can_device::MotorsCanSendApi>(num_motors, std::move(command_interface));
     }
 
     /**

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_robot/src/can_receiver.cpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_robot/src/can_receiver.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tita_robot/can_receiver.hpp"
+
+namespace can_device
+{
+
+void MotorsImuCanReceiveApi::register_motors_device_can_filter()
+{
+  // if (!this->is_running.load()) {
+  //   throw std::runtime_error("MotorsImuCanReceiveApi is not running");
+  // }
+  struct can_filter motors_device_rx_filter;
+  motors_device_rx_filter.can_id = CAN_ID_MOTOR_IN;
+  motors_device_rx_filter.can_mask = CAN_MASK_AS_MOTORS_INFO;
+  this->motors_can_receive_api->set_filter(&motors_device_rx_filter, sizeof(struct can_filter));
+}
+
+void MotorsImuCanReceiveApi::board_can_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  if (recv_frame->can_id >= CAN_ID_MOTOR_IN && recv_frame->can_id < CAN_ID_MOTOR_IN + leg_num_) {
+    motors_data_callback(recv_frame);
+  } else if (recv_frame->can_id == CAN_ID_IMU1) {
+    imu_data_callback(recv_frame);
+  } else {
+    return;
+  }
+}
+void MotorsImuCanReceiveApi::motors_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  std::unique_lock<std::shared_mutex> lock(motors_in_mutex_);
+  for (size_t i = 0; i < leg_dof_; i++) {
+    api_motor_in_t motor;
+    std::memcpy(&motor, recv_frame->data + 16 * i, sizeof(api_motor_in_t));
+    auto it = recv_frame->can_id - CAN_ID_MOTOR_IN;
+    motors_in_[i + leg_dof_ * it] = motor;
+  }
+}
+void MotorsImuCanReceiveApi::imu_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  std::unique_lock<std::shared_mutex> lock(imu_mutex_);
+  std::memcpy(&imu_data_, recv_frame->data, sizeof(api_imu_data_t));
+  for (size_t i(0); i < 3; ++i) {
+    imu_data_.accl[i] *= GRAVITY;
+  }
+  return;
+}
+void MotorsImuCanReceiveApi::motors_status_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  std::memcpy(&motors_status_, recv_frame->data, sizeof(api_motor_status_t));
+}
+
+}  // namespace can_device

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_robot/src/can_sender.cpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_robot/src/can_sender.cpp
@@ -1,0 +1,90 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tita_robot/can_sender.hpp"
+
+namespace can_device
+{
+bool MotorsCanSendApi::send_command_can_channel_input(ChannelInput data)
+{
+  data.timestamp = get_current_time();
+  struct canfd_frame frame;
+  frame.can_id = CAN_ID_CHANNEL_INPUT;
+  frame.len = 40u;
+  memset(frame.data, 0x00U, sizeof(frame.data));
+  
+  std::memcpy(frame.data, &data, sizeof(data));
+
+  return can_send_api_->send_can_message(frame);
+}
+
+bool MotorsCanSendApi::send_command_can_rpc_request(RpcRequest data){
+  data.timestamp = get_current_time();
+
+  struct canfd_frame frame;
+  frame.can_id = CAN_ID_RPC_REQUEST;
+  frame.len = 10U;
+
+  memset(frame.data, 0x00U, sizeof(frame.data));
+
+  std::memcpy(frame.data, &data.timestamp, sizeof(data.timestamp));
+  std::memcpy(frame.data + 4, &data.key, sizeof(data.key));
+  std::memcpy(frame.data + 6, &data.value, sizeof(data.value));
+
+  return can_send_api_->send_can_message(frame);
+}
+
+bool MotorsCanSendApi::send_motors_can(std::vector<motor_out> motors)
+{
+  if (motors.size() != leg_dof_ * leg_num_) {
+    std::cerr << "[MOTORS_CAN_SEND] motors size not equal to robot dof" << std::endl;
+    return false;
+  }
+  if(leg_dof_ == 3){
+    motor_out motor = {};
+    auto it = motors.begin() + 3;
+    motors.insert(it, motor);
+    motors.push_back(motor);
+  }
+  bool send_success = true;
+  struct canfd_frame frame;
+  frame.len = 48U;
+  auto now = get_current_time();
+  for (size_t id(0); id < motors.size()/2; id++) {
+    frame.can_id = CAN_ID_SEND_MOTORS + id;
+    memset(frame.data, 0x00U, sizeof(frame.data));
+    auto motor = motors[2 * id];
+    motor.timestamp = now;
+    std::memcpy(frame.data, &motor.timestamp, sizeof(motor.timestamp));
+    std::memcpy(frame.data + 4, &motor.position, sizeof(motor.position));
+    std::memcpy(frame.data + 8, &motor.kp, sizeof(motor.kp));
+    std::memcpy(frame.data + 12, &motor.velocity, sizeof(motor.velocity));
+    std::memcpy(frame.data + 16, &motor.kd, sizeof(motor.kd));
+    std::memcpy(frame.data + 20, &motor.torque, sizeof(motor.torque));
+
+    motor = motors[2 * id + 1];
+    motor.timestamp = now;
+    std::memcpy(frame.data + 24, &motor.timestamp, sizeof(motor.timestamp));
+    std::memcpy(frame.data + 28, &motor.position, sizeof(motor.position));
+    std::memcpy(frame.data + 32, &motor.kp, sizeof(motor.kp));
+    std::memcpy(frame.data + 36, &motor.velocity, sizeof(motor.velocity));
+    std::memcpy(frame.data + 40, &motor.kd, sizeof(motor.kd));
+    std::memcpy(frame.data + 44, &motor.torque, sizeof(motor.torque));
+    send_success &= can_send_api_->send_can_message(frame);
+    std::this_thread::sleep_for(std::chrono::microseconds(150)); // 等待 100 微秒
+  }
+  return send_success;
+}
+
+}  // namespace can_device

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_robot/src/tita_robot.cpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_robot/src/tita_robot.cpp
@@ -1,0 +1,171 @@
+#include "tita_robot/tita_robot.hpp"
+
+std::vector<double> tita_robot::get_joint_q() const
+{
+  auto infos = can_receiver_->get_motors_in();
+  std::vector<double> joint;
+  for (const auto & info : *infos) {
+    joint.push_back(info.position);
+  }
+  return joint;
+}
+
+std::vector<double> tita_robot::get_joint_v() const
+{
+  auto infos = can_receiver_->get_motors_in();
+  std::vector<double> joint;
+  for (const auto & info : *infos) {
+    joint.push_back(info.velocity);
+  }
+  return joint;
+}
+
+std::vector<double> tita_robot::get_joint_t() const
+{
+  auto infos = can_receiver_->get_motors_in();
+  std::vector<double> joint;
+  for (const auto & info : *infos) {
+    joint.push_back(info.torque);
+  }
+  return joint;
+}
+
+std::vector<uint8_t> tita_robot::get_joint_status() const  // TODO: why 8
+{
+  auto infos = can_receiver_->get_motors_status();
+  std::vector<uint8_t> joint;
+  for (size_t id = 0; id < 8; id++) {
+    joint.push_back(infos->value[id]);
+  }
+  return joint;
+}
+
+std::array<double, 4> tita_robot::get_imu_quaternion() const
+{
+  auto infos = can_receiver_->get_imu_data();
+  std::array<double, 4> data;
+  for (size_t i = 0; i < 4; i++) {
+    data[i] = infos->quaternion[i];
+  }
+  return data;
+}
+
+std::array<double, 3> tita_robot::get_imu_acceleration() const
+{
+  auto infos = can_receiver_->get_imu_data();
+  std::array<double, 3> data;
+  for (size_t i = 0; i < 3; i++) {
+    data[i] = infos->accl[i];
+  }
+  return data;
+}
+
+std::array<double, 3> tita_robot::get_imu_angular_velocity() const
+{
+  auto infos = can_receiver_->get_imu_data();
+  std::array<double, 3> data;
+  for (size_t i = 0; i < 3; i++) {
+    data[i] = infos->gyro[i];
+  }
+  return data;
+}
+
+bool tita_robot::set_target_joint_t(const std::vector<double> & t)
+{
+  std::vector<can_device::motor_out> motors;
+  for (size_t id = 0; id < motor_num_; id++) {
+    can_device::motor_out motor;
+    motor.torque = t[id];
+    motor.kp = 0.0f;
+    motor.kd = 0.0f;
+    motor.velocity = 0.0f;
+    motor.position = 0.0f;
+    motors.push_back(motor);
+  }
+  return can_sender_->send_motors_can(motors);
+}
+
+bool tita_robot::set_target_joint_mit(
+  const std::vector<double> & q, const std::vector<double> & v, const std::vector<double> & kp,
+  const std::vector<double> & kd, const std::vector<double> & t)
+{
+  std::vector<can_device::motor_out> motors;
+  for (size_t id = 0; id < motor_num_; id++) {
+    can_device::motor_out motor;
+    motor.torque = t[id];
+    motor.kp = kp[id];
+    motor.kd = kd[id];
+    motor.velocity = v[id];
+    motor.position = q[id];
+    motors.push_back(motor);
+  }
+  return can_sender_->send_motors_can(motors);
+}
+
+// bool tita_robot::set_board_mode(ReadyNext mode)
+// {
+//   can_device::RpcRequest rpc_request;
+//   rpc_request.key = can_device::SET_READY_NEXT;
+//   rpc_request.value = mode;
+//   return can_sender_->send_command_can_rpc_request(rpc_request);
+// }
+
+bool tita_robot::set_motors_sdk(bool if_sdk)
+{
+  can_device::RpcRequest rpc_request;
+  rpc_request.key = can_device::SET_READY_NEXT;
+  rpc_request.value = READY_WAITING;
+  bool return_ok = can_sender_->send_command_can_rpc_request(rpc_request);
+  std::this_thread::sleep_for(std::chrono::microseconds(100));
+  if (if_sdk) {
+    rpc_request.value = FORCE_DIRECT;
+  } else {
+    rpc_request.value = AUTO_LOCOMOTION;
+  }
+  return_ok &= can_sender_->send_command_can_rpc_request(rpc_request);
+  return return_ok;
+}
+
+bool tita_robot::set_rc_input(ChannelInput input)
+{
+  can_device::ChannelInput can_input;
+  can_input.forward = input.forward;
+  can_input.yaw = input.yaw;
+  can_input.pitch = input.pitch;
+  can_input.roll = input.roll;
+  can_input.height = input.height;
+  can_input.split = input.split;
+  can_input.tilt = input.tilt;
+  can_input.forward_accel = input.forward_accel;
+  can_input.yaw_accel = input.yaw_accel;
+  return can_sender_->send_command_can_channel_input(can_input);
+}
+
+bool tita_robot::set_robot_stand(bool stand)
+{
+  can_device::RpcRequest rpc_request;
+  rpc_request.key = can_device::SET_STAND_MODE;
+  rpc_request.value = !stand ? 0x01U : 0x02U;
+  return can_sender_->send_command_can_rpc_request(rpc_request);
+}
+
+bool tita_robot::set_robot_jump(bool jump)
+{
+  can_device::RpcRequest rpc_request;
+  rpc_request.key = can_device::SET_JUMP;
+  rpc_request.value = !jump ? 0x01U : 0x02U;
+  return can_sender_->send_command_can_rpc_request(rpc_request);
+}
+
+bool tita_robot::set_robot_stop()
+{
+  can_device::RpcRequest rpc_request;
+  rpc_request.value = 0x01U;
+  rpc_request.key = can_device::SET_STAND_MODE;
+  bool return_ok = can_sender_->send_command_can_rpc_request(rpc_request);
+  std::this_thread::sleep_for(std::chrono::microseconds(200));
+  rpc_request.value = 0x02U;
+  rpc_request.key = can_device::SET_JUMP;
+  return_ok &= can_sender_->send_command_can_rpc_request(rpc_request);
+  return true;
+}

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_robot/src/tita_robot.cpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_robot/src/tita_robot.cpp
@@ -1,5 +1,8 @@
 #include "tita_robot/tita_robot.hpp"
 
+#include <chrono>
+#include <thread>
+
 std::vector<double> tita_robot::get_joint_q() const
 {
   auto infos = can_receiver_->get_motors_in();

--- a/rl_sar/src/rl_sar/policy/fsm.hpp
+++ b/rl_sar/src/rl_sar/policy/fsm.hpp
@@ -17,5 +17,6 @@
 #include "l4w4/fsm.hpp"
 #include "lite3/fsm.hpp"
 #include "tita/fsm.hpp"
+#include "titati/fsm.hpp"
 
 #endif // FSM_HPP

--- a/rl_sar/src/rl_sar/src/rl_real_titati.cpp
+++ b/rl_sar/src/rl_sar/src/rl_real_titati.cpp
@@ -1,0 +1,369 @@
+/*
+ * Copyright (c) 2024-2025 Ziqi Fan
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "rl_real_titati.hpp"
+
+#include <cmath>
+
+RL_Real::RL_Real()
+#if defined(USE_ROS2) && defined(USE_ROS)
+    : rclcpp::Node("rl_real_node")
+#endif
+{
+#if defined(USE_ROS1) && defined(USE_ROS)
+    ros::NodeHandle nh;
+    this->cmd_vel_subscriber = nh.subscribe<geometry_msgs::Twist>("/cmd_vel", 10, &RL_Real::CmdvelCallback, this);
+#elif defined(USE_ROS2) && defined(USE_ROS)
+    this->cmd_vel_subscriber = this->create_subscription<geometry_msgs::msg::Twist>(
+        "/cmd_vel", rclcpp::SystemDefaultsQoS(),
+        [this](const geometry_msgs::msg::Twist::SharedPtr msg) { this->CmdvelCallback(msg); }
+    );
+#endif
+
+    // read params from yaml
+    this->ang_vel_type = "ang_vel_body";
+    this->robot_name = "titati";
+    this->ReadYamlBase(this->robot_name);
+
+    // auto load FSM by robot_name
+    if (FSMManager::GetInstance().IsTypeSupported(this->robot_name))
+    {
+        auto fsm_ptr = FSMManager::GetInstance().CreateFSM(this->robot_name, this);
+        if (fsm_ptr)
+        {
+            this->fsm = *fsm_ptr;
+        }
+    }
+    else
+    {
+        std::cout << LOGGER::ERROR << "No FSM registered for robot: " << this->robot_name << std::endl;
+    }
+
+    // init torch
+    torch::autograd::GradMode::set_enabled(false);
+    torch::set_num_threads(4);
+
+    // init robot hardware
+    titati_robot_ = std::make_unique<tita_robot>(this->params.num_of_dofs);
+    titati_robot_->set_motors_sdk(true);
+    joint_positions_.resize(this->params.num_of_dofs, 0.0);
+    joint_velocities_.resize(this->params.num_of_dofs, 0.0);
+    joint_torques_.resize(this->params.num_of_dofs, 0.0);
+
+    this->InitOutputs();
+    this->InitControl();
+
+    // loop
+    this->loop_keyboard = std::make_shared<LoopFunc>("loop_keyboard", 0.05, std::bind(&RL_Real::KeyboardInterface, this));
+    this->loop_control = std::make_shared<LoopFunc>("loop_control", this->params.dt, std::bind(&RL_Real::RobotControl, this));
+    this->loop_rl = std::make_shared<LoopFunc>("loop_rl", this->params.dt * this->params.decimation, std::bind(&RL_Real::RunModel, this));
+    this->loop_keyboard->start();
+    this->loop_control->start();
+    this->loop_rl->start();
+
+#ifdef PLOT
+    this->plot_t = std::vector<int>(this->plot_size, 0);
+    this->plot_real_joint_pos.resize(this->params.num_of_dofs);
+    this->plot_target_joint_pos.resize(this->params.num_of_dofs);
+    for (auto &vector : this->plot_real_joint_pos) { vector = std::vector<double>(this->plot_size, 0); }
+    for (auto &vector : this->plot_target_joint_pos) { vector = std::vector<double>(this->plot_size, 0); }
+    this->loop_plot = std::make_shared<LoopFunc>("loop_plot", 0.002, std::bind(&RL_Real::Plot, this));
+    this->loop_plot->start();
+#endif
+#ifdef CSV_LOGGER
+    this->CSVInit(this->robot_name);
+#endif
+}
+
+RL_Real::~RL_Real()
+{
+    this->loop_keyboard->shutdown();
+    this->loop_control->shutdown();
+    this->loop_rl->shutdown();
+#ifdef PLOT
+    this->loop_plot->shutdown();
+#endif
+    if (titati_robot_)
+    {
+        std::vector<double> zero_torque(this->params.num_of_dofs, 0.0);
+        titati_robot_->set_target_joint_t(zero_torque);
+        titati_robot_->set_motors_sdk(false);
+    }
+    std::cout << LOGGER::INFO << "RL_Real exit" << std::endl;
+}
+
+void RL_Real::GetState(RobotState<double> *state)
+{
+    if (!state || !titati_robot_)
+    {
+        return;
+    }
+
+    joint_positions_ = titati_robot_->get_joint_q();
+    joint_velocities_ = titati_robot_->get_joint_v();
+    joint_torques_ = titati_robot_->get_joint_t();
+
+    if (joint_positions_.size() < static_cast<size_t>(this->params.num_of_dofs))
+    {
+        return;
+    }
+
+    const size_t half_joints = joint_positions_.size() / 2;
+    for (size_t id = 0; id < joint_positions_.size(); ++id)
+    {
+        if (id == 1 || id == 1 + half_joints)
+        {
+            if (joint_positions_[id] < -2.5)
+            {
+                joint_positions_[id] += 2 * M_PI;
+            }
+        }
+    }
+
+    auto quat = titati_robot_->get_imu_quaternion();
+    auto accl = titati_robot_->get_imu_acceleration();
+    auto gyro = titati_robot_->get_imu_angular_velocity();
+
+    state->imu.quaternion[0] = quat[3]; // w
+    state->imu.quaternion[1] = quat[0]; // x
+    state->imu.quaternion[2] = quat[1]; // y
+    state->imu.quaternion[3] = quat[2]; // z
+
+    for (size_t i = 0; i < 3; ++i)
+    {
+        state->imu.gyroscope[i] = gyro[i];
+        state->imu.accelerometer[i] = accl[i];
+    }
+
+    for (int i = 0; i < this->params.num_of_dofs; ++i)
+    {
+        int idx = this->params.joint_mapping[i];
+        state->motor_state.q[i] = joint_positions_[idx];
+        state->motor_state.dq[i] = joint_velocities_[idx];
+        state->motor_state.tau_est[i] = joint_torques_[idx];
+    }
+}
+
+void RL_Real::SetCommand(const RobotCommand<double> *command)
+{
+    if (!command || !titati_robot_)
+    {
+        return;
+    }
+    std::vector<double> q(this->params.num_of_dofs, 0.0);
+    std::vector<double> dq(this->params.num_of_dofs, 0.0);
+    std::vector<double> kp(this->params.num_of_dofs, 0.0);
+    std::vector<double> kd(this->params.num_of_dofs, 0.0);
+    std::vector<double> tau(this->params.num_of_dofs, 0.0);
+
+    for (int i = 0; i < this->params.num_of_dofs; ++i)
+    {
+        int idx = this->params.joint_mapping[i];
+        q[idx] = command->motor_command.q[i];
+        dq[idx] = command->motor_command.dq[i];
+        kp[idx] = command->motor_command.kp[i];
+        kd[idx] = command->motor_command.kd[i];
+        tau[idx] = command->motor_command.tau[i];
+    }
+
+    titati_robot_->set_target_joint_mit(q, dq, kp, kd, tau);
+}
+
+void RL_Real::RobotControl()
+{
+    this->motiontime++;
+
+    if (this->control.current_keyboard == Input::Keyboard::W)
+    {
+        this->control.x += 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::S)
+    {
+        this->control.x -= 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::A)
+    {
+        this->control.y += 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::D)
+    {
+        this->control.y -= 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::Q)
+    {
+        this->control.yaw += 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::E)
+    {
+        this->control.yaw -= 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::Space)
+    {
+        this->control.x = 0;
+        this->control.y = 0;
+        this->control.yaw = 0;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::N || this->control.current_gamepad == Input::Gamepad::X)
+    {
+        this->control.navigation_mode = !this->control.navigation_mode;
+        std::cout << std::endl << LOGGER::INFO << "Navigation mode: " << (this->control.navigation_mode ? "ON" : "OFF") << std::endl;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+
+    this->GetState(&this->robot_state);
+    this->StateController(&this->robot_state, &this->robot_command);
+    this->SetCommand(&this->robot_command);
+}
+
+void RL_Real::RunModel()
+{
+    if (this->rl_init_done)
+    {
+        this->episode_length_buf += 1;
+        this->obs.ang_vel = torch::tensor(this->robot_state.imu.gyroscope).unsqueeze(0);
+        if (this->control.navigation_mode)
+        {
+#if !defined(USE_CMAKE) && defined(USE_ROS)
+            this->obs.commands = torch::tensor({{this->cmd_vel.linear.x, this->cmd_vel.linear.y, this->cmd_vel.angular.z}});
+#endif
+        }
+        else
+        {
+            this->obs.commands = torch::tensor({{this->control.x, this->control.y, this->control.yaw}});
+        }
+        this->obs.base_quat = torch::tensor(this->robot_state.imu.quaternion).unsqueeze(0);
+        this->obs.dof_pos = torch::tensor(this->robot_state.motor_state.q).narrow(0, 0, this->params.num_of_dofs).unsqueeze(0);
+        this->obs.dof_vel = torch::tensor(this->robot_state.motor_state.dq).narrow(0, 0, this->params.num_of_dofs).unsqueeze(0);
+
+        this->obs.actions = this->Forward();
+        this->ComputeOutput(this->obs.actions, this->output_dof_pos, this->output_dof_vel, this->output_dof_tau);
+
+        if (this->output_dof_pos.defined() && this->output_dof_pos.numel() > 0)
+        {
+            output_dof_pos_queue.push(this->output_dof_pos);
+        }
+        if (this->output_dof_vel.defined() && this->output_dof_vel.numel() > 0)
+        {
+            output_dof_vel_queue.push(this->output_dof_vel);
+        }
+        if (this->output_dof_tau.defined() && this->output_dof_tau.numel() > 0)
+        {
+            output_dof_tau_queue.push(this->output_dof_tau);
+        }
+
+        this->TorqueProtect(this->output_dof_tau);
+        // this->AttitudeProtect(this->robot_state.imu.quaternion, 75.0f, 75.0f);
+
+#ifdef CSV_LOGGER
+        torch::Tensor tau_est = torch::tensor(this->robot_state.motor_state.tau_est).unsqueeze(0);
+        this->CSVLogger(this->output_dof_tau, tau_est, this->obs.dof_pos, this->output_dof_pos, this->obs.dof_vel);
+#endif
+    }
+}
+
+torch::Tensor RL_Real::Forward()
+{
+    torch::autograd::GradMode::set_enabled(false);
+
+    torch::Tensor clamped_obs = this->ComputeObservation();
+
+    torch::Tensor actions;
+    if (!this->params.observations_history.empty())
+    {
+        this->history_obs_buf.insert(clamped_obs);
+        this->history_obs = this->history_obs_buf.get_obs_vec(this->params.observations_history);
+        if (this->fsm.current_state_->GetStateName() != "RLFSMStateRL_LocomotionLab")
+        {
+            torch::Tensor myTensor = history_obs.view({1, 10, 57});
+            actions = this->model.forward({clamped_obs, myTensor}).toTensor();
+        }
+        else
+        {
+            actions = this->model.forward({this->history_obs}).toTensor();
+        }
+    }
+    else
+    {
+        actions = this->model.forward({clamped_obs}).toTensor();
+    }
+
+    if (this->params.clip_actions_upper.numel() != 0 && this->params.clip_actions_lower.numel() != 0)
+    {
+        return torch::clamp(actions, this->params.clip_actions_lower, this->params.clip_actions_upper);
+    }
+    else
+    {
+        return actions;
+    }
+}
+
+#ifdef PLOT
+void RL_Real::Plot()
+{
+    this->plot_t.erase(this->plot_t.begin());
+    this->plot_t.push_back(this->motiontime);
+    plt::cla();
+    plt::clf();
+    for (int i = 0; i < this->params.num_of_dofs; ++i)
+    {
+        this->plot_real_joint_pos[i].erase(this->plot_real_joint_pos[i].begin());
+        this->plot_target_joint_pos[i].erase(this->plot_target_joint_pos[i].begin());
+        int idx = this->params.joint_mapping[i];
+        this->plot_real_joint_pos[i].push_back(joint_positions_[idx]);
+        this->plot_target_joint_pos[i].push_back(this->output_dof_pos[0][i].item<double>());
+        plt::subplot(this->params.num_of_dofs, 1, i + 1);
+        plt::named_plot("_real_joint_pos", this->plot_t, this->plot_real_joint_pos[i], "r");
+        plt::named_plot("_target_joint_pos", this->plot_t, this->plot_target_joint_pos[i], "b");
+        plt::xlim(this->plot_t.front(), this->plot_t.back());
+    }
+    plt::pause(0.0001);
+}
+#endif
+
+#if !defined(USE_CMAKE) && defined(USE_ROS)
+void RL_Real::CmdvelCallback(
+#if defined(USE_ROS1) && defined(USE_ROS)
+    const geometry_msgs::Twist::ConstPtr &msg
+#elif defined(USE_ROS2) && defined(USE_ROS)
+    const geometry_msgs::msg::Twist::SharedPtr msg
+#endif
+)
+{
+    this->cmd_vel = *msg;
+}
+#endif
+
+#if defined(USE_ROS1) && defined(USE_ROS)
+void signalHandler(int signum)
+{
+    ros::shutdown();
+    exit(0);
+}
+#endif
+
+int main(int argc, char **argv)
+{
+#if defined(USE_ROS1) && defined(USE_ROS)
+    signal(SIGINT, signalHandler);
+    ros::init(argc, argv, "rl_sar");
+    RL_Real rl_sar;
+    ros::spin();
+#elif defined(USE_ROS2) && defined(USE_ROS)
+    rclcpp::init(argc, argv);
+    rclcpp::spin(std::make_shared<RL_Real>());
+    rclcpp::shutdown();
+#elif defined(USE_CMAKE) || !defined(USE_ROS)
+    RL_Real rl_sar;
+    while (1) { sleep(10); }
+#endif
+    return 0;
+}

--- a/rl_sar/src/rl_sar/src/rl_real_titati.cpp
+++ b/rl_sar/src/rl_sar/src/rl_real_titati.cpp
@@ -6,10 +6,16 @@
 #include "rl_real_titati.hpp"
 
 #include <cmath>
+#include <vector>
 
-RL_Real::RL_Real()
+RL_Real::RL_Real(const std::string &feedback_can_interface, const std::string &command_can_interface)
 #if defined(USE_ROS2) && defined(USE_ROS)
     : rclcpp::Node("rl_real_node")
+    , feedback_can_interface_(feedback_can_interface)
+    , command_can_interface_(command_can_interface)
+#else
+    : feedback_can_interface_(feedback_can_interface)
+    , command_can_interface_(command_can_interface)
 #endif
 {
 #if defined(USE_ROS1) && defined(USE_ROS)
@@ -46,8 +52,23 @@ RL_Real::RL_Real()
     torch::set_num_threads(4);
 
     // init robot hardware
-    titati_robot_ = std::make_unique<tita_robot>(this->params.num_of_dofs);
-    titati_robot_->set_motors_sdk(true);
+    titati_robot_ = std::make_unique<tita_robot>(this->params.num_of_dofs, feedback_can_interface_, command_can_interface_);
+    zero_torque_cmd_.assign(this->params.num_of_dofs, 0.0);
+    if (titati_robot_)
+    {
+        motors_sdk_enabled_ = titati_robot_->set_motors_sdk(true);
+        if (motors_sdk_enabled_)
+        {
+            std::cout << LOGGER::INFO << "Titati motors switched to SDK control via CAN interfaces ('"
+                      << feedback_can_interface_ << "' feedback / '" << command_can_interface_ << "' command)." << std::endl;
+        }
+        else
+        {
+            std::cout << LOGGER::ERROR << "Failed to switch Titati motors to SDK control on CAN interface '"
+                      << command_can_interface_ << "'." << std::endl;
+            estop_engaged_ = true;
+        }
+    }
     joint_positions_.resize(this->params.num_of_dofs, 0.0);
     joint_velocities_.resize(this->params.num_of_dofs, 0.0);
     joint_torques_.resize(this->params.num_of_dofs, 0.0);
@@ -87,9 +108,12 @@ RL_Real::~RL_Real()
 #endif
     if (titati_robot_)
     {
-        std::vector<double> zero_torque(this->params.num_of_dofs, 0.0);
-        titati_robot_->set_target_joint_t(zero_torque);
-        titati_robot_->set_motors_sdk(false);
+        ApplyZeroTorque();
+        if (motors_sdk_enabled_.load())
+        {
+            titati_robot_->set_motors_sdk(false);
+            motors_sdk_enabled_ = false;
+        }
     }
     std::cout << LOGGER::INFO << "RL_Real exit" << std::endl;
 }
@@ -148,10 +172,11 @@ void RL_Real::GetState(RobotState<double> *state)
 
 void RL_Real::SetCommand(const RobotCommand<double> *command)
 {
-    if (!command || !titati_robot_)
+    if (!command || !titati_robot_ || estop_engaged_.load() || !motors_sdk_enabled_.load())
     {
         return;
     }
+    std::scoped_lock<std::mutex> lock(command_mutex_);
     std::vector<double> q(this->params.num_of_dofs, 0.0);
     std::vector<double> dq(this->params.num_of_dofs, 0.0);
     std::vector<double> kp(this->params.num_of_dofs, 0.0);
@@ -171,9 +196,134 @@ void RL_Real::SetCommand(const RobotCommand<double> *command)
     titati_robot_->set_target_joint_mit(q, dq, kp, kd, tau);
 }
 
+void RL_Real::ApplyZeroTorque()
+{
+    if (!titati_robot_)
+    {
+        return;
+    }
+    if (zero_torque_cmd_.size() != static_cast<size_t>(this->params.num_of_dofs))
+    {
+        zero_torque_cmd_.assign(this->params.num_of_dofs, 0.0);
+    }
+    std::scoped_lock<std::mutex> lock(command_mutex_);
+    titati_robot_->set_target_joint_t(zero_torque_cmd_);
+}
+
+void RL_Real::ClearCommandQueues()
+{
+    torch::Tensor dump;
+    while (output_dof_pos_queue.try_pop(dump))
+    {
+    }
+    while (output_dof_vel_queue.try_pop(dump))
+    {
+    }
+    while (output_dof_tau_queue.try_pop(dump))
+    {
+    }
+}
+
+void RL_Real::EngageEstop(const std::string &source)
+{
+    bool expected = false;
+    if (!estop_engaged_.compare_exchange_strong(expected, true))
+    {
+        return;
+    }
+
+    std::cout << LOGGER::WARNING << "Soft e-stop engaged by " << source << "." << std::endl;
+    ApplyZeroTorque();
+    ClearCommandQueues();
+
+    if (titati_robot_)
+    {
+        std::scoped_lock<std::mutex> lock(command_mutex_);
+        if (motors_sdk_enabled_.load())
+        {
+            if (!titati_robot_->set_motors_sdk(false))
+            {
+                std::cout << LOGGER::WARNING << "Titati did not acknowledge SDK disable request during e-stop." << std::endl;
+            }
+            motors_sdk_enabled_ = false;
+        }
+    }
+}
+
+void RL_Real::ReleaseEstop(const std::string &source)
+{
+    bool expected = true;
+    if (!estop_engaged_.compare_exchange_strong(expected, false))
+    {
+        return;
+    }
+
+    std::cout << LOGGER::INFO << "Soft e-stop cleared by " << source << "." << std::endl;
+
+    if (!titati_robot_)
+    {
+        std::cout << LOGGER::ERROR << "Titati hardware interface is not initialised; unable to clear e-stop." << std::endl;
+        estop_engaged_ = true;
+        return;
+    }
+
+    bool sdk_enabled = motors_sdk_enabled_.load();
+    if (!sdk_enabled)
+    {
+        std::scoped_lock<std::mutex> lock(command_mutex_);
+        sdk_enabled = titati_robot_->set_motors_sdk(true);
+        motors_sdk_enabled_ = sdk_enabled;
+    }
+
+    if (!sdk_enabled)
+    {
+        std::cout << LOGGER::ERROR << "Unable to re-enable Titati SDK control after e-stop; keeping motors disabled." << std::endl;
+        ClearCommandQueues();
+        estop_engaged_ = true;
+        return;
+    }
+
+    auto current_q = titati_robot_->get_joint_q();
+    auto current_dq = titati_robot_->get_joint_v();
+    if (current_q.size() != static_cast<size_t>(this->params.num_of_dofs))
+    {
+        current_q = std::vector<double>(this->params.num_of_dofs, 0.0);
+    }
+    if (current_dq.size() != static_cast<size_t>(this->params.num_of_dofs))
+    {
+        current_dq = std::vector<double>(this->params.num_of_dofs, 0.0);
+    }
+
+    std::vector<double> kp(this->params.num_of_dofs, 0.0);
+    std::vector<double> kd(this->params.num_of_dofs, 0.0);
+
+    {
+        std::scoped_lock<std::mutex> lock(command_mutex_);
+        titati_robot_->set_target_joint_mit(current_q, current_dq, kp, kd, zero_torque_cmd_);
+    }
+
+    ClearCommandQueues();
+}
+
 void RL_Real::RobotControl()
 {
     this->motiontime++;
+
+    if (this->control.current_keyboard == Input::Keyboard::M)
+    {
+        EngageEstop("keyboard 'M'");
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::Escape)
+    {
+        EngageEstop("keyboard 'ESC'");
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::K)
+    {
+        ReleaseEstop("keyboard 'K'");
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
 
     if (this->control.current_keyboard == Input::Keyboard::W)
     {
@@ -220,12 +370,24 @@ void RL_Real::RobotControl()
     }
 
     this->GetState(&this->robot_state);
+
+    if (estop_engaged_.load() || !motors_sdk_enabled_.load())
+    {
+        ApplyZeroTorque();
+        return;
+    }
+
     this->StateController(&this->robot_state, &this->robot_command);
     this->SetCommand(&this->robot_command);
 }
 
 void RL_Real::RunModel()
 {
+    if (estop_engaged_.load() || !motors_sdk_enabled_.load())
+    {
+        return;
+    }
+
     if (this->rl_init_done)
     {
         this->episode_length_buf += 1;
@@ -352,17 +514,67 @@ void signalHandler(int signum)
 
 int main(int argc, char **argv)
 {
+    std::string feedback_can = "can0";
+    std::string command_can = "can0";
+    bool show_help = false;
+    std::vector<char *> passthrough_args;
+    passthrough_args.push_back(argv[0]);
+
+    for (int i = 1; i < argc; ++i)
+    {
+        std::string arg(argv[i]);
+        if ((arg == "--can" || arg == "--interface") && (i + 1) < argc)
+        {
+            feedback_can = argv[++i];
+            command_can = feedback_can;
+            continue;
+        }
+        if (arg == "--feedback-can" && (i + 1) < argc)
+        {
+            feedback_can = argv[++i];
+            continue;
+        }
+        if (arg == "--command-can" && (i + 1) < argc)
+        {
+            command_can = argv[++i];
+            continue;
+        }
+        if (arg == "--help" || arg == "-h")
+        {
+            show_help = true;
+            continue;
+        }
+        if (arg == "--can" || arg == "--interface" || arg == "--feedback-can" || arg == "--command-can")
+        {
+            std::cout << LOGGER::ERROR << "Missing value for option '" << arg << "'." << std::endl;
+            return -1;
+        }
+        passthrough_args.push_back(argv[i]);
+    }
+
+    if (show_help)
+    {
+        std::cout << "Usage: " << argv[0] << " [--can CAN_IFACE] [--feedback-can CAN_IFACE] [--command-can CAN_IFACE]" << std::endl;
+        std::cout << "       --can/-interface sets both the feedback and command interface (default: can0)" << std::endl;
+        std::cout << "       --feedback-can sets the CAN FD interface for IMU/motor feedback" << std::endl;
+        std::cout << "       --command-can sets the CAN FD interface for torque/mit commands" << std::endl;
+        return 0;
+    }
+
+    int ros_argc = static_cast<int>(passthrough_args.size());
+    char **ros_argv = passthrough_args.data();
+
 #if defined(USE_ROS1) && defined(USE_ROS)
     signal(SIGINT, signalHandler);
-    ros::init(argc, argv, "rl_sar");
-    RL_Real rl_sar;
+    ros::init(ros_argc, ros_argv, "rl_sar");
+    RL_Real rl_sar(feedback_can, command_can);
     ros::spin();
 #elif defined(USE_ROS2) && defined(USE_ROS)
-    rclcpp::init(argc, argv);
-    rclcpp::spin(std::make_shared<RL_Real>());
+    rclcpp::init(ros_argc, ros_argv);
+    rclcpp::spin(std::make_shared<RL_Real>(feedback_can, command_can));
     rclcpp::shutdown();
 #elif defined(USE_CMAKE) || !defined(USE_ROS)
-    RL_Real rl_sar;
+    RL_Real rl_sar(feedback_can, command_can);
     while (1) { sleep(10); }
 #endif
     return 0;

--- a/rl_sar/src/rl_sar/src/titati_motor_test.cpp
+++ b/rl_sar/src/rl_sar/src/titati_motor_test.cpp
@@ -1,0 +1,400 @@
+/*
+ * Copyright (c) 2024-2025 Ziqi Fan
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "tita_robot/tita_robot.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace LOGGER
+{
+const char *const INFO = "\033[0;37m[INFO]\033[0m ";
+const char *const WARNING = "\033[0;33m[WARNING]\033[0m ";
+const char *const ERROR = "\033[0;31m[ERROR]\033[0m ";
+}
+
+namespace
+{
+std::atomic<bool> running{true};
+
+void SignalHandler(int)
+{
+    running = false;
+}
+
+struct Options
+{
+    std::string mode = "scan"; // scan, single, torque, monitor
+    int joint = -1;
+    bool absolute = false;
+    double offset = 0.15; // rad
+    double kp = 35.0;
+    double kd = 1.5;
+    double torque = 2.0;
+    double rate_hz = 400.0;
+    double duration = 2.0; // seconds per target
+    double settle = 1.0;   // seconds to return to neutral
+    size_t num_dofs = 16;
+    std::string feedback_can = "can0";
+    std::string command_can = "can0";
+};
+
+bool WaitForFeedback(tita_robot &robot, size_t expected_dofs, double timeout_sec)
+{
+    auto start = std::chrono::steady_clock::now();
+    while (running)
+    {
+        auto joints = robot.get_joint_q();
+        if (joints.size() == expected_dofs)
+        {
+            return true;
+        }
+        if (std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count() > timeout_sec)
+        {
+            return false;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    return false;
+}
+
+void PrintUsage(const char *binary)
+{
+    std::cout << "Usage: " << binary
+              << " [--mode scan|single|torque|monitor] [--joint IDX] [--offset RAD] [--absolute]" << std::endl
+              << "             [--kp VAL] [--kd VAL] [--torque NM] [--duration SEC] [--settle SEC]" << std::endl
+              << "             [--rate HZ] [--num-dofs N] [--feedback-can IFACE] [--command-can IFACE]" << std::endl
+              << std::endl
+              << "Examples:" << std::endl
+              << "  " << binary << " --mode scan --offset 0.1" << std::endl
+              << "  " << binary << " --mode single --joint 3 --offset -0.2 --kp 40 --kd 1.5" << std::endl
+              << "  " << binary << " --mode torque --joint 5 --torque 3.0" << std::endl
+              << "  " << binary << " --mode monitor" << std::endl;
+}
+
+bool ParseOptions(int argc, char **argv, Options &opts, bool &show_usage)
+{
+    for (int i = 1; i < argc; ++i)
+    {
+        std::string arg(argv[i]);
+        auto need_value = [&](const std::string &name) -> bool {
+            if (i + 1 >= argc)
+            {
+                std::cout << LOGGER::ERROR << "Option '" << name << "' expects a value." << std::endl;
+                return false;
+            }
+            return true;
+        };
+
+        try
+        {
+            if (arg == "--mode")
+            {
+                if (!need_value(arg)) return false;
+                opts.mode = argv[++i];
+            }
+            else if (arg == "--joint")
+            {
+                if (!need_value(arg)) return false;
+                opts.joint = std::stoi(argv[++i]);
+            }
+            else if (arg == "--offset")
+            {
+                if (!need_value(arg)) return false;
+                opts.offset = std::stod(argv[++i]);
+            }
+            else if (arg == "--kp")
+            {
+                if (!need_value(arg)) return false;
+                opts.kp = std::stod(argv[++i]);
+            }
+            else if (arg == "--kd")
+            {
+                if (!need_value(arg)) return false;
+                opts.kd = std::stod(argv[++i]);
+            }
+            else if (arg == "--torque")
+            {
+                if (!need_value(arg)) return false;
+                opts.torque = std::stod(argv[++i]);
+            }
+            else if (arg == "--duration")
+            {
+                if (!need_value(arg)) return false;
+                opts.duration = std::stod(argv[++i]);
+            }
+            else if (arg == "--settle")
+            {
+                if (!need_value(arg)) return false;
+                opts.settle = std::stod(argv[++i]);
+            }
+            else if (arg == "--rate")
+            {
+                if (!need_value(arg)) return false;
+                opts.rate_hz = std::stod(argv[++i]);
+            }
+            else if (arg == "--num-dofs")
+            {
+                if (!need_value(arg)) return false;
+                opts.num_dofs = static_cast<size_t>(std::stoul(argv[++i]));
+            }
+            else if (arg == "--feedback-can")
+            {
+                if (!need_value(arg)) return false;
+                opts.feedback_can = argv[++i];
+            }
+            else if (arg == "--command-can")
+            {
+                if (!need_value(arg)) return false;
+                opts.command_can = argv[++i];
+            }
+            else if (arg == "--can" || arg == "--interface")
+            {
+                if (!need_value(arg)) return false;
+                opts.feedback_can = argv[++i];
+                opts.command_can = opts.feedback_can;
+            }
+            else if (arg == "--absolute")
+            {
+                opts.absolute = true;
+            }
+            else if (arg == "--help" || arg == "-h")
+            {
+                show_usage = true;
+                PrintUsage(argv[0]);
+                return false;
+            }
+            else
+            {
+                std::cout << LOGGER::ERROR << "Unknown option '" << arg << "'." << std::endl;
+                return false;
+            }
+        }
+        catch (const std::exception &e)
+        {
+            std::cout << LOGGER::ERROR << "Failed to parse argument for '" << arg << "': " << e.what() << std::endl;
+            return false;
+        }
+    }
+
+    return true;
+}
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+    Options opts;
+    bool show_usage = false;
+    if (!ParseOptions(argc, argv, opts, show_usage))
+    {
+        if (show_usage)
+        {
+            return 0;
+        }
+        return -1;
+    }
+
+    if (opts.rate_hz <= 0.0)
+    {
+        std::cout << LOGGER::ERROR << "Rate must be positive." << std::endl;
+        return -1;
+    }
+    if (opts.num_dofs == 0)
+    {
+        std::cout << LOGGER::ERROR << "Number of DOFs must be greater than zero." << std::endl;
+        return -1;
+    }
+
+    std::signal(SIGINT, SignalHandler);
+    running = true;
+
+    tita_robot robot(opts.num_dofs, opts.feedback_can, opts.command_can);
+
+    const bool require_direct_control = opts.mode != "monitor";
+    bool motors_enabled = false;
+    std::vector<double> zero_torque(opts.num_dofs, 0.0);
+
+    if (require_direct_control)
+    {
+        motors_enabled = robot.set_motors_sdk(true);
+        if (!motors_enabled)
+        {
+            std::cout << LOGGER::ERROR << "Unable to switch Titati to SDK control mode on CAN interface '"
+                      << opts.command_can << "'." << std::endl;
+            return -1;
+        }
+    }
+
+    auto cleanup = [&]() {
+        if (require_direct_control && motors_enabled)
+        {
+            robot.set_target_joint_t(zero_torque);
+            robot.set_motors_sdk(false);
+        }
+    };
+
+    if (!WaitForFeedback(robot, opts.num_dofs, 2.0))
+    {
+        std::cout << LOGGER::ERROR << "Failed to receive Titati feedback within timeout." << std::endl;
+        cleanup();
+        return -1;
+    }
+
+    const std::chrono::duration<double> period(1.0 / opts.rate_hz);
+    std::vector<double> dq(opts.num_dofs, 0.0);
+    std::vector<double> kp(opts.num_dofs, 0.0);
+    std::vector<double> kd(opts.num_dofs, 0.0);
+    std::vector<double> tau(opts.num_dofs, 0.0);
+
+    if (opts.mode == "monitor")
+    {
+        std::cout << LOGGER::INFO << "Streaming Titati joint states. Press Ctrl+C to exit." << std::endl;
+        while (running)
+        {
+            auto q = robot.get_joint_q();
+            auto v = robot.get_joint_v();
+            auto t = robot.get_joint_t();
+            if (q.size() == opts.num_dofs && v.size() == opts.num_dofs)
+            {
+                std::cout << std::fixed << std::setprecision(3);
+                std::cout << "q:";
+                for (size_t i = 0; i < opts.num_dofs; ++i)
+                {
+                    std::cout << " " << q[i];
+                }
+                std::cout << std::endl << "dq:";
+                for (size_t i = 0; i < opts.num_dofs; ++i)
+                {
+                    std::cout << " " << v[i];
+                }
+                if (t.size() == opts.num_dofs)
+                {
+                    std::cout << std::endl << "tau:";
+                    for (size_t i = 0; i < opts.num_dofs; ++i)
+                    {
+                        std::cout << " " << t[i];
+                    }
+                }
+                std::cout << std::endl;
+            }
+            std::this_thread::sleep_for(period);
+        }
+        cleanup();
+        return 0;
+    }
+
+    if (opts.mode == "scan")
+    {
+        auto initial = robot.get_joint_q();
+        if (initial.size() != opts.num_dofs)
+        {
+            std::cout << LOGGER::ERROR << "Unexpected joint vector size during scan." << std::endl;
+            cleanup();
+            return -1;
+        }
+        std::cout << LOGGER::INFO << "Sequentially exciting each joint by " << opts.offset << " rad." << std::endl;
+        for (size_t joint = 0; joint < opts.num_dofs && running; ++joint)
+        {
+            std::cout << LOGGER::INFO << "Testing joint " << joint << std::endl;
+            auto target = initial;
+            kp.assign(opts.num_dofs, 0.0);
+            kd.assign(opts.num_dofs, 0.0);
+            kp[joint] = opts.kp;
+            kd[joint] = opts.kd;
+
+            double desired = opts.absolute ? opts.offset : initial[joint] + opts.offset;
+            target[joint] = desired;
+
+            auto start = std::chrono::steady_clock::now();
+            while (running && std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count() < opts.duration)
+            {
+                robot.set_target_joint_mit(target, dq, kp, kd, tau);
+                std::this_thread::sleep_for(period);
+            }
+
+            target[joint] = initial[joint];
+            start = std::chrono::steady_clock::now();
+            while (running && std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count() < opts.settle)
+            {
+                robot.set_target_joint_mit(target, dq, kp, kd, tau);
+                std::this_thread::sleep_for(period);
+            }
+        }
+        cleanup();
+        return 0;
+    }
+
+    if (opts.mode == "single" || opts.mode == "torque")
+    {
+        if (opts.joint < 0 || static_cast<size_t>(opts.joint) >= opts.num_dofs)
+        {
+            std::cout << LOGGER::ERROR << "Joint index out of range." << std::endl;
+            cleanup();
+            return -1;
+        }
+
+        if (opts.mode == "single")
+        {
+            auto initial = robot.get_joint_q();
+            if (initial.size() != opts.num_dofs)
+            {
+                std::cout << LOGGER::ERROR << "Unexpected joint vector size." << std::endl;
+                cleanup();
+                return -1;
+            }
+
+            auto target = initial;
+            kp.assign(opts.num_dofs, 0.0);
+            kd.assign(opts.num_dofs, 0.0);
+            kp[opts.joint] = opts.kp;
+            kd[opts.joint] = opts.kd;
+            double desired = opts.absolute ? opts.offset : initial[opts.joint] + opts.offset;
+            target[opts.joint] = desired;
+
+            std::cout << LOGGER::INFO << "Driving joint " << opts.joint << " toward target " << desired << " rad." << std::endl;
+            auto start = std::chrono::steady_clock::now();
+            while (running && std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count() < opts.duration)
+            {
+                robot.set_target_joint_mit(target, dq, kp, kd, tau);
+                std::this_thread::sleep_for(period);
+            }
+
+            target[opts.joint] = initial[opts.joint];
+            start = std::chrono::steady_clock::now();
+            while (running && std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count() < opts.settle)
+            {
+                robot.set_target_joint_mit(target, dq, kp, kd, tau);
+                std::this_thread::sleep_for(period);
+            }
+        }
+        else // torque mode
+        {
+            std::cout << LOGGER::INFO << "Applying " << opts.torque << " Nm torque to joint " << opts.joint << "." << std::endl;
+            auto torques = zero_torque;
+            torques[opts.joint] = opts.torque;
+            auto start = std::chrono::steady_clock::now();
+            while (running && std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count() < opts.duration)
+            {
+                robot.set_target_joint_t(torques);
+                std::this_thread::sleep_for(period);
+            }
+            robot.set_target_joint_t(zero_torque);
+        }
+
+        cleanup();
+        return 0;
+    }
+
+    std::cout << LOGGER::ERROR << "Unknown mode '" << opts.mode << "'." << std::endl;
+    cleanup();
+    return -1;
+}


### PR DESCRIPTION
## Summary
- vendor the TITA hardware CAN driver and expose it as a titati_robot static library inside rl_sar
- register the titati FSM configuration and add a new rl_real_titati executable that streams RL commands to the Titati robot through the CAN interface
- enable direct MIT-style torque control using the real robot state (IMU and joint feedback) to drive the Titati quadruped from rl_sar policies

## Testing
- `./build.sh -m rl_sar` *(fails: Torch library not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccbc2ba1288321b7a28f0f80a5f568