### PR TITLE
Add Titati hardware interface and controller

### DIFF
--- a/rl_sar/README.md
+++ b/rl_sar/README.md
@@ -343,6 +343,43 @@ Pull the code and compile it. The process is the same as above.
 
 <details>
 
+<summary>DDTRobot Titati (Click to expand)</summary>
+
+Titati is assembled from two Tita robots that share a single CAN-FD backbone. The real robot controller in this repository exposes a new binary `rl_real_titati` that talks directly to the hardware interface without any dependency on the legacy `titati_control` stack. The program drives both half-robots from the master Jetson and automatically enables direct motor control on the MCU router.
+
+1. **Bring up CAN-FD on both Jetsons** (master and slave) after powering the robots:
+
+   ```bash
+   sudo ip link set can0 down
+   sudo ip link set can0 up type can bitrate 1000000 sample-point 0.80 dbitrate 8000000 dsample-point 0.80 fd on restart-ms 100
+   sudo ifconfig can0 txqueuelen 1000
+   ```
+
+   These commands must be executed on both Jetsons so that the CAN-FD router forwards frames between the two Tita platforms.
+
+2. **Launch the Titati controller on the master Jetson** (the slave Jetson only needs the CAN interface from step 1):
+
+   ```bash
+   # ROS1
+   source devel/setup.bash
+   rosrun rl_sar rl_real_titati
+
+   # ROS2
+   source install/setup.bash
+   ros2 run rl_sar rl_real_titati
+
+   # CMake (standalone)
+   ./cmake_build/bin/rl_real_titati
+   ```
+
+   The executable assumes the CAN device is named `can0`. To override this (for example when using a USB-to-CAN adapter), export `CAN_INTERFACE=<device>` before running the controller.
+
+3. **Operate Titati using keyboard/joystick commands** (see the control table above). The controller reads joint states from both robots, publishes MIT-style torque commands through the CAN router, and keeps the MCU router locked in `FORCE_DIRECT` mode for RL execution. No additional helper nodes are required on the slave Jetson.
+
+</details>
+
+<details>
+
 <summary>Deeprobotics Lite3 (Click to expand)</summary>
 
 Deeprobotics Lite3 can be connected using wireless method.

--- a/rl_sar/src/rl_sar/CMakeLists.txt
+++ b/rl_sar/src/rl_sar/CMakeLists.txt
@@ -192,6 +192,18 @@ if(NOT USE_CMAKE)
     endif()
 endif()
 
+add_library(titati_hardware
+    library/hardware/titati/titati_hardware.cpp
+)
+target_include_directories(titati_hardware PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/library/hardware/titati
+)
+set_target_properties(titati_hardware PROPERTIES
+    CXX_STANDARD 14
+    CXX_STANDARD_REQUIRED ON
+)
+target_link_libraries(titati_hardware PUBLIC Threads::Threads)
+
 if(NOT USE_CMAKE)
     add_executable(rl_sim src/rl_sim.cpp)
     target_link_libraries(rl_sim
@@ -318,6 +330,25 @@ if(NOT USE_CMAKE)
             geometry_msgs
         )
         install(TARGETS rl_real_l4w4 DESTINATION lib/${PROJECT_NAME})
+    endif()
+endif()
+
+add_executable(rl_real_titati src/rl_real_titati.cpp)
+target_link_libraries(rl_real_titati
+    titati_hardware
+    rl_sdk
+    observation_buffer
+    yaml-cpp
+)
+if(NOT USE_CMAKE)
+    if($ENV{ROS_DISTRO} MATCHES "noetic")
+        target_link_libraries(rl_real_titati ${catkin_LIBRARIES})
+    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+        ament_target_dependencies(rl_real_titati
+            rclcpp
+            geometry_msgs
+        )
+        install(TARGETS rl_real_titati DESTINATION lib/${PROJECT_NAME})
     endif()
 endif()
 

--- a/rl_sar/src/rl_sar/include/rl_real_titati.hpp
+++ b/rl_sar/src/rl_sar/include/rl_real_titati.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "rl_sdk.hpp"
+#include "observation_buffer.hpp"
+#include "loop.hpp"
+#include "fsm.hpp"
+
+#include "titati_hardware.hpp"
+
+#if defined(USE_ROS1) && defined(USE_ROS)
+#include <ros/ros.h>
+#include <geometry_msgs/Twist.h>
+#elif defined(USE_ROS2) && defined(USE_ROS)
+#include <rclcpp/rclcpp.hpp>
+#include <geometry_msgs/msg/twist.hpp>
+#endif
+
+#include <memory>
+#include <vector>
+
+class RL_Real
+    : public RL
+#if defined(USE_ROS2) && defined(USE_ROS)
+    , public rclcpp::Node
+#endif
+{
+public:
+    RL_Real(const std::string& can_interface = "can0");
+    ~RL_Real();
+
+private:
+    torch::Tensor Forward() override;
+    void GetState(RobotState<double>* state) override;
+    void SetCommand(const RobotCommand<double>* command) override;
+    void RunModel();
+    void RobotControl();
+
+    std::shared_ptr<LoopFunc> loop_keyboard;
+    std::shared_ptr<LoopFunc> loop_control;
+    std::shared_ptr<LoopFunc> loop_rl;
+    std::shared_ptr<LoopFunc> loop_plot;
+
+    void Plot();
+    const int plot_size = 100;
+    std::vector<int> plot_t;
+    std::vector<std::vector<double>> plot_real_joint_pos;
+    std::vector<std::vector<double>> plot_target_joint_pos;
+
+    std::unique_ptr<titati::hardware::TitatiHardware> hardware_;
+    titati::hardware::CombinedState cached_state_;
+
+    std::vector<double> command_q_;
+    std::vector<double> command_dq_;
+    std::vector<double> command_kp_;
+    std::vector<double> command_kd_;
+    std::vector<double> command_tau_;
+
+#if defined(USE_ROS1) && defined(USE_ROS)
+    geometry_msgs::Twist cmd_vel;
+    ros::Subscriber cmd_vel_subscriber;
+    void CmdvelCallback(const geometry_msgs::Twist::ConstPtr& msg);
+#elif defined(USE_ROS2) && defined(USE_ROS)
+    geometry_msgs::msg::Twist cmd_vel;
+    rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_subscriber;
+    void CmdvelCallback(const geometry_msgs::msg::Twist::SharedPtr msg);
+#endif
+};
+

--- a/rl_sar/src/rl_sar/library/hardware/titati/titati_hardware.cpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/titati_hardware.cpp
@@ -1,0 +1,471 @@
+#include "titati_hardware.hpp"
+
+#include <linux/can.h>
+#include <linux/can/error.h>
+#include <linux/can/raw.h>
+#include <net/if.h>
+#include <poll.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstring>
+#include <iostream>
+#include <stdexcept>
+#include <thread>
+#include <cerrno>
+
+namespace titati::hardware
+{
+namespace
+{
+constexpr std::uint32_t kMotorFeedbackBaseId = 0x108U;
+constexpr std::uint32_t kMotorFeedbackMask = 0x7E0U;
+constexpr std::uint32_t kMotorCommandBaseId = 0x120U;
+constexpr std::uint32_t kImuFeedbackId = 0x118U;
+constexpr std::uint32_t kRouterStatusId = 0x09FU;
+constexpr std::uint32_t kRpcCommandId = 0x170U;
+constexpr float kGravity = 9.81f;
+constexpr std::uint16_t kRpcKeyReadyNext = 0x200U;
+constexpr std::uint32_t kReadyWaiting = 0x00U;
+constexpr std::uint32_t kAutoLocomotion = 0x01U;
+constexpr std::uint32_t kForceDirect = 0x03U;
+
+struct __attribute__((packed)) MotorFeedbackPacket
+{
+    std::uint32_t timestamp;
+    float position;
+    float velocity;
+    float torque;
+};
+
+struct __attribute__((packed)) MotorCommandPacket
+{
+    std::uint32_t timestamp;
+    float position;
+    float kp;
+    float velocity;
+    float kd;
+    float torque;
+};
+
+struct __attribute__((packed)) ImuPacket
+{
+    std::uint32_t timestamp;
+    float acceleration[3];
+    float gyroscope[3];
+    float quaternion[4];  // x, y, z, w
+    float temperature;
+};
+
+}  // namespace
+
+TitatiHardware::TitatiHardware(std::string can_interface, std::size_t motor_count)
+    : interface_(std::move(can_interface)),
+      motor_count_(motor_count)
+{
+    if (motor_count_ == 0)
+    {
+        throw std::invalid_argument("motor_count must be greater than zero");
+    }
+
+    if (motor_count_ % 4 == 0)
+    {
+        dof_per_leg_ = 4;
+    }
+    else if (motor_count_ % 6 == 0)
+    {
+        dof_per_leg_ = 6;
+    }
+    else
+    {
+        dof_per_leg_ = motor_count_;
+    }
+    leg_count_ = motor_count_ / dof_per_leg_;
+    motor_state_.resize(motor_count_);
+}
+
+TitatiHardware::~TitatiHardware()
+{
+    Shutdown();
+}
+
+bool TitatiHardware::Initialize()
+{
+    if (initialized_.load())
+    {
+        return true;
+    }
+
+    socket_fd_ = ::socket(PF_CAN, SOCK_RAW, CAN_RAW);
+    if (socket_fd_ < 0)
+    {
+        std::perror("titati_can socket");
+        return false;
+    }
+
+    int canfd_on = 1;
+    if (::setsockopt(socket_fd_, SOL_CAN_RAW, CAN_RAW_FD_FRAMES, &canfd_on, sizeof(canfd_on)) < 0)
+    {
+        std::perror("setsockopt CAN_RAW_FD_FRAMES");
+        ::close(socket_fd_);
+        socket_fd_ = -1;
+        return false;
+    }
+
+    int recv_own_msgs = 0;
+    (void)::setsockopt(socket_fd_, SOL_CAN_RAW, CAN_RAW_RECV_OWN_MSGS, &recv_own_msgs, sizeof(recv_own_msgs));
+
+    struct ifreq ifr
+    {
+    };
+    std::strncpy(ifr.ifr_name, interface_.c_str(), IFNAMSIZ - 1);
+    if (ioctl(socket_fd_, SIOCGIFINDEX, &ifr) < 0)
+    {
+        std::perror("ioctl SIOCGIFINDEX");
+        ::close(socket_fd_);
+        socket_fd_ = -1;
+        return false;
+    }
+
+    struct sockaddr_can addr
+    {
+    };
+    addr.can_family = AF_CAN;
+    addr.can_ifindex = ifr.ifr_ifindex;
+    if (::bind(socket_fd_, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) < 0)
+    {
+        std::perror("bind can interface");
+        ::close(socket_fd_);
+        socket_fd_ = -1;
+        return false;
+    }
+
+    struct can_filter filters[3];
+    filters[0].can_id = kMotorFeedbackBaseId;
+    filters[0].can_mask = kMotorFeedbackMask;
+    filters[1].can_id = kImuFeedbackId;
+    filters[1].can_mask = CAN_SFF_MASK;
+    filters[2].can_id = kRouterStatusId;
+    filters[2].can_mask = CAN_SFF_MASK;
+    if (::setsockopt(socket_fd_, SOL_CAN_RAW, CAN_RAW_FILTER, &filters, sizeof(filters)) < 0)
+    {
+        std::perror("setsockopt CAN_RAW_FILTER");
+        ::close(socket_fd_);
+        socket_fd_ = -1;
+        return false;
+    }
+
+    running_.store(true);
+    receiver_thread_ = std::thread(&TitatiHardware::ReceiverLoop, this);
+    initialized_.store(true);
+    return true;
+}
+
+void TitatiHardware::Shutdown()
+{
+    running_.store(false);
+    if (receiver_thread_.joinable())
+    {
+        receiver_thread_.join();
+    }
+
+    if (socket_fd_ >= 0)
+    {
+        ::close(socket_fd_);
+        socket_fd_ = -1;
+    }
+
+    initialized_.store(false);
+}
+
+CombinedState TitatiHardware::GetLatestState() const
+{
+    CombinedState output;
+    output.motors.resize(motor_state_.size());
+
+    {
+        std::scoped_lock<std::mutex> lock(state_mutex_);
+        output.motors = motor_state_;
+        output.imu = imu_state_;
+    }
+    output.sequence = state_sequence_.load(std::memory_order_relaxed);
+    return output;
+}
+
+bool TitatiHardware::SendMitCommand(const std::vector<double>& position,
+                                    const std::vector<double>& velocity,
+                                    const std::vector<double>& kp,
+                                    const std::vector<double>& kd,
+                                    const std::vector<double>& torque)
+{
+    if (!initialized_.load())
+    {
+        return false;
+    }
+
+    if (position.size() != motor_count_ || velocity.size() != motor_count_ ||
+        kp.size() != motor_count_ || kd.size() != motor_count_ || torque.size() != motor_count_)
+    {
+        std::cerr << "[TitatiHardware] Invalid command vector size" << std::endl;
+        return false;
+    }
+
+    if (motor_count_ == 0)
+    {
+        return false;
+    }
+
+    bool success = true;
+    const std::uint32_t timestamp = AcquireTimestampUs();
+
+    struct canfd_frame frame
+    {
+    };
+    frame.len = sizeof(MotorCommandPacket) * 2;
+    frame.flags = 0U;
+
+    const std::size_t command_pairs = (motor_count_ + 1) / 2;
+
+    for (std::size_t pair = 0; pair < command_pairs; ++pair)
+    {
+        frame.can_id = kMotorCommandBaseId + pair;
+        std::memset(frame.data, 0, sizeof(frame.data));
+
+        for (std::size_t j = 0; j < 2; ++j)
+        {
+            const std::size_t idx = pair * 2 + j;
+            if (idx >= motor_count_)
+            {
+                break;
+            }
+
+            MotorCommandPacket packet{};
+            packet.timestamp = timestamp;
+            packet.position = static_cast<float>(position[idx]);
+            packet.velocity = static_cast<float>(velocity[idx]);
+            packet.kp = static_cast<float>(kp[idx]);
+            packet.kd = static_cast<float>(kd[idx]);
+            packet.torque = static_cast<float>(torque[idx]);
+
+            std::memcpy(frame.data + j * sizeof(MotorCommandPacket), &packet, sizeof(MotorCommandPacket));
+        }
+
+        if (!SendFrame(&frame, CANFD_MTU))
+        {
+            success = false;
+        }
+
+        std::this_thread::sleep_for(std::chrono::microseconds(150));
+    }
+
+    return success;
+}
+
+bool TitatiHardware::SendTorqueCommand(const std::vector<double>& torque)
+{
+    std::vector<double> zeros(motor_count_, 0.0);
+    return SendMitCommand(zeros, zeros, zeros, zeros, torque);
+}
+
+bool TitatiHardware::SetDirectControlMode(bool enable)
+{
+    if (!initialized_.load())
+    {
+        return false;
+    }
+
+    bool ok = SendRpcCommand(kRpcKeyReadyNext, kReadyWaiting);
+    std::this_thread::sleep_for(std::chrono::microseconds(200));
+    ok &= SendRpcCommand(kRpcKeyReadyNext, enable ? kForceDirect : kAutoLocomotion);
+    if (enable)
+    {
+        router_force_direct_pending_.store(true);
+    }
+    return ok;
+}
+
+void TitatiHardware::ReceiverLoop()
+{
+    struct pollfd poll_fd
+    {
+        socket_fd_, POLLIN, 0
+    };
+
+    while (running_.load())
+    {
+        const int poll_ret = ::poll(&poll_fd, 1, 100);
+        if (!running_.load())
+        {
+            break;
+        }
+
+        if (poll_ret < 0)
+        {
+            if (errno == EINTR)
+            {
+                continue;
+            }
+            std::perror("poll can socket");
+            continue;
+        }
+
+        if (poll_ret == 0)
+        {
+            continue;
+        }
+
+        struct canfd_frame frame
+        {
+        };
+        const ssize_t bytes_read = ::read(socket_fd_, &frame, sizeof(frame));
+        if (bytes_read < 0)
+        {
+            if (errno == EWOULDBLOCK || errno == EAGAIN)
+            {
+                continue;
+            }
+            std::perror("read can frame");
+            continue;
+        }
+
+        const std::uint32_t can_id = frame.can_id & CAN_SFF_MASK;
+        if (can_id >= kMotorFeedbackBaseId && can_id < kMotorFeedbackBaseId + leg_count_)
+        {
+            HandleMotorFeedback(can_id, frame.data, frame.len);
+        }
+        else if (can_id == kImuFeedbackId)
+        {
+            HandleImuFeedback(frame.data, frame.len);
+        }
+        else if (can_id == kRouterStatusId)
+        {
+            HandleRouterFeedback(frame.data, frame.len);
+        }
+        else
+        {
+            // Ignore other frames
+        }
+    }
+}
+
+void TitatiHardware::HandleMotorFeedback(std::uint32_t can_id, const std::uint8_t* data, std::uint8_t dlc)
+{
+    if (dlc < dof_per_leg_ * sizeof(MotorFeedbackPacket))
+    {
+        return;
+    }
+
+    const std::size_t leg_index = can_id - kMotorFeedbackBaseId;
+    const std::size_t base_index = leg_index * dof_per_leg_;
+
+    std::scoped_lock<std::mutex> lock(state_mutex_);
+    for (std::size_t i = 0; i < dof_per_leg_; ++i)
+    {
+        MotorFeedbackPacket packet{};
+        std::memcpy(&packet, data + i * sizeof(MotorFeedbackPacket), sizeof(MotorFeedbackPacket));
+
+        const std::size_t motor_index = base_index + i;
+        if (motor_index >= motor_state_.size())
+        {
+            continue;
+        }
+
+        motor_state_[motor_index].position = static_cast<double>(packet.position);
+        motor_state_[motor_index].velocity = static_cast<double>(packet.velocity);
+        motor_state_[motor_index].torque = static_cast<double>(packet.torque);
+        motor_state_[motor_index].timestamp = packet.timestamp;
+    }
+    state_sequence_.fetch_add(1, std::memory_order_relaxed);
+}
+
+void TitatiHardware::HandleImuFeedback(const std::uint8_t* data, std::uint8_t dlc)
+{
+    if (dlc < sizeof(ImuPacket))
+    {
+        return;
+    }
+
+    ImuPacket packet{};
+    std::memcpy(&packet, data, sizeof(ImuPacket));
+
+    std::scoped_lock<std::mutex> lock(state_mutex_);
+    imu_state_.timestamp = packet.timestamp;
+    imu_state_.acceleration = {packet.acceleration[0] * kGravity,
+                               packet.acceleration[1] * kGravity,
+                               packet.acceleration[2] * kGravity};
+    imu_state_.gyroscope = {packet.gyroscope[0], packet.gyroscope[1], packet.gyroscope[2]};
+    imu_state_.quaternion = {packet.quaternion[3], packet.quaternion[0], packet.quaternion[1], packet.quaternion[2]};
+    state_sequence_.fetch_add(1, std::memory_order_relaxed);
+}
+
+void TitatiHardware::HandleRouterFeedback(const std::uint8_t* data, std::uint8_t dlc)
+{
+    if (!router_force_direct_pending_.load())
+    {
+        return;
+    }
+
+    if (dlc < 12)
+    {
+        return;
+    }
+
+    std::uint32_t mode = 0;
+    std::memcpy(&mode, data + 4, sizeof(mode));
+    if (mode == 0x01U || mode == 0x02U)
+    {
+        router_force_direct_pending_.store(false);
+        SendRpcCommand(kRpcKeyReadyNext, kReadyWaiting);
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        SendRpcCommand(kRpcKeyReadyNext, kForceDirect);
+    }
+}
+
+bool TitatiHardware::SendRpcCommand(std::uint16_t key, std::uint32_t value)
+{
+    if (socket_fd_ < 0)
+    {
+        return false;
+    }
+
+    struct canfd_frame frame
+    {
+    };
+    frame.can_id = kRpcCommandId;
+    frame.len = 10U;
+    frame.flags = 0U;
+
+    const std::uint32_t timestamp = AcquireTimestampUs();
+    std::memcpy(frame.data, &timestamp, sizeof(timestamp));
+    std::memcpy(frame.data + 4, &key, sizeof(key));
+    std::memcpy(frame.data + 6, &value, sizeof(value));
+
+    return SendFrame(&frame, CANFD_MTU);
+}
+
+bool TitatiHardware::SendFrame(const void* frame, std::size_t length) const
+{
+    if (socket_fd_ < 0)
+    {
+        return false;
+    }
+
+    const ssize_t written = ::write(socket_fd_, frame, length);
+    if (written < 0)
+    {
+        std::perror("write can frame");
+        return false;
+    }
+    return true;
+}
+
+std::uint32_t TitatiHardware::AcquireTimestampUs() const
+{
+    const auto now = std::chrono::steady_clock::now().time_since_epoch();
+    const auto micros = std::chrono::duration_cast<std::chrono::microseconds>(now).count();
+    return static_cast<std::uint32_t>(micros & 0xFFFFFFFFU);
+}
+
+}  // namespace titati::hardware

--- a/rl_sar/src/rl_sar/library/hardware/titati/titati_hardware.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/titati_hardware.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace titati::hardware
+{
+
+struct MotorState
+{
+    double position{0.0};
+    double velocity{0.0};
+    double torque{0.0};
+    uint32_t timestamp{0U};
+};
+
+struct ImuState
+{
+    std::array<double, 4> quaternion{ {1.0, 0.0, 0.0, 0.0} };  // w, x, y, z
+    std::array<double, 3> gyroscope{ {0.0, 0.0, 0.0} };
+    std::array<double, 3> acceleration{ {0.0, 0.0, 0.0} };
+    uint32_t timestamp{0U};
+};
+
+struct CombinedState
+{
+    std::vector<MotorState> motors;
+    ImuState imu;
+    uint64_t sequence{0U};
+};
+
+class TitatiHardware
+{
+public:
+    TitatiHardware(std::string can_interface, std::size_t motor_count);
+    ~TitatiHardware();
+
+    TitatiHardware(const TitatiHardware&) = delete;
+    TitatiHardware& operator=(const TitatiHardware&) = delete;
+
+    bool Initialize();
+    void Shutdown();
+
+    bool IsInitialized() const { return initialized_.load(); }
+
+    CombinedState GetLatestState() const;
+
+    bool SendMitCommand(const std::vector<double>& position,
+                        const std::vector<double>& velocity,
+                        const std::vector<double>& kp,
+                        const std::vector<double>& kd,
+                        const std::vector<double>& torque);
+
+    bool SendTorqueCommand(const std::vector<double>& torque);
+
+    bool SetDirectControlMode(bool enable);
+
+private:
+    void ReceiverLoop();
+    void HandleMotorFeedback(std::uint32_t can_id, const std::uint8_t* data, std::uint8_t dlc);
+    void HandleImuFeedback(const std::uint8_t* data, std::uint8_t dlc);
+    void HandleRouterFeedback(const std::uint8_t* data, std::uint8_t dlc);
+    bool SendRpcCommand(std::uint16_t key, std::uint32_t value);
+    bool SendFrame(const void* frame, std::size_t length) const;
+    std::uint32_t AcquireTimestampUs() const;
+
+    const std::string interface_;
+    const std::size_t motor_count_;
+    std::size_t dof_per_leg_;
+    std::size_t leg_count_;
+
+    int socket_fd_{-1};
+    std::atomic<bool> initialized_{false};
+    std::atomic<bool> running_{false};
+    std::atomic<bool> router_force_direct_pending_{false};
+
+    std::thread receiver_thread_;
+
+    mutable std::mutex state_mutex_;
+    std::vector<MotorState> motor_state_;
+    ImuState imu_state_{};
+    std::atomic<uint64_t> state_sequence_{0U};
+};
+
+}  // namespace titati::hardware

--- a/rl_sar/src/rl_sar/src/rl_real_titati.cpp
+++ b/rl_sar/src/rl_sar/src/rl_real_titati.cpp
@@ -1,0 +1,357 @@
+#include "rl_real_titati.hpp"
+
+#include <iostream>
+#include <stdexcept>
+#include <algorithm>
+#include <csignal>
+#include <cstdlib>
+#include <string>
+#include <unistd.h>
+
+#ifdef PLOT
+#include "matplotlibcpp.h"
+namespace plt = matplotlibcpp;
+#endif
+
+RL_Real::RL_Real(const std::string& can_interface)
+#if defined(USE_ROS2) && defined(USE_ROS)
+    : rclcpp::Node("rl_real_node")
+#endif
+{
+#if defined(USE_ROS1) && defined(USE_ROS)
+    ros::NodeHandle nh;
+    this->cmd_vel_subscriber = nh.subscribe<geometry_msgs::Twist>("/cmd_vel", 10, &RL_Real::CmdvelCallback, this);
+#elif defined(USE_ROS2) && defined(USE_ROS)
+    this->cmd_vel_subscriber = this->create_subscription<geometry_msgs::msg::Twist>(
+        "/cmd_vel", rclcpp::SystemDefaultsQoS(),
+        [this](const geometry_msgs::msg::Twist::SharedPtr msg) { this->CmdvelCallback(msg); });
+#endif
+
+    this->ang_vel_type = "ang_vel_body";
+    this->robot_name = "titati";
+    this->ReadYamlBase(this->robot_name);
+
+    if (FSMManager::GetInstance().IsTypeSupported(this->robot_name))
+    {
+        auto fsm_ptr = FSMManager::GetInstance().CreateFSM(this->robot_name, this);
+        if (fsm_ptr)
+        {
+            this->fsm = *fsm_ptr;
+        }
+    }
+    else
+    {
+        std::cout << LOGGER::ERROR << "No FSM registered for robot: " << this->robot_name << std::endl;
+    }
+
+    torch::autograd::GradMode::set_enabled(false);
+    torch::set_num_threads(4);
+
+    hardware_ = std::make_unique<titati::hardware::TitatiHardware>(can_interface, this->params.num_of_dofs);
+    if (!hardware_->Initialize())
+    {
+        throw std::runtime_error("Failed to initialise Titati CAN interface");
+    }
+    if (!hardware_->SetDirectControlMode(true))
+    {
+        std::cerr << LOGGER::WARNING << "Unable to switch Titati controller to direct mode" << std::endl;
+    }
+
+    this->InitOutputs();
+    this->InitControl();
+
+    command_q_.assign(this->params.num_of_dofs, 0.0);
+    command_dq_.assign(this->params.num_of_dofs, 0.0);
+    command_kp_.assign(this->params.num_of_dofs, 0.0);
+    command_kd_.assign(this->params.num_of_dofs, 0.0);
+    command_tau_.assign(this->params.num_of_dofs, 0.0);
+
+    this->loop_keyboard = std::make_shared<LoopFunc>("loop_keyboard", 0.05, std::bind(&RL_Real::KeyboardInterface, this));
+    this->loop_control = std::make_shared<LoopFunc>("loop_control", this->params.dt, std::bind(&RL_Real::RobotControl, this));
+    this->loop_rl = std::make_shared<LoopFunc>("loop_rl", this->params.dt * this->params.decimation, std::bind(&RL_Real::RunModel, this));
+    this->loop_keyboard->start();
+    this->loop_control->start();
+    this->loop_rl->start();
+
+#ifdef PLOT
+    this->plot_t = std::vector<int>(this->plot_size, 0);
+    this->plot_real_joint_pos.resize(this->params.num_of_dofs);
+    this->plot_target_joint_pos.resize(this->params.num_of_dofs);
+    for (auto &vec : this->plot_real_joint_pos)
+    {
+        vec = std::vector<double>(this->plot_size, 0.0);
+    }
+    for (auto &vec : this->plot_target_joint_pos)
+    {
+        vec = std::vector<double>(this->plot_size, 0.0);
+    }
+    this->loop_plot = std::make_shared<LoopFunc>("loop_plot", 0.002, std::bind(&RL_Real::Plot, this));
+    this->loop_plot->start();
+#endif
+#ifdef CSV_LOGGER
+    this->CSVInit(this->robot_name);
+#endif
+}
+
+RL_Real::~RL_Real()
+{
+    this->loop_keyboard->shutdown();
+    this->loop_control->shutdown();
+    this->loop_rl->shutdown();
+#ifdef PLOT
+    this->loop_plot->shutdown();
+#endif
+    if (hardware_)
+    {
+        hardware_->Shutdown();
+    }
+    std::cout << LOGGER::INFO << "RL_Real exit" << std::endl;
+}
+
+void RL_Real::GetState(RobotState<double>* state)
+{
+    cached_state_ = hardware_->GetLatestState();
+
+    state->imu.quaternion[0] = cached_state_.imu.quaternion[0];
+    state->imu.quaternion[1] = cached_state_.imu.quaternion[1];
+    state->imu.quaternion[2] = cached_state_.imu.quaternion[2];
+    state->imu.quaternion[3] = cached_state_.imu.quaternion[3];
+
+    for (int i = 0; i < 3; ++i)
+    {
+        state->imu.gyroscope[i] = cached_state_.imu.gyroscope[i];
+        state->imu.accelerometer[i] = cached_state_.imu.acceleration[i];
+    }
+
+    for (int i = 0; i < this->params.num_of_dofs; ++i)
+    {
+        const std::size_t hardware_index = this->params.joint_mapping[i];
+        if (hardware_index >= cached_state_.motors.size())
+        {
+            continue;
+        }
+        state->motor_state.q[i] = cached_state_.motors[hardware_index].position;
+        state->motor_state.dq[i] = cached_state_.motors[hardware_index].velocity;
+        state->motor_state.tau_est[i] = cached_state_.motors[hardware_index].torque;
+    }
+}
+
+void RL_Real::SetCommand(const RobotCommand<double>* command)
+{
+    std::fill(command_q_.begin(), command_q_.end(), 0.0);
+    std::fill(command_dq_.begin(), command_dq_.end(), 0.0);
+    std::fill(command_kp_.begin(), command_kp_.end(), 0.0);
+    std::fill(command_kd_.begin(), command_kd_.end(), 0.0);
+    std::fill(command_tau_.begin(), command_tau_.end(), 0.0);
+
+    for (int i = 0; i < this->params.num_of_dofs; ++i)
+    {
+        const std::size_t hardware_index = this->params.joint_mapping[i];
+        if (hardware_index >= command_q_.size())
+        {
+            continue;
+        }
+        command_q_[hardware_index] = command->motor_command.q[i];
+        command_dq_[hardware_index] = command->motor_command.dq[i];
+        command_kp_[hardware_index] = command->motor_command.kp[i];
+        command_kd_[hardware_index] = command->motor_command.kd[i];
+        command_tau_[hardware_index] = command->motor_command.tau[i];
+    }
+
+    if (!hardware_->SendMitCommand(command_q_, command_dq_, command_kp_, command_kd_, command_tau_))
+    {
+        std::cerr << LOGGER::WARNING << "Failed to send Titati motor command" << std::endl;
+    }
+}
+
+void RL_Real::RobotControl()
+{
+    if (this->control.current_keyboard == Input::Keyboard::W)
+    {
+        this->control.x += 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::S)
+    {
+        this->control.x -= 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::A)
+    {
+        this->control.y += 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::D)
+    {
+        this->control.y -= 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::Q)
+    {
+        this->control.yaw += 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::E)
+    {
+        this->control.yaw -= 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::Space)
+    {
+        this->control.x = 0.0;
+        this->control.y = 0.0;
+        this->control.yaw = 0.0;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::N)
+    {
+        this->control.navigation_mode = !this->control.navigation_mode;
+        std::cout << std::endl
+                  << LOGGER::INFO << "Navigation mode: "
+                  << (this->control.navigation_mode ? "ON" : "OFF") << std::endl;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+
+#if defined(USE_ROS) && (defined(USE_ROS1) || defined(USE_ROS2))
+    if (this->control.navigation_mode)
+    {
+        this->control.x = this->cmd_vel.linear.x;
+        this->control.y = this->cmd_vel.linear.y;
+        this->control.yaw = this->cmd_vel.angular.z;
+    }
+#endif
+
+    this->GetState(&this->robot_state);
+    this->StateController(&this->robot_state, &this->robot_command);
+    this->SetCommand(&this->robot_command);
+}
+
+void RL_Real::RunModel()
+{
+    if (this->rl_init_done)
+    {
+        this->episode_length_buf += 1;
+        this->obs.ang_vel = torch::tensor(this->robot_state.imu.gyroscope).unsqueeze(0);
+#if defined(USE_ROS) && (defined(USE_ROS1) || defined(USE_ROS2))
+        if (this->control.navigation_mode)
+        {
+            this->obs.commands = torch::tensor({{this->cmd_vel.linear.x, this->cmd_vel.linear.y, this->cmd_vel.angular.z}});
+        }
+        else
+#endif
+        {
+            this->obs.commands = torch::tensor({{this->control.x, this->control.y, this->control.yaw}});
+        }
+        this->obs.base_quat = torch::tensor(this->robot_state.imu.quaternion).unsqueeze(0);
+        this->obs.dof_pos = torch::tensor(this->robot_state.motor_state.q).narrow(0, 0, this->params.num_of_dofs).unsqueeze(0);
+        this->obs.dof_vel = torch::tensor(this->robot_state.motor_state.dq).narrow(0, 0, this->params.num_of_dofs).unsqueeze(0);
+
+        this->obs.actions = this->Forward();
+        this->ComputeOutput(this->obs.actions, this->output_dof_pos, this->output_dof_vel, this->output_dof_tau);
+
+        if (this->output_dof_pos.defined() && this->output_dof_pos.numel() > 0)
+        {
+            output_dof_pos_queue.push(this->output_dof_pos);
+        }
+        if (this->output_dof_vel.defined() && this->output_dof_vel.numel() > 0)
+        {
+            output_dof_vel_queue.push(this->output_dof_vel);
+        }
+        if (this->output_dof_tau.defined() && this->output_dof_tau.numel() > 0)
+        {
+            output_dof_tau_queue.push(this->output_dof_tau);
+        }
+    }
+}
+
+torch::Tensor RL_Real::Forward()
+{
+    torch::autograd::GradMode::set_enabled(false);
+    torch::Tensor clamped_obs = this->ComputeObservation();
+
+    torch::Tensor actions;
+    if (!this->params.observations_history.empty())
+    {
+        this->history_obs_buf.insert(clamped_obs);
+        this->history_obs = this->history_obs_buf.get_obs_vec(this->params.observations_history);
+        actions = this->model.forward({this->history_obs}).toTensor();
+    }
+    else
+    {
+        actions = this->model.forward({clamped_obs}).toTensor();
+    }
+
+    if (this->params.clip_actions_upper.numel() != 0 && this->params.clip_actions_lower.numel() != 0)
+    {
+        return torch::clamp(actions, this->params.clip_actions_lower, this->params.clip_actions_upper);
+    }
+    return actions;
+}
+
+#ifdef PLOT
+void RL_Real::Plot()
+{
+    this->plot_t.erase(this->plot_t.begin());
+    this->plot_t.push_back(this->episode_length_buf);
+    plt::cla();
+    plt::clf();
+    for (int i = 0; i < this->params.num_of_dofs; ++i)
+    {
+        this->plot_real_joint_pos[i].erase(this->plot_real_joint_pos[i].begin());
+        this->plot_target_joint_pos[i].erase(this->plot_target_joint_pos[i].begin());
+        this->plot_real_joint_pos[i].push_back(this->robot_state.motor_state.q[i]);
+        this->plot_target_joint_pos[i].push_back(this->output_dof_pos[0][i].item<double>());
+        plt::subplot(this->params.num_of_dofs, 1, i + 1);
+        plt::named_plot("real_joint_pos", this->plot_t, this->plot_real_joint_pos[i], "r");
+        plt::named_plot("target_joint_pos", this->plot_t, this->plot_target_joint_pos[i], "b");
+        plt::xlim(this->plot_t.front(), this->plot_t.back());
+    }
+    plt::pause(0.0001);
+}
+#else
+void RL_Real::Plot() {}
+#endif
+
+#if defined(USE_ROS1) && defined(USE_ROS)
+void RL_Real::CmdvelCallback(const geometry_msgs::Twist::ConstPtr& msg)
+{
+    this->cmd_vel = *msg;
+}
+#elif defined(USE_ROS2) && defined(USE_ROS)
+void RL_Real::CmdvelCallback(const geometry_msgs::msg::Twist::SharedPtr msg)
+{
+    this->cmd_vel = *msg;
+}
+#endif
+
+#if defined(USE_ROS1) && defined(USE_ROS)
+void signalHandler(int signum)
+{
+    ros::shutdown();
+    exit(0);
+}
+#endif
+
+int main(int argc, char **argv)
+{
+    std::string can_interface = "can0";
+    if (const char *env = std::getenv("CAN_INTERFACE"))
+    {
+        can_interface = env;
+    }
+#if defined(USE_ROS1) && defined(USE_ROS)
+    signal(SIGINT, signalHandler);
+    ros::init(argc, argv, "rl_sar");
+    RL_Real rl_sar(can_interface);
+    ros::spin();
+#elif defined(USE_ROS2) && defined(USE_ROS)
+    rclcpp::init(argc, argv);
+    rclcpp::spin(std::make_shared<RL_Real>(can_interface));
+    rclcpp::shutdown();
+#elif defined(USE_CMAKE) || !defined(USE_ROS)
+    RL_Real rl_sar(can_interface);
+    while (1) { sleep(10); }
+#endif
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- implement a dedicated CAN-FD hardware layer for Titati that fuses both Tita sub-robots
- add a real robot controller entry point that drives the Titati hardware via reinforcement learning
- extend the build system and documentation to expose the new binary and usage instructions

## Testing
- ./build.sh -m *(fails: Torch not available in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68cd743cd6848321a542e41f027e15fc