### PR TITLE
Add Titati hardware interface and motor tester

### DIFF
--- a/rl_sar/README.md
+++ b/rl_sar/README.md
@@ -376,6 +376,58 @@ ros2 run rl_sar rl_real_lite3
 
 </details>
 
+<details>
+
+<summary>DDTRobot Tita / Titati (Click to expand)</summary>
+
+The new Tita/Titati hardware interface is fully integrated inside **rl_sar** and is built with **C++17**. Only the Titati targets
+are enabled by default. Other robot executables can be re-enabled through the new CMake options described below.
+
+**CAN topology**
+
+1. Configure both Jetson boards' `can0` interfaces in CAN-FD mode (1 Mbps nominal / 8 Mbps data phase).
+2. Physically bridge the two `can0` ports using the supplied "small box" so that master and slave share the same CAN-FD bus.
+3. On the slave Jetson only run `titati_canfd_router_node` and, after the power-on self-check, call `set_forcedirect_mode(true)` so
+   that all frames are forwarded transparently.
+4. The master Jetson runs the new rl_sar hardware layer and publishes commands for all 16 actuators directly on the shared CAN bus.
+
+**Build options**
+
+```bash
+cmake -S src/rl_sar -B cmake_build -DUSE_CMAKE=ON \
+      -DBUILD_TITATI=ON -DBUILD_UNITREE_A1=OFF -DBUILD_UNITREE_GO2=OFF \
+      -DBUILD_UNITREE_G1=OFF -DBUILD_L4W4=OFF -DBUILD_LITE3=OFF
+cmake --build cmake_build -j4
+```
+
+`BUILD_TITATI` is `ON` by default while all other real robot executables are disabled, matching the "Titati only" workflow. Enable
+additional robots by setting the corresponding option to `ON` when required.
+
+**Motor verification**
+
+Before running reinforcement learning, verify CAN connectivity with the dedicated tester:
+
+```bash
+./cmake_build/bin/titati_motor_test --robot=titati     # 16 motor sweep
+# or for a single robot
+./cmake_build/bin/titati_motor_test --robot=tita       # 8 motor sweep
+```
+
+The program sequentially excites each joint using MIT mode so that you can confirm that every actuator responds safely.
+
+**RL control entry-point**
+
+Launch the real-time controller from the master Jetson once the slave is forwarding traffic:
+
+```bash
+./cmake_build/bin/rl_real_tita --robot=titati
+```
+
+Use `--robot=tita` when operating a single Tita platform. The executable reuses the Titati policy configuration located under
+`policy/titati` and exposes the same keyboard/gamepad interface as other rl_sar robots.
+
+</details>
+
 ### Train the actuator network
 
 Take A1 as an example below

--- a/rl_sar/README.md
+++ b/rl_sar/README.md
@@ -429,9 +429,16 @@ Before running reinforcement learning, verify CAN connectivity with the dedicate
 ./cmake_build/bin/titati_motor_test --robot=titati     # 16 motor sweep
 # or for a single robot
 ./cmake_build/bin/titati_motor_test --robot=tita       # 8 motor sweep
+# hold the measured pose and excite only joint 6 for 5 seconds at 1 Hz with 0.15 rad amplitude
+./cmake_build/bin/titati_motor_test --robot=titati --joint=6 --frequency=1.0 --duration=5.0 --amplitude=0.15
+# alternatively drive the joint with a sine torque (Nm)
+./cmake_build/bin/titati_motor_test --robot=titati --joint=6 --mode=torque --torque-amplitude=8.0
 ```
 
-The program sequentially excites each joint using MIT mode so that you can confirm that every actuator responds safely.
+The program now samples the current joint configuration as the hold pose, stabilises the robot, and then excites the selected
+joint(s). Use `--joint=<index>` to command a single actuator, tune PD gains via `--kp/--kd` and `--wheel-kp/--wheel-kd`, or switch
+to pure torque mode with `--mode=torque` combined with `--torque-amplitude`/`--torque-bias`. Passing `--pose=default` falls back
+to the previously documented nominal stance.
 
 **RL control entry-point**
 

--- a/rl_sar/README.md
+++ b/rl_sar/README.md
@@ -402,10 +402,10 @@ are enabled by default. Other robot executables can be re-enabled through the ne
    ```bash
    bash src/rl_sar/scripts/titati_can_setup_slave.sh
    # or run manually after configuring CAN
-   ./cmake_build/bin/titati_canfd_router_node [--stay-alive]
+   ./cmake_build/bin/titati_canfd_router_node [--stay-alive|--once]
    ```
 
-   The program waits for the power-on self-test heartbeat (router mode 1/2) and then automatically calls `set_forcedirect_mode(true)` so that every CAN frame is transparently forwarded. Use `--stay-alive` to keep monitoring after the command is acknowledged.
+   The program waits for the power-on self-test heartbeat (router mode 1/2) and then automatically calls `set_forcedirect_mode(true)` so that every CAN frame is transparently forwarded. The helper script keeps the router process alive (press `Ctrl+C` to stop) so the forwarding remains active while the master issues commands. Use `--once` if you only want to send the command and exit immediately.
 
 4. The master Jetson runs the new rl_sar hardware layer and publishes commands for all 16 actuators directly on the shared CAN bus once the slave reports "Router switched to forced-direct relay mode".
 

--- a/rl_sar/README.md
+++ b/rl_sar/README.md
@@ -407,7 +407,7 @@ are enabled by default. Other robot executables can be re-enabled through the ne
 
    The program waits for the power-on self-test heartbeat (router mode 1/2) and then automatically calls `set_forcedirect_mode(true)` so that every CAN frame is transparently forwarded. The helper script keeps the router process alive (press `Ctrl+C` to stop) so the forwarding remains active while the master issues commands. Use `--once` if you only want to send the command and exit immediately.
 
-4. The master Jetson runs the new rl_sar hardware layer and publishes commands for all 16 actuators directly on the shared CAN bus once the slave reports "Router switched to forced-direct relay mode".
+4. The master Jetson runs the new rl_sar hardware layer and publishes commands for all 16 actuators directly on the shared CAN bus once the slave reports "Router switched to forced-direct relay mode". The CAN backend now mirrors the addressing used by `titati_control`: every torque frame is emitted once per motor board (IDs `0x120–0x123` for the front unit and `0x130–0x133` for the rear unit) and feedback frames from both boards are reassembled into a single 16-joint state vector.
 
 **Build options**
 
@@ -439,6 +439,7 @@ The program now samples the current joint configuration as the hold pose, stabil
 joint(s). Use `--joint=<index>` to command a single actuator, tune PD gains via `--kp/--kd` and `--wheel-kp/--wheel-kd`, or switch
 to pure torque mode with `--mode=torque` combined with `--torque-amplitude`/`--torque-bias`. Passing `--pose=default` falls back
 to the previously documented nominal stance.
+Each excitation step now confirms that both Titati motor boards respond in sequence—the sweep enumerates 12 leg joints followed by the 4 wheel motors—so you can validate end-to-end CAN coverage before loading any RL policy.
 
 **RL control entry-point**
 

--- a/rl_sar/README.md
+++ b/rl_sar/README.md
@@ -385,11 +385,29 @@ are enabled by default. Other robot executables can be re-enabled through the ne
 
 **CAN topology**
 
-1. Configure both Jetson boards' `can0` interfaces in CAN-FD mode (1 Mbps nominal / 8 Mbps data phase).
+1. Configure each Jetson's `can0` in CAN-FD mode (1 Mbps nominal / 8 Mbps data phase):
+
+   ```bash
+   sudo ip link set can0 down
+   sudo ip link set can0 up type can bitrate 1000000 sample-point 0.80 dbitrate 8000000 \
+       dsample-point 0.80 fd on restart-ms 100
+   sudo ifconfig can0 txqueuelen 1000
+   ```
+
+   The helper script `bash src/rl_sar/scripts/titati_can_setup_master.sh` performs the same configuration for the master Jetson (pass a different interface name as the first argument if needed).
+
 2. Physically bridge the two `can0` ports using the supplied "small box" so that master and slave share the same CAN-FD bus.
-3. On the slave Jetson only run `titati_canfd_router_node` and, after the power-on self-check, call `set_forcedirect_mode(true)` so
-   that all frames are forwarded transparently.
-4. The master Jetson runs the new rl_sar hardware layer and publishes commands for all 16 actuators directly on the shared CAN bus.
+3. On the slave Jetson run the dedicated router helper:
+
+   ```bash
+   bash src/rl_sar/scripts/titati_can_setup_slave.sh
+   # or run manually after configuring CAN
+   ./cmake_build/bin/titati_canfd_router_node [--stay-alive]
+   ```
+
+   The program waits for the power-on self-test heartbeat (router mode 1/2) and then automatically calls `set_forcedirect_mode(true)` so that every CAN frame is transparently forwarded. Use `--stay-alive` to keep monitoring after the command is acknowledged.
+
+4. The master Jetson runs the new rl_sar hardware layer and publishes commands for all 16 actuators directly on the shared CAN bus once the slave reports "Router switched to forced-direct relay mode".
 
 **Build options**
 

--- a/rl_sar/README_CN.md
+++ b/rl_sar/README_CN.md
@@ -402,10 +402,10 @@ ros2 run rl_sar rl_real_lite3
    ```bash
    bash src/rl_sar/scripts/titati_can_setup_slave.sh
    # 或者在手动配置 CAN 后直接运行
-   ./cmake_build/bin/titati_canfd_router_node [--stay-alive]
+   ./cmake_build/bin/titati_canfd_router_node [--stay-alive|--once]
    ```
 
-   程序会等待上电自检完成（路由板心跳 mode=1/2），随后自动调用 `set_forcedirect_mode(true)` 把 CAN 报文透传到总线上。若需持续监控，可附加 `--stay-alive` 参数。
+   程序会等待上电自检完成（路由板心跳 mode=1/2），随后自动调用 `set_forcedirect_mode(true)` 把 CAN 报文透传到总线上。脚本会让路由进程保持运行（需要停止时按 `Ctrl+C`），确保主机在发送指令期间转发始终有效；若只希望发送一次指令后退出，可使用 `--once` 参数。
 
 4. 待终端提示“Router switched to forced-direct relay mode”后，主机 Jetson 再启动 rl_sar 控制程序，在同一 CAN-FD 总线上直接下发 16 个电机命令。
 

--- a/rl_sar/README_CN.md
+++ b/rl_sar/README_CN.md
@@ -407,7 +407,7 @@ ros2 run rl_sar rl_real_lite3
 
    程序会等待上电自检完成（路由板心跳 mode=1/2），随后自动调用 `set_forcedirect_mode(true)` 把 CAN 报文透传到总线上。脚本会让路由进程保持运行（需要停止时按 `Ctrl+C`），确保主机在发送指令期间转发始终有效；若只希望发送一次指令后退出，可使用 `--once` 参数。
 
-4. 待终端提示“Router switched to forced-direct relay mode”后，主机 Jetson 再启动 rl_sar 控制程序，在同一 CAN-FD 总线上直接下发 16 个电机命令。
+4. 待终端提示“Router switched to forced-direct relay mode”后，主机 Jetson 再启动 rl_sar 控制程序，在同一 CAN-FD 总线上直接下发 16 个电机命令。底层 CAN 发送策略与 `titati_control` 一致：每个力矩帧会针对前后两个控制板分别发送一遍（ID 范围分别为 `0x120-0x123` 与 `0x130-0x133`），反馈帧也会自动重组到一份 16 关节的状态向量中。
 
 **编译选项**
 
@@ -436,7 +436,7 @@ cmake --build cmake_build -j4
 
 程序会先读取当前关节位置作为保持姿态，稳定后再对目标关节进行激励。使用 `--joint=<索引>` 可以仅测试单个关节；
 `--kp/--kd` 与 `--wheel-kp/--wheel-kd` 可调整腿部/轮毂的 PD 增益；通过 `--mode=torque` 联合 `--torque-amplitude`、`--torque-bias`
-可以切换为直接施加力矩。若希望回到预设站姿，可加上 `--pose=default` 参数。
+可以切换为直接施加力矩。若希望回到预设站姿，可加上 `--pose=default` 参数。扫描过程中会依次验证 12 个腿部关节与 4 个轮毂电机，确保两块电机控制板都能被主机正确驱动。
 
 **RL 控制入口**
 

--- a/rl_sar/README_CN.md
+++ b/rl_sar/README_CN.md
@@ -428,9 +428,15 @@ cmake --build cmake_build -j4
 ./cmake_build/bin/titati_motor_test --robot=titati     # 16 个电机依次扫描
 # 单机测试
 ./cmake_build/bin/titati_motor_test --robot=tita       # 8 个电机依次扫描
+# 使用当前姿态保持，仅激励 6 号关节，持续 5 秒，频率 1 Hz，幅度 0.15 rad
+./cmake_build/bin/titati_motor_test --robot=titati --joint=6 --frequency=1.0 --duration=5.0 --amplitude=0.15
+# 或者改用力矩正弦波（单位：牛·米）
+./cmake_build/bin/titati_motor_test --robot=titati --joint=6 --mode=torque --torque-amplitude=8.0
 ```
 
-程序会在 MIT 模式下逐一激励每个关节，便于确认 CAN 链路、方向与限位。
+程序会先读取当前关节位置作为保持姿态，稳定后再对目标关节进行激励。使用 `--joint=<索引>` 可以仅测试单个关节；
+`--kp/--kd` 与 `--wheel-kp/--wheel-kd` 可调整腿部/轮毂的 PD 增益；通过 `--mode=torque` 联合 `--torque-amplitude`、`--torque-bias`
+可以切换为直接施加力矩。若希望回到预设站姿，可加上 `--pose=default` 参数。
 
 **RL 控制入口**
 

--- a/rl_sar/README_CN.md
+++ b/rl_sar/README_CN.md
@@ -376,6 +376,55 @@ ros2 run rl_sar rl_real_lite3
 
 </details>
 
+<details>
+
+<summary>DDTRobot Tita / Titati（点击展开）</summary>
+
+新的 Tita/Titati 硬件接口已经完全集成在 **rl_sar** 中，并统一使用 **C++17** 标准编译。默认仅会生成 Titati
+相关的可执行文件，其它机器人的程序可以通过新增的 CMake 选项重新启用。
+
+**CAN 拓扑**
+
+1. 将两台 Jetson 的 `can0` 配置为 CAN-FD（标称 1 Mbps / 数据 8 Mbps）。
+2. 使用提供的“小盒子”把两台 `can0` 物理连接到同一条 CAN-FD 总线。
+3. 从机 Jetson 只运行 `titati_canfd_router_node`，待上电自检完成后调用 `set_forcedirect_mode(true)`，实现 CAN 报文透传。
+4. 主机 Jetson 在同一总线上通过新的 rl_sar 硬件接口直接下发 16 个电机指令。
+
+**编译选项**
+
+```bash
+cmake -S src/rl_sar -B cmake_build -DUSE_CMAKE=ON \
+      -DBUILD_TITATI=ON -DBUILD_UNITREE_A1=OFF -DBUILD_UNITREE_GO2=OFF \
+      -DBUILD_UNITREE_G1=OFF -DBUILD_L4W4=OFF -DBUILD_LITE3=OFF
+cmake --build cmake_build -j4
+```
+
+`BUILD_TITATI` 默认开启，其他机器人默认关闭，满足“只编译 Titati” 的需求。如需编译其它机器人，可将对应选项设置为 `ON`。
+
+**电机连通性测试**
+
+运行 RL 控制前，先使用专用测试程序确认电机和 CAN 通讯是否正常：
+
+```bash
+./cmake_build/bin/titati_motor_test --robot=titati     # 16 个电机依次扫描
+# 单机测试
+./cmake_build/bin/titati_motor_test --robot=tita       # 8 个电机依次扫描
+```
+
+程序会在 MIT 模式下逐一激励每个关节，便于确认 CAN 链路、方向与限位。
+
+**RL 控制入口**
+
+当从机已经启用透传后，在主机上启动实时控制程序：
+
+```bash
+./cmake_build/bin/rl_real_tita --robot=titati
+```
+
+若只控制单台 Tita，请使用 `--robot=tita`。该可执行文件复用了 `policy/titati` 下的策略配置，并提供与其它机器人一致的键盘/手柄接口。
+
+</details>
+
 ### 训练执行器网络
 
 下面拿A1举例

--- a/rl_sar/README_CN.md
+++ b/rl_sar/README_CN.md
@@ -385,10 +385,29 @@ ros2 run rl_sar rl_real_lite3
 
 **CAN 拓扑**
 
-1. 将两台 Jetson 的 `can0` 配置为 CAN-FD（标称 1 Mbps / 数据 8 Mbps）。
+1. 先把每台 Jetson 的 `can0` 配置为 CAN-FD（标称 1 Mbps / 数据 8 Mbps）：
+
+   ```bash
+   sudo ip link set can0 down
+   sudo ip link set can0 up type can bitrate 1000000 sample-point 0.80 dbitrate 8000000 \
+       dsample-point 0.80 fd on restart-ms 100
+   sudo ifconfig can0 txqueuelen 1000
+   ```
+
+   主机可以直接运行脚本 `bash src/rl_sar/scripts/titati_can_setup_master.sh` 完成上述配置（如需修改接口名，可作为第一个参数传入）。
+
 2. 使用提供的“小盒子”把两台 `can0` 物理连接到同一条 CAN-FD 总线。
-3. 从机 Jetson 只运行 `titati_canfd_router_node`，待上电自检完成后调用 `set_forcedirect_mode(true)`，实现 CAN 报文透传。
-4. 主机 Jetson 在同一总线上通过新的 rl_sar 硬件接口直接下发 16 个电机指令。
+3. 从机 Jetson 运行路由程序：
+
+   ```bash
+   bash src/rl_sar/scripts/titati_can_setup_slave.sh
+   # 或者在手动配置 CAN 后直接运行
+   ./cmake_build/bin/titati_canfd_router_node [--stay-alive]
+   ```
+
+   程序会等待上电自检完成（路由板心跳 mode=1/2），随后自动调用 `set_forcedirect_mode(true)` 把 CAN 报文透传到总线上。若需持续监控，可附加 `--stay-alive` 参数。
+
+4. 待终端提示“Router switched to forced-direct relay mode”后，主机 Jetson 再启动 rl_sar 控制程序，在同一 CAN-FD 总线上直接下发 16 个电机命令。
 
 **编译选项**
 

--- a/rl_sar/src/rl_sar/CMakeLists.txt
+++ b/rl_sar/src/rl_sar/CMakeLists.txt
@@ -155,6 +155,14 @@ target_include_directories(tita_sdk PUBLIC
 )
 target_link_libraries(tita_sdk PUBLIC Threads::Threads)
 
+add_library(tita_canfd_router
+    library/thirdparty/tita_sdk/src/canfd_router_can_receive_api.cpp
+)
+target_include_directories(tita_canfd_router PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/tita_sdk/include
+)
+target_link_libraries(tita_canfd_router PUBLIC Threads::Threads)
+
 # Retroid Gamepad
 set(GAMEPAD_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/gamepad/src/gamepad.cpp
@@ -377,6 +385,11 @@ if(BUILD_TITATI)
     target_link_libraries(titati_motor_test
         tita_sdk
         yaml-cpp
+    )
+
+    add_executable(titati_canfd_router_node src/titati_canfd_router_node.cpp)
+    target_link_libraries(titati_canfd_router_node
+        tita_canfd_router
     )
 endif()
 

--- a/rl_sar/src/rl_sar/CMakeLists.txt
+++ b/rl_sar/src/rl_sar/CMakeLists.txt
@@ -21,6 +21,9 @@ else()
 endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
@@ -29,6 +32,13 @@ string(TOUPPER "${CMAKE_BUILD_TYPE}" UPPER_BUILD_TYPE)
 if(UPPER_BUILD_TYPE STREQUAL "DEBUG")
     add_compile_options(-g)
 endif()
+
+option(BUILD_TITATI "Build Titati master/slave hardware executables" ON)
+option(BUILD_UNITREE_A1 "Build Unitree A1 real robot executable" OFF)
+option(BUILD_UNITREE_GO2 "Build Unitree Go2 real robot executable" OFF)
+option(BUILD_UNITREE_G1 "Build Unitree G1 real robot executable" OFF)
+option(BUILD_L4W4 "Build GoldenRetriever L4W4 real robot executable" OFF)
+option(BUILD_LITE3 "Build Deeprobotics Lite3 real robot executable" OFF)
 
 add_definitions(-DCMAKE_CURRENT_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 add_definitions(-DBOOST_BIND_GLOBAL_PLACEHOLDERS)
@@ -134,6 +144,17 @@ if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
     )
 endif()
 
+# TITA SDK
+add_library(tita_sdk
+    library/thirdparty/tita_sdk/src/can_receiver.cpp
+    library/thirdparty/tita_sdk/src/can_sender.cpp
+    library/thirdparty/tita_sdk/src/tita_robot.cpp
+)
+target_include_directories(tita_sdk PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/tita_sdk/include
+)
+target_link_libraries(tita_sdk PUBLIC Threads::Threads)
+
 # Retroid Gamepad
 set(GAMEPAD_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/gamepad/src/gamepad.cpp
@@ -154,12 +175,13 @@ include_directories(
     library/core/rl_sdk
     library/core/loop
     library/core/fsm
+    library/thirdparty/tita_sdk/include
     policy
 )
 
 add_library(rl_sdk library/core/rl_sdk/rl_sdk.cpp)
 set_target_properties(rl_sdk PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED ON
 )
 target_link_libraries(rl_sdk PUBLIC
@@ -183,7 +205,7 @@ endif()
 add_library(observation_buffer library/core/observation_buffer/observation_buffer.cpp)
 target_link_libraries(observation_buffer PUBLIC "${TORCH_LIBRARIES}")
 set_target_properties(observation_buffer PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED ON
 )
 if(NOT USE_CMAKE)
@@ -220,105 +242,142 @@ if(NOT USE_CMAKE)
     endif()
 endif()
 
-add_executable(rl_real_a1 src/rl_real_a1.cpp)
-target_link_libraries(rl_real_a1
-    ${UNITREE_A1_LIBS}
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
-if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_a1 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_a1
-            rclcpp
-            geometry_msgs
-        )
-        install(TARGETS rl_real_a1 DESTINATION lib/${PROJECT_NAME})
+if(BUILD_UNITREE_A1)
+    add_executable(rl_real_a1 src/rl_real_a1.cpp)
+    target_link_libraries(rl_real_a1
+        ${UNITREE_A1_LIBS}
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_a1 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_a1
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_a1 DESTINATION lib/${PROJECT_NAME})
+        endif()
     endif()
 endif()
 
-add_executable(rl_real_lite3
-    src/rl_real_lite3.cpp
-    ${GAMEPAD_SRC}
-)
-target_link_libraries(rl_real_lite3
-    ${LITE3_REAL_LIBS}
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
-target_include_directories(rl_real_lite3 PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/gamepad/include
-)
-if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_lite3 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_lite3
-            rclcpp
-            geometry_msgs
-        )
-        install(TARGETS rl_real_lite3 DESTINATION lib/${PROJECT_NAME})
+if(BUILD_LITE3)
+    add_executable(rl_real_lite3
+        src/rl_real_lite3.cpp
+        ${GAMEPAD_SRC}
+    )
+    target_link_libraries(rl_real_lite3
+        ${LITE3_REAL_LIBS}
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    target_include_directories(rl_real_lite3 PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/gamepad/include
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_lite3 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_lite3
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_lite3 DESTINATION lib/${PROJECT_NAME})
+        endif()
     endif()
 endif()
 
-add_executable(rl_real_go2 src/rl_real_go2.cpp)
-target_link_libraries(rl_real_go2
-    unitree_sdk2
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
-if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_go2 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_go2
-            rclcpp
-            geometry_msgs
-        )
-        install(TARGETS rl_real_go2 DESTINATION lib/${PROJECT_NAME})
+if(BUILD_UNITREE_GO2)
+    add_executable(rl_real_go2 src/rl_real_go2.cpp)
+    target_link_libraries(rl_real_go2
+        unitree_sdk2
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_go2 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_go2
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_go2 DESTINATION lib/${PROJECT_NAME})
+        endif()
     endif()
 endif()
 
-add_executable(rl_real_g1 src/rl_real_g1.cpp)
-target_link_libraries(rl_real_g1
-    unitree_sdk2
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
-if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_g1 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_g1
-            rclcpp
-            geometry_msgs
-        )
-        install(TARGETS rl_real_g1 DESTINATION lib/${PROJECT_NAME})
+if(BUILD_UNITREE_G1)
+    add_executable(rl_real_g1 src/rl_real_g1.cpp)
+    target_link_libraries(rl_real_g1
+        unitree_sdk2
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_g1 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_g1
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_g1 DESTINATION lib/${PROJECT_NAME})
+        endif()
     endif()
 endif()
 
-add_executable(rl_real_l4w4 src/rl_real_l4w4.cpp)
-target_link_libraries(rl_real_l4w4
-    l4w4_sdk
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
-if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_l4w4 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_l4w4
-            rclcpp
-            geometry_msgs
-        )
-        install(TARGETS rl_real_l4w4 DESTINATION lib/${PROJECT_NAME})
+if(BUILD_L4W4)
+    add_executable(rl_real_l4w4 src/rl_real_l4w4.cpp)
+    target_link_libraries(rl_real_l4w4
+        l4w4_sdk
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_l4w4 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_l4w4
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_l4w4 DESTINATION lib/${PROJECT_NAME})
+        endif()
     endif()
+endif()
+
+if(BUILD_TITATI)
+    add_executable(rl_real_tita src/rl_real_titati.cpp)
+    target_link_libraries(rl_real_tita
+        tita_sdk
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_tita ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_tita
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_tita DESTINATION lib/${PROJECT_NAME})
+        endif()
+    endif()
+
+    add_executable(titati_motor_test test/titati_motor_test.cpp)
+    target_link_libraries(titati_motor_test
+        tita_sdk
+        yaml-cpp
+    )
 endif()
 
 if(NOT USE_CMAKE)

--- a/rl_sar/src/rl_sar/include/rl_real_titati.hpp
+++ b/rl_sar/src/rl_sar/include/rl_real_titati.hpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2024-2025 Ziqi Fan
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef RL_REAL_TITATI_HPP
+#define RL_REAL_TITATI_HPP
+
+// #define PLOT
+// #define CSV_LOGGER
+// #define USE_ROS
+
+#include "rl_sdk.hpp"
+#include "observation_buffer.hpp"
+#include "loop.hpp"
+#include "fsm.hpp"
+
+#include "tita_robot/tita_robot.hpp"
+#include <csignal>
+#include <memory>
+#include <string>
+#include <vector>
+
+#if defined(USE_ROS1) && defined(USE_ROS)
+#include <ros/ros.h>
+#include <geometry_msgs/Twist.h>
+#elif defined(USE_ROS2) && defined(USE_ROS)
+#include <rclcpp/rclcpp.hpp>
+#include <geometry_msgs/msg/twist.hpp>
+#endif
+
+#include "matplotlibcpp.h"
+namespace plt = matplotlibcpp;
+
+class RL_Real : public RL
+#if defined(USE_ROS2) && defined(USE_ROS)
+    , public rclcpp::Node
+#endif
+{
+public:
+    explicit RL_Real(const std::string &robot_variant = "titati");
+    ~RL_Real();
+
+private:
+    // rl functions
+    torch::Tensor Forward() override;
+    void GetState(RobotState<double> *state) override;
+    void SetCommand(const RobotCommand<double> *command) override;
+    void RunModel();
+    void RobotControl();
+
+    // loop
+    std::shared_ptr<LoopFunc> loop_keyboard;
+    std::shared_ptr<LoopFunc> loop_control;
+    std::shared_ptr<LoopFunc> loop_rl;
+    std::shared_ptr<LoopFunc> loop_plot;
+
+    // plot
+    const int plot_size = 100;
+    std::vector<int> plot_t;
+    std::vector<std::vector<double>> plot_real_joint_pos, plot_target_joint_pos;
+    void Plot();
+
+    // hardware interface
+    std::unique_ptr<tita_robot> robot_;
+    std::string robot_variant_;
+
+    // others
+    int motiontime = 0;
+
+#if defined(USE_ROS1) && defined(USE_ROS)
+    geometry_msgs::Twist cmd_vel;
+    ros::Subscriber cmd_vel_subscriber;
+    void CmdvelCallback(const geometry_msgs::Twist::ConstPtr &msg);
+#elif defined(USE_ROS2) && defined(USE_ROS)
+    geometry_msgs::msg::Twist cmd_vel;
+    rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_subscriber;
+    void CmdvelCallback(const geometry_msgs::msg::Twist::SharedPtr msg);
+#endif
+};
+
+#endif // RL_REAL_TITATI_HPP

--- a/rl_sar/src/rl_sar/include/rl_real_titati.hpp
+++ b/rl_sar/src/rl_sar/include/rl_real_titati.hpp
@@ -64,6 +64,7 @@ private:
     // hardware interface
     std::unique_ptr<tita_robot> robot_;
     std::string robot_variant_;
+    std::vector<double> torque_limits_;
 
     // others
     int motiontime = 0;

--- a/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/include/protocol/can_utils.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/include/protocol/can_utils.hpp
@@ -1,0 +1,468 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__CAN_UTILS_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__CAN_UTILS_HPP_
+
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "linux/can.h"
+#include "linux/can/error.h"
+#include "linux/can/raw.h"
+#include "socket_can_receiver.hpp"
+#include "socket_can_sender.hpp"
+
+#define C_END "\033[m"
+// #define C_RED "\033[0;32;31m"
+#define C_RED "\033[0;31m"
+#define C_YELLOW "\033[1;33m"
+
+#ifdef GCC_OPTIMIZE_03
+#pragma GCC optimize("O3")
+#else
+#pragma GCC optimize("O0")
+#endif
+namespace can_device
+{
+namespace socket_can
+{
+using can_std_callback = std::function<void(std::shared_ptr<struct can_frame> recv_frame)>;
+using can_fd_callback = std::function<void(std::shared_ptr<struct canfd_frame> recv_frame)>;
+class CanRxDev
+{
+public:
+  explicit CanRxDev(
+    const std::string & interface, const std::string & name, can_std_callback recv_callback,
+    bool is_block, int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    init(interface, name, false, recv_callback, nullptr, is_block, nano_timeout);
+  }
+  explicit CanRxDev(
+    const std::string & interface, const std::string & name, can_fd_callback recv_callback,
+    bool is_block, int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    init(interface, name, true, nullptr, recv_callback, is_block, nano_timeout);
+  }
+
+  ~CanRxDev()
+  {
+    ready_ = false;
+    isthreadrunning_ = false;
+    if (main_T_ != nullptr) {
+      main_T_->join();
+    }
+    main_T_ = nullptr;
+    receiver_ = nullptr;
+  }
+
+  bool is_ready() { return ready_; }
+  bool is_timeout() { return is_timeout_; }
+  void set_filter(const struct can_filter filter[], size_t s)
+  {
+    if (receiver_ != nullptr) {
+      receiver_->set_filter(filter, s);
+    }
+  }
+
+  std::shared_ptr<canfd_frame> wait_for_can_data_block()
+  {
+    can_device::socket_can::CanId receive_id{};
+    std::string can_type;
+    if (canfd_) {
+      can_type = "FD";
+      rx_fd_frame_ = std::make_shared<struct canfd_frame>();
+    } else {
+      can_type = "STD";
+      rx_std_frame_ = std::make_shared<struct can_frame>();
+    }
+    if (receiver_ != nullptr) {
+      try {
+        bool result =
+          canfd_ ? receiver_->receive(rx_fd_frame_, std::chrono::nanoseconds(nano_timeout_))
+                 : receiver_->receive(rx_std_frame_, std::chrono::nanoseconds(nano_timeout_));
+        if (result) {
+          is_timeout_ = false;
+          return rx_fd_frame_;
+        } else {
+          return nullptr;
+        }
+      } catch (const std::exception & ex) {
+        if (ex.what()[0] == '$') {
+          is_timeout_ = true;
+          return nullptr;
+        }
+      }
+    } else {
+      isthreadrunning_ = false;
+      printf(
+        C_RED
+        "[CAN_RX %s][ERROR][%s] Error receiving CAN %s message: %s, "
+        "no receiver init\r\n" C_END,
+        can_type.c_str(), name_.c_str(), can_type.c_str(), interface_.c_str());
+    }
+    return nullptr;
+  }
+
+#ifdef COMMON_PROTOCOL_TEST
+  bool testing_setcandata(can_frame frame)
+  {
+    if (can_std_callback_ != nullptr) {
+      can_std_callback_(std::make_shared<struct can_frame>(frame));
+      return true;
+    }
+    return false;
+  }
+  bool testing_setcandata(canfd_frame frame)
+  {
+    if (can_fd_callback_ != nullptr) {
+      can_fd_callback_(std::make_shared<struct canfd_frame>(frame));
+      return true;
+    }
+    return false;
+  }
+#endif  // COMMON_PROTOCOL_TEST
+
+private:
+  bool ready_;
+  bool canfd_;
+  bool is_timeout_;
+  bool extended_frame_;
+  bool isthreadrunning_;
+  int64_t nano_timeout_;
+  std::string name_;
+  std::string interface_;
+  can_std_callback can_std_callback_;
+  can_fd_callback can_fd_callback_;
+  std::unique_ptr<std::thread> main_T_;
+  std::shared_ptr<struct can_frame> rx_std_frame_;
+  std::shared_ptr<struct canfd_frame> rx_fd_frame_;
+  std::unique_ptr<can_device::socket_can::SocketCanReceiver> receiver_;
+  uint8_t can_id_offset_ = 0;
+  void init(
+    const std::string & interface, const std::string & name, bool canfd_on,
+    can_std_callback std_callback, can_fd_callback fd_callback, bool is_block, int64_t nano_timeout)
+  {
+    name_ = name;
+    interface_ = interface;
+    canfd_ = canfd_on;
+    nano_timeout_ = nano_timeout;
+    is_timeout_ = false;
+    interface_ = interface;
+    can_std_callback_ = std_callback;
+    can_fd_callback_ = fd_callback;
+    try {
+      receiver_ = std::make_unique<can_device::socket_can::SocketCanReceiver>(interface_, canfd_);
+      if (!is_block) {
+        isthreadrunning_ = true;
+        ready_ = true;
+        main_T_ = std::make_unique<std::thread>(std::bind(&CanRxDev::main_recv_func, this));
+      }
+    } catch (const std::exception & ex) {
+      printf(
+        C_RED "[CAN_RX][ERROR][%s] %s receiver creat error! %s\r\n" C_END, name_.c_str(),
+        interface_.c_str(), ex.what());
+      return;
+    }
+  }
+
+  bool wait_for_can_data()
+  {
+    can_device::socket_can::CanId receive_id{};
+    std::string can_type;
+    if (canfd_) {
+      can_type = "FD";
+      rx_fd_frame_ = std::make_shared<struct canfd_frame>();
+    } else {
+      can_type = "STD";
+      rx_std_frame_ = std::make_shared<struct can_frame>();
+    }
+
+    if (receiver_ != nullptr) {
+      try {
+        bool result =
+          canfd_ ? receiver_->receive(rx_fd_frame_, std::chrono::nanoseconds(nano_timeout_))
+                 : receiver_->receive(rx_std_frame_, std::chrono::nanoseconds(nano_timeout_));
+        if (result) {
+          is_timeout_ = false;
+        }
+        return result;
+      } catch (const std::exception & ex) {
+        if (ex.what()[0] == '$') {
+          is_timeout_ = true;
+          return false;
+        }
+        printf(
+          C_RED "[CAN_RX %s][ERROR][%s] Error receiving CAN %s message: %s - %s\n" C_END,
+          can_type.c_str(), name_.c_str(), can_type.c_str(), interface_.c_str(), ex.what());
+      }
+    } else {
+      isthreadrunning_ = false;
+      printf(
+        C_RED
+        "[CAN_RX %s][ERROR][%s] Error receiving CAN %s message: %s, "
+        "no receiver init\r\n" C_END,
+        can_type.c_str(), name_.c_str(), can_type.c_str(), interface_.c_str());
+    }
+    return false;
+  }
+
+  void main_recv_func()
+  {
+#ifdef DEBUG_LOG
+    printf("[CAN_RX][INFO][%s] Start recv thread: %s\r\n", interface_.c_str(), name_.c_str());
+#endif  // DEBUG_LOG
+    while (isthreadrunning_ && ready_) {
+      if (wait_for_can_data()) {
+        if (!canfd_ && can_std_callback_ != nullptr) {
+          can_std_callback_(rx_std_frame_);
+        } else if (canfd_ && can_fd_callback_ != nullptr) {
+          can_fd_callback_(rx_fd_frame_);
+        }
+      }
+    }
+#ifdef DEBUG_LOG
+    printf("[CAN_RX][INFO][%s] Exit recv thread: %s\r\n", interface_.c_str(), name_.c_str());
+#endif  // DEBUG_LOG
+  }
+};
+
+class CanTxDev
+{
+public:
+  explicit CanTxDev(
+    const std::string & interface, const std::string & name, bool extended_frame, bool canfd_on,
+    int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    can_id_offset_ = can_id_offset;
+    ready_ = false;
+    name_ = name;
+    nano_timeout_ = nano_timeout;
+    is_timeout_ = false;
+    canfd_on_ = canfd_on;
+    interface_ = interface;
+    extended_frame_ = extended_frame;
+    try {
+      sender_ = std::make_unique<can_device::socket_can::SocketCanSender>(interface_, canfd_on_);
+    } catch (const std::exception & ex) {
+      printf(
+        C_RED "[CAN_TX][ERROR][%s] %s sender creat error! %s\r\n" C_END, name_.c_str(),
+        interface_.c_str(), ex.what());
+      return;
+    }
+    ready_ = true;
+  }
+
+  ~CanTxDev()
+  {
+    ready_ = false;
+    sender_ = nullptr;
+  }
+
+  bool send_can_message(struct can_frame & tx_frame)
+  {
+    return send_can_message(&tx_frame, nullptr);
+  }
+  bool send_can_message(struct canfd_frame & tx_frame)
+  {
+    return send_can_message(nullptr, &tx_frame);
+  }
+
+  bool is_ready() { return ready_; }
+  bool is_timeout() { return is_timeout_; }
+
+private:
+  bool ready_;
+  bool canfd_on_;
+  bool is_timeout_;
+  bool extended_frame_;
+  int64_t nano_timeout_;
+  std::string name_;
+  std::string interface_;
+  std::unique_ptr<can_device::socket_can::SocketCanSender> sender_;
+  uint8_t can_id_offset_;
+
+  bool send_can_message(struct can_frame * std_frame, struct canfd_frame * fd_frame)
+  {
+    bool self_fd = (fd_frame != nullptr);
+    std::string can_type = self_fd ? "FD" : "STD";
+    if (canfd_on_ != self_fd) {
+      printf(
+        C_RED
+        "[CAN_TX %s][ERROR][%s] Error sending CAN message: %s - "
+        "Not support can/canfd frame mixed\r\n" C_END,
+        can_type.c_str(), name_.c_str(), interface_.c_str());
+      return false;
+    }
+    canid_t * canid = self_fd ? &fd_frame->can_id : &std_frame->can_id;
+
+    bool result = true;
+    can_device::socket_can::CanId send_id =
+      extended_frame_
+        ? can_device::socket_can::CanId(
+            *canid, can_device::socket_can::FrameType::DATA, can_device::socket_can::ExtendedFrame)
+        : can_device::socket_can::CanId(
+            *canid, can_device::socket_can::FrameType::DATA, can_device::socket_can::StandardFrame);
+    if (sender_ != nullptr) {
+      try {
+        if (self_fd) {
+          sender_->send_fd(
+            fd_frame->data, (fd_frame->len == 0) ? 64 : fd_frame->len, send_id,
+            std::chrono::nanoseconds(nano_timeout_));
+          is_timeout_ = false;
+        } else {
+          sender_->send(
+            std_frame->data, (std_frame->can_dlc == 0) ? 8 : std_frame->can_dlc, send_id,
+            std::chrono::nanoseconds(nano_timeout_));
+          is_timeout_ = false;
+        }
+      } catch (const std::exception & ex) {
+        if (ex.what()[0] == '$') {
+          is_timeout_ = true;
+          return false;
+        }
+        result = false;
+        printf(
+          C_RED "[CAN_TX %s][ERROR][%s] Error sending CAN message: %s - %s\r\n" C_END,
+          can_type.c_str(), name_.c_str(), interface_.c_str(), ex.what());
+      }
+    } else {
+      result = false;
+      printf(
+        C_RED "[CAN_TX %s][ERROR][%s] Error sending CAN message: %s - No device\r\n" C_END,
+        can_type.c_str(), name_.c_str(), interface_.c_str());
+    }
+    return result;
+  }
+};
+
+class CanDev
+{
+public:
+  explicit CanDev(
+    const std::string & interface, const std::string & name, bool extended_frame,
+    can_std_callback recv_callback, bool is_block, int64_t nano_timeout = -1,
+    uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    name_ = name;
+    send_only_ = false;
+    tx_op_ = std::make_unique<CanTxDev>(
+      interface, name_, extended_frame, false, nano_timeout, can_id_offset_);
+    rx_op_ = std::make_unique<CanRxDev>(
+      interface, name_, recv_callback, is_block, nano_timeout, can_id_offset_);
+  }
+  explicit CanDev(
+    const std::string & interface, const std::string & name, bool extended_frame,
+    can_fd_callback recv_callback, bool is_block, int64_t nano_timeout = -1,
+    uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    name_ = name;
+    send_only_ = false;
+    tx_op_ = std::make_unique<CanTxDev>(
+      interface, name_, extended_frame, true, nano_timeout, can_id_offset_);
+    rx_op_ = std::make_unique<CanRxDev>(
+      interface, name_, recv_callback, is_block, nano_timeout, can_id_offset_);
+  }
+  explicit CanDev(
+    const std::string & interface, const std::string & name, bool extended_frame, bool canfd_on,
+    int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    name_ = name;
+    send_only_ = true;
+    tx_op_ = std::make_unique<CanTxDev>(
+      interface, name_, extended_frame, canfd_on, nano_timeout, can_id_offset_);
+  }
+
+  ~CanDev()
+  {
+    rx_op_ = nullptr;
+    tx_op_ = nullptr;
+  }
+
+  std::shared_ptr<canfd_frame> receive_can_message_block()
+  {
+    return rx_op_->wait_for_can_data_block();
+  }
+
+  bool send_can_message(struct can_frame & tx_frame)
+  {
+#ifdef COMMON_PROTOCOL_TEST
+    if (rx_op_ != nullptr) {
+      return rx_op_->testing_setcandata(tx_frame);
+    }
+    return false;
+#else
+    if (tx_op_ != nullptr) {
+      return tx_op_->send_can_message(tx_frame);
+    }
+    return false;
+#endif  // COMMON_PROTOCOL_TEST
+  }
+
+  bool send_can_message(struct canfd_frame & tx_frame)
+  {
+#ifdef COMMON_PROTOCOL_TEST
+    if (rx_op_ != nullptr) {
+      return rx_op_->testing_setcandata(tx_frame);
+    }
+    return false;
+#else
+    if (tx_op_ != nullptr) {
+      return tx_op_->send_can_message(tx_frame);
+    }
+    return false;
+#endif  // COMMON_PROTOCOL_TEST
+  }
+
+  void set_filter(const struct can_filter filter[], size_t s)
+  {
+    if (rx_op_ != nullptr) {
+      rx_op_->set_filter(filter, s);
+    }
+  }
+  bool is_send_only() { return send_only_; }
+  bool is_ready()
+  {
+    bool result = (tx_op_ == nullptr) ? false : tx_op_->is_ready();
+    if (send_only_) {
+      return result;
+    } else {
+      return result && ((rx_op_ == nullptr) ? false : rx_op_->is_ready());
+    }
+  }
+  bool is_rx_timeout() { return rx_op_->is_timeout(); }
+  bool is_tx_timeout() { return tx_op_->is_timeout(); }
+
+private:
+  bool send_only_;
+  std::string name_;
+  std::unique_ptr<CanRxDev> rx_op_;
+  std::unique_ptr<CanTxDev> tx_op_;
+  uint8_t can_id_offset_ = 0;
+};
+
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__CAN_UTILS_HPP_

--- a/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/include/protocol/socket_can_common.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/include/protocol/socket_can_common.hpp
@@ -1,0 +1,122 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_COMMON_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_COMMON_HPP_
+
+#include <linux/can.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <sys/time.h>
+
+#include <chrono>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+
+#define GCC_OPTIMIZE_03
+
+#ifdef GCC_OPTIMIZE_03
+#pragma GCC optimize("O3")
+#else
+#pragma GCC optimize("O0")
+#endif
+
+namespace can_device
+{
+namespace socket_can
+{
+inline bool bind_can_socket(int & fd, const std::string & interface, const bool canfd_on = false)
+{
+  if (interface.length() >= static_cast<std::string::size_type>(IFNAMSIZ)) {
+    throw std::domain_error{"CAN interface name too long"};
+    return false;
+  }
+
+  fd = socket(PF_CAN, static_cast<int32_t>(SOCK_RAW), CAN_RAW);
+  if (0 > fd) {
+    throw std::runtime_error{"Failed to open CAN socket"};
+    return false;
+  }
+
+  // Make it non-blocking so we can use timeouts
+
+  struct ifreq ifr;
+  (void)strncpy(&ifr.ifr_name[0U], interface.c_str(), IFNAMSIZ - 1);
+  ifr.ifr_name[IFNAMSIZ - 1] = '\0';
+  ifr.ifr_ifindex = if_nametoindex(ifr.ifr_name);
+  if (!ifr.ifr_ifindex) {
+    perror("if_nametoindex");
+    return false;
+  }
+
+  struct sockaddr_can addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.can_family = AF_CAN;
+  addr.can_ifindex = ifr.ifr_ifindex;
+
+  if (canfd_on) {
+    if (ioctl(fd, SIOCGIFMTU, &ifr) < 0) {
+      throw std::runtime_error{"Failed to set CAN FD socket name via ioctl()"};
+      return false;
+    }
+    if (ifr.ifr_mtu != CANFD_MTU) {
+      throw std::runtime_error{"Interface does not support CAN FD"};
+      return false;
+    }
+    int _canfd_on = canfd_on ? 1 : 0;
+    auto ret = setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FD_FRAMES, &_canfd_on, sizeof(_canfd_on));
+    if (ret) {
+      throw std::runtime_error{"error whem enable canfd"};
+      return false;
+    }
+  }
+
+  /* disable default receive filter on this RAW socket */
+  /* This is obsolete as we do not read from the socket at all, but for */
+  /* this reason we can remove the receive list in the Kernel to save a */
+  /* little (really a very little!) CPU usage.                          */
+  setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FILTER, NULL, 0);
+
+  if (0 > bind(fd, (struct sockaddr *)&addr, sizeof(addr))) {
+    throw std::runtime_error{"Failed to bind CAN socket"};
+    return false;
+  }
+
+  return true;
+}
+
+inline struct timeval to_timeval(const std::chrono::nanoseconds timeout) noexcept
+{
+  const auto count = timeout.count();
+  constexpr auto BILLION = 1'000'000'000LL;
+  struct timeval c_timeout;
+  c_timeout.tv_sec = static_cast<decltype(c_timeout.tv_sec)>(count / BILLION);
+  c_timeout.tv_usec = static_cast<decltype(c_timeout.tv_usec)>((count % BILLION) * (0.001));
+
+  return c_timeout;
+}
+
+inline fd_set single_set(int32_t file_descriptor) noexcept
+{
+  fd_set descriptor_set;
+  FD_ZERO(&descriptor_set);
+  FD_SET(file_descriptor, &descriptor_set);
+
+  return descriptor_set;
+}
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_COMMON_HPP_

--- a/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/include/protocol/socket_can_id.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/include/protocol/socket_can_id.hpp
@@ -1,0 +1,188 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_ID_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_ID_HPP_
+
+#include <linux/can.h>
+
+#include <stdexcept>
+#include <utility>
+
+#include "visibility_control.hpp"
+
+namespace can_device
+{
+namespace socket_can
+{
+using IdT = uint32_t;
+using LengthT = uint32_t;
+
+constexpr std::size_t MAX_DATA_LENGTH = 64U;
+
+static_assert(
+  MAX_DATA_LENGTH == sizeof(std::declval<struct canfd_frame>().data),
+  "Unexpected CAN frame data size");
+static_assert(std::is_same<IdT, canid_t>::value, "Underlying type of CanId is incorrect");
+constexpr IdT EXTENDED_MASK = CAN_EFF_FLAG;
+constexpr IdT REMOTE_MASK = CAN_RTR_FLAG;
+constexpr IdT ERROR_MASK = CAN_ERR_FLAG;
+constexpr IdT EXTENDED_ID_MASK = CAN_EFF_MASK;
+constexpr IdT STANDARD_ID_MASK = CAN_SFF_MASK;
+
+class SOCKETCAN_PUBLIC SocketCanTimeout : public std::runtime_error
+{
+public:
+  explicit SocketCanTimeout(const char * const what) : runtime_error{what} {};
+};  // class SocketCanTimeout
+
+enum class FrameType : uint32_t { DATA, ERROR, REMOTE };
+
+struct StandardFrame_
+{
+};
+
+constexpr StandardFrame_ StandardFrame;
+
+struct ExtendedFrame_
+{
+};
+
+constexpr ExtendedFrame_ ExtendedFrame;
+
+class SOCKETCAN_PUBLIC CanId
+{
+public:
+  CanId() = default;
+  explicit CanId(const IdT raw_id, const LengthT data_length = 0U)
+  : m_id{raw_id}, m_data_length{data_length}
+  {
+    (void)frame_type();
+  }
+
+  CanId(const IdT id, FrameType type, StandardFrame_) : CanId{id, type, false} {}
+  CanId(const IdT id, FrameType type, ExtendedFrame_) : CanId{id, type, true} {}
+
+  CanId & standard() noexcept
+  {
+    m_id = m_id & (~EXTENDED_MASK);
+    return *this;
+  }
+
+  CanId & extended() noexcept
+  {
+    m_id = m_id | EXTENDED_MASK;
+    return *this;
+  }
+
+  CanId & error_frame() noexcept
+  {
+    m_id = m_id & (~REMOTE_MASK);
+    m_id = m_id | ERROR_MASK;
+    return *this;
+  }
+
+  CanId & remote_frame() noexcept
+  {
+    m_id = m_id & (~ERROR_MASK);
+    m_id = m_id | REMOTE_MASK;
+    return *this;
+  }
+
+  CanId & data_frame() noexcept
+  {
+    m_id = m_id & (~ERROR_MASK);
+    m_id = m_id & (~REMOTE_MASK);
+    return *this;
+  }
+
+  CanId & frame_type(const FrameType type)
+  {
+    switch (type) {
+      case FrameType::DATA:
+        (void)data_frame();
+        break;
+      case FrameType::ERROR:
+        (void)error_frame();
+        break;
+      case FrameType::REMOTE:
+        (void)remote_frame();
+        break;
+      default:
+        throw std::logic_error{"CanId: No such type"};
+    }
+    return *this;
+  }
+
+  CanId & identifier(const IdT id)
+  {
+    constexpr auto MAX_EXTENDED = 0x1FBF'FFFFU;
+    constexpr auto MAX_STANDARD = 0x7FFU;
+
+    static_assert(MAX_EXTENDED <= EXTENDED_ID_MASK, "Max extended id value is wrong");
+    static_assert(MAX_STANDARD <= STANDARD_ID_MASK, "Max standed id value is wrong");
+    const auto max_id = is_extended() ? MAX_EXTENDED : MAX_STANDARD;
+    if (max_id < id) {
+      throw std::domain_error{"CanId would be truncated!"};
+    }
+    m_id = m_id & (~EXTENDED_ID_MASK);
+    m_id = m_id | id;
+    return *this;
+  }
+
+  IdT identifier() const noexcept
+  {
+    const auto mask = is_extended() ? EXTENDED_ID_MASK : STANDARD_ID_MASK;
+    return m_id & mask;
+  }
+
+  IdT get() const noexcept { return m_id; }
+
+  bool is_extended() const noexcept { return (m_id & EXTENDED_MASK) == EXTENDED_MASK; }
+
+  FrameType frame_type() const
+  {
+    const auto is_error = (m_id & ERROR_MASK) == ERROR_MASK;
+    const auto is_remote = (m_id & REMOTE_MASK) == REMOTE_MASK;
+    if (is_error && is_remote) {
+      throw std::domain_error{"CanId has both bit 29 and 30 set! Inconsistent"};
+    }
+    if (is_error) {
+      return FrameType::ERROR;
+    }
+    if (is_remote) {
+      return FrameType::REMOTE;
+    }
+    return FrameType::DATA;
+  }
+
+  LengthT length() const noexcept { return m_data_length; }
+  IdT m_id{};
+
+private:
+  SOCKETCAN_LOCAL CanId(const IdT id, FrameType type, bool is_extended)
+  {
+    if (is_extended) {
+      (void)extended();
+    }
+    (void)frame_type(type);
+    (void)identifier(id);
+  }
+
+  LengthT m_data_length{};
+};  // class CanId
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_ID_HPP_

--- a/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/include/protocol/socket_can_receiver.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/include/protocol/socket_can_receiver.hpp
@@ -1,0 +1,145 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_RECEIVER_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_RECEIVER_HPP_
+#include <linux/can.h>
+#include <linux/can/raw.h>
+#include <sys/socket.h>
+#include <unistd.h>  // for close()
+
+#include <chrono>
+#include <cstring>
+#include <memory>
+#include <string>
+
+#include "socket_can_common.hpp"
+#include "socket_can_id.hpp"
+#include "visibility_control.hpp"
+
+namespace can_device
+{
+namespace socket_can
+{
+// using target_can_device = static_cast<std::string>(TARGET_CAN_DEVICE);
+
+class SOCKETCAN_PUBLIC SocketCanReceiver
+{
+public:
+  explicit SocketCanReceiver(
+    const std::string & interface = "can0", bool canfd_on = false)
+  {
+    if (!bind_can_socket(fd_, interface, canfd_on)) {
+      printf("bind_can_socket failed!\r\n");
+      return;
+    }
+  }
+
+  ~SocketCanReceiver() noexcept { (void)close(fd_); }
+
+  bool receive(
+    std::shared_ptr<struct can_frame> rx_frame,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero())
+  {
+    wait(timeout);
+
+    struct canfd_frame frame;
+    memset(&frame, 0, sizeof(frame));
+    const auto nbytes = read(fd_, &frame, sizeof(frame));
+
+    if (nbytes < 0) {
+      throw std::runtime_error{strerror(errno)};
+    }
+    if (static_cast<std::size_t>(nbytes) < CAN_MTU) {
+      throw std::logic_error{"read: incomplete CAN frame"};
+    }
+    if (static_cast<std::size_t>(nbytes) != CAN_MTU) {
+      throw std::logic_error{"Message was wrong size"};
+    }
+
+    auto receive_id = CanId{frame.can_id, frame.len};
+    if (receive_id.frame_type() == can_device::socket_can::FrameType::DATA) {
+      rx_frame->can_id = receive_id.standard().get();
+      rx_frame->can_id = receive_id.length();
+      std::memcpy(rx_frame->data, frame.data, sizeof(rx_frame->data));
+      return true;
+    }
+    return false;
+  }
+
+  bool receive(
+    std::shared_ptr<struct canfd_frame> rx_frame,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero())
+  {
+    wait(timeout);
+
+    struct canfd_frame frame;
+    const auto nbytes = read(fd_, &frame, sizeof(frame));
+
+    uint8_t except_len = CAN_MTU - 8 + frame.len;
+    if (nbytes < 0) {
+      throw std::runtime_error{strerror(errno)};
+    }
+    if (static_cast<std::size_t>(nbytes) < except_len) {
+      throw std::runtime_error{"read: incomplete CAN frame"};
+    }
+
+    auto receive_id = CanId{frame.can_id, frame.len};
+    if (receive_id.frame_type() == can_device::socket_can::FrameType::DATA) {
+      rx_frame->can_id = receive_id.standard().get();
+      rx_frame->len = receive_id.length();
+      std::memcpy(rx_frame->data, frame.data, sizeof(rx_frame->data));
+      return true;
+    }
+    return false;
+  }
+
+  void set_filter(const struct can_filter filter[], size_t s)
+  {
+    setsockopt(fd_, SOL_CAN_RAW, CAN_RAW_FILTER, filter, s);
+  }
+
+private:
+  SOCKETCAN_LOCAL void wait(const std::chrono::nanoseconds timeout) const
+  {
+    if (decltype(timeout)::zero() < timeout) {
+      auto c_timeout = to_timeval(timeout);
+      auto read_set = single_set(fd_);
+
+      if (0 == select(fd_ + 1, &read_set, NULL, NULL, &c_timeout)) {
+        throw SocketCanTimeout{"$CAN Receive Timeout 1"};
+      }
+
+      if (!FD_ISSET(fd_, &read_set)) {
+        throw SocketCanTimeout{"$CAN Receive Timeout 2"};
+      }
+    } else {
+      auto read_set = single_set(fd_);
+
+      if (0 == select(fd_ + 1, &read_set, NULL, NULL, NULL)) {
+        throw SocketCanTimeout{"$CAN Receive Timeout 1"};
+      }
+
+      if (!FD_ISSET(fd_, &read_set)) {
+        throw SocketCanTimeout{"CAN Receive Timeout 2"};
+      }
+    }
+  }
+
+  int32_t fd_;
+};  // class SocketCanReceiver
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_RECEIVER_HPP_

--- a/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/include/protocol/socket_can_sender.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/include/protocol/socket_can_sender.hpp
@@ -1,0 +1,168 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_SENDER_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_SENDER_HPP_
+
+#include <linux/can.h>
+#include <linux/can/raw.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <stdexcept>
+#include <string>
+
+#include "socket_can_common.hpp"
+#include "socket_can_id.hpp"
+#include "visibility_control.hpp"
+
+namespace can_device
+{
+namespace socket_can
+{
+class SOCKETCAN_PUBLIC SocketCanSender
+{
+public:
+  explicit SocketCanSender(
+    const std::string & interface = "can0", bool canfd_on = false,
+    const CanId & default_id = CanId{})
+  : m_default_id{default_id}
+  {
+    if (!bind_can_socket(fd_, interface, canfd_on)) {
+      printf("bind_can_socket failed\r\n");
+      return;
+    }
+  }
+  ~SocketCanSender() noexcept
+  {
+    (void)close(fd_);
+    // I'm destructing--there's not much else I can do on an error
+    // seem not good
+  }
+
+  void send(
+    const void * const data, const std::size_t Length,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    send(data, Length, m_default_id, timeout);
+  }
+
+  void send(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    if (length > MAX_DATA_LENGTH) {
+      throw std::domain_error{"Size is too large to send via CAN"};
+    }
+    send_impl(data, length, id, timeout);
+  }
+
+  template <typename T, typename = std::enable_if_t<!std::is_pointer<T>::value>>
+  void send(
+    const T & data, const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    send(data, m_default_id, timeout);
+  }
+
+  template <typename T, typename = std::enable_if<!std::is_pointer<T>::value>>
+  void send(
+    const T & data, const CanId id,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    static_assert(sizeof(data) <= MAX_DATA_LENGTH, "Data type too large for CAN");
+    send_impl(reinterpret_cast<const char *>(&data), sizeof(data), id, timeout);
+  }
+
+  void send_fd(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    if (length > MAX_DATA_LENGTH) {
+      throw std::domain_error{"Size is too large to send via CAN"};
+    }
+    send_fd_impl(data, length, id, timeout);
+  }
+
+  CanId default_id() const noexcept { return m_default_id; }
+
+private:
+  void send_impl(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout) const
+  {
+    // (void)data;
+    // (void)length;
+    // (void)id;
+    (void)timeout;
+
+    struct can_frame data_frame;
+    data_frame.can_id = id.get();
+
+    data_frame.can_dlc = static_cast<decltype(data_frame.can_dlc)>(length);
+
+    (void)std::memcpy(static_cast<void *>(&data_frame.data[0U]), data, length);
+
+    if (write(fd_, &data_frame, static_cast<int>(CAN_MTU)) != static_cast<int>(CAN_MTU)) {
+      throw std::runtime_error{strerror(errno)};
+    }
+  }
+
+  void send_fd_impl(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout) const
+  {
+    // (void)data;
+    // (void)length;
+    // (void)id;
+    (void)timeout;
+
+    struct canfd_frame data_frame;
+    memset(&data_frame, 0, sizeof(data_frame));
+    data_frame.can_id = id.get();
+    data_frame.flags = CANFD_FDF | CANFD_BRS;
+    data_frame.len = static_cast<decltype(data_frame.len)>(length);
+    std::memcpy(static_cast<void *>(&data_frame.data[0U]), data, length);
+    if (write(fd_, &data_frame, CANFD_MTU) != CANFD_MTU) {
+      throw std::runtime_error{strerror(errno)};
+    }
+  }
+
+  SOCKETCAN_LOCAL void wait(const std::chrono::nanoseconds timeout) const
+  {
+    if (decltype(timeout)::zero() < timeout) {
+      auto c_timeout = to_timeval(timeout);
+      auto write_set = single_set(fd_);
+
+      // wait
+      if (0 == select(fd_ + 1, NULL, &write_set, NULL, &c_timeout)) {
+        throw SocketCanTimeout{"$CAN Send Timeout [1]"};
+      }
+
+      if (!FD_ISSET(fd_, &write_set)) {
+        throw SocketCanTimeout{"$CAN Send Timeout [2]"};
+      }
+    } else {
+      // do nothing
+      // auto write_set = single_set(fd_);
+    }
+  }
+
+  int32_t fd_;
+  CanId m_default_id;
+};
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_SENDER_HPP_

--- a/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/include/protocol/visibility_control.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/include/protocol/visibility_control.hpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__VISIBILITY_CONTROL_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__VISIBILITY_CONTROL_HPP_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+#ifdef __GNUC__
+#define SOCKETCAN_EXPORT __attribute__((dllexport))
+#define SOCKETCAN_IMPORT __attribute__((dllimport))
+#else
+#define SOCKETCAN_EXPORT __declspec(dllexport)
+#define SOCKETCAN_IMPORT __declspec(dllimport)
+#endif
+#ifdef SOCKETCAN_BUILDING_LIBRARY
+#define SOCKETCAN_PUBLIC SOCKETCAN_EXPORT
+#else
+#define SOCKETCAN_PUBLIC SOCKETCAN_IMPORT
+#endif
+#define SOCKETCAN_PUBLIC_TYPE SOCKETCAN_PUBLIC
+#define SOCKETCAN_LOCAL
+#else
+#define SOCKETCAN_EXPORT __attribute__((visibility("default")))
+#define SOCKETCAN_IMPORT
+#if __GNUC__ >= 4
+#define SOCKETCAN_PUBLIC __attribute__((visibility("default")))
+#define SOCKETCAN_LOCAL __attribute__((visibility("hidden")))
+#else
+#define SOCKETCAN_PUBLIC
+#define SOCKETCAN_LOCAL
+#endif
+#define SOCKETCAN_PUBLIC_TYPE
+#endif
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__VISIBILITY_CONTROL_HPP_

--- a/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/include/tita_robot/can_receiver.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/include/tita_robot/can_receiver.hpp
@@ -68,6 +68,8 @@ namespace can_device
       if(size % 8 == 0) leg_dof_ = 4;
       else if(size % 6 == 0) leg_dof_ = 3;
       leg_num_ = size / leg_dof_;
+      board_count_ = std::max<size_t>(1, size / motors_per_board_nominal_);
+      leg_num_per_board_ = leg_num_ / board_count_;
       register_motors_device_can_filter();
       api_motor_in_t default_motor_in;
       std::memset(&default_motor_in, 0x00U, sizeof(api_motor_in_t));
@@ -100,7 +102,7 @@ namespace can_device
             motors_can_rx_is_block, motors_timeout_us, motors_can_id_offset);
 
     void board_can_data_callback(std::shared_ptr<struct canfd_frame> recv_frame);
-    void motors_data_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+    void motors_data_callback(std::shared_ptr<struct canfd_frame> recv_frame, size_t frame_index);
     void imu_data_callback(std::shared_ptr<struct canfd_frame> recv_frame);
     void motors_status_callback(std::shared_ptr<struct canfd_frame> recv_frame);
 
@@ -110,6 +112,10 @@ namespace can_device
 
     mutable std::shared_mutex motors_in_mutex_, imu_mutex_;
     size_t leg_dof_{4}, leg_num_{2};
+    size_t board_count_{1};
+    size_t leg_num_per_board_{2};
+    static constexpr size_t motors_per_board_nominal_{8};
+    static constexpr uint32_t can_board_stride_{0x10U};
   };
 } // namespace can_device
 

--- a/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/include/tita_robot/can_receiver.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/include/tita_robot/can_receiver.hpp
@@ -1,0 +1,116 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MOTORS_CAN__MOTORS_CAN_API_HPP_
+#define MOTORS_CAN__MOTORS_CAN_API_HPP_
+
+#include <algorithm>
+#include <atomic>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "protocol/can_utils.hpp"
+namespace can_device
+{
+#define PACKED __attribute__((__packed__))
+#define GRAVITY 9.81f
+#define CAN_ID_MOTOR_IN 0x108
+#define CAN_ID_IMU1 0x118
+#define CAN_ID_STATE 0x102
+
+  struct api_motor_in_t
+  {
+    uint32_t timestamp;
+    float position;
+    float velocity;
+    float torque;
+  } PACKED;
+  /* 44 bytes */
+  struct api_imu_data_t
+  {
+    uint32_t timestamp;
+    float accl[3];
+    float gyro[3];
+    float quaternion[4]; // x y z w
+    float temperature;
+  } PACKED;
+  
+  struct api_motor_status_t
+  {
+    uint32_t timestamp;
+    uint16_t key;
+    uint8_t value[8];
+  } PACKED;
+
+  class MotorsImuCanReceiveApi
+  {
+  public:
+    MotorsImuCanReceiveApi(size_t size)
+    {
+      if(size % 8 == 0) leg_dof_ = 4;
+      else if(size % 6 == 0) leg_dof_ = 3;
+      leg_num_ = size / leg_dof_;
+      register_motors_device_can_filter();
+      api_motor_in_t default_motor_in;
+      std::memset(&default_motor_in, 0x00U, sizeof(api_motor_in_t));
+      motors_in_.resize(size, default_motor_in);
+      std::memset(&imu_data_, 0x00U, sizeof(api_imu_data_t));
+    }
+    ~MotorsImuCanReceiveApi() {}
+    const std::vector<api_motor_in_t> *get_motors_in() const { return &motors_in_; }
+    const api_imu_data_t *get_imu_data() const { return &imu_data_; }
+    const api_motor_status_t *get_motors_status() const { return &motors_status_; }
+
+  private:
+#define MIN_TIME_OUT_US 1'000L     // 1ms
+#define MAX_TIME_OUT_US 3'000'000L // 3s
+#define CAN_MASK_AS_MOTORS_INFO (0x7E0U)
+    std::string motors_can_interface = "can0";
+    std::string motors_can_name = "motors_can";
+    bool motors_can_extended_frame = false;
+    bool motors_can_rx_is_block = false;
+    int64_t motors_timeout_us = MAX_TIME_OUT_US;
+    uint8_t motors_can_id_offset = 0x00U;
+
+    void register_motors_device_can_filter();
+    can_device::socket_can::can_fd_callback motors_can_receive_callback =
+        std::bind(&MotorsImuCanReceiveApi::board_can_data_callback, this, std::placeholders::_1);
+
+    std::shared_ptr<can_device::socket_can::CanDev> motors_can_receive_api =
+        std::make_shared<can_device::socket_can::CanDev>(
+            motors_can_interface, motors_can_name, motors_can_extended_frame, motors_can_receive_callback,
+            motors_can_rx_is_block, motors_timeout_us, motors_can_id_offset);
+
+    void board_can_data_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+    void motors_data_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+    void imu_data_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+    void motors_status_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+
+    std::vector<api_motor_in_t> motors_in_;
+    api_imu_data_t imu_data_;
+    api_motor_status_t motors_status_;
+
+    mutable std::shared_mutex motors_in_mutex_, imu_mutex_;
+    size_t leg_dof_{4}, leg_num_{2};
+  };
+} // namespace can_device
+
+#endif // MOTORS_CAN__MOTORS_CAN_API_HPP_

--- a/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/include/tita_robot/can_sender.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/include/tita_robot/can_sender.hpp
@@ -82,11 +82,15 @@ namespace can_device
   public:
     MotorsCanSendApi(size_t size)
     {
-      if (size % 8 == 0)
+      if (size % 8 == 0) {
         leg_dof_ = 4;
-      else if (size % 6 == 0)
+      } else if (size % 6 == 0) {
         leg_dof_ = 3;
+      }
       leg_num_ = size / leg_dof_;
+      board_count_ = std::max<size_t>(1, size / motors_per_board_nominal_);
+      motors_per_board_ = size / board_count_;
+      frames_per_board_ = motors_per_board_ / 2;
     }
     ~MotorsCanSendApi() = default;
     bool send_motors_can(std::vector<motor_out> motors);
@@ -114,6 +118,11 @@ namespace can_device
       return std::move(tv.tv_sec * 1000000 + tv.tv_usec);
     }
     size_t leg_dof_{4}, leg_num_{2};
+    size_t board_count_{1};
+    size_t motors_per_board_{motors_per_board_nominal_};
+    size_t frames_per_board_{motors_per_board_nominal_ / 2};
+    static constexpr size_t motors_per_board_nominal_{8};
+    static constexpr uint32_t can_board_stride_{0x10U};
   };
 } // namespace can_device
 

--- a/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/include/tita_robot/can_sender.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/include/tita_robot/can_sender.hpp
@@ -1,0 +1,120 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MOTORS_CAN__MOTORS_CAN_SEND_API_HPP_
+#define MOTORS_CAN__MOTORS_CAN_SEND_API_HPP_
+
+#include <algorithm>
+#include <atomic>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "protocol/can_utils.hpp"
+
+namespace can_device
+{
+
+#define CAN_ID_SEND_MOTORS (0x120U)
+#define CAN_ID_CHANNEL_INPUT (0x12DU)
+#define CAN_ID_RPC_REQUEST (0x170U)
+
+  enum ApiRpcKey
+  {
+    RPC_UNDEFINED = 0x000,
+    GET_MODEL_INFO = 0x100,
+    GET_SERIAL_NUMBER = 0x101,
+    SET_READY_NEXT = 0x200,
+    SET_BOARDCAST = 0x201,
+    SET_INPUT_MODE = 0x221,
+    SET_STAND_MODE = 0x222,
+    SET_HEAD_MODE = 0x223,
+    SET_JUMP = 0x231,
+    SET_MOTOR_ZERO = 0x280,
+  };
+  struct ChannelInput
+  {
+    uint32_t timestamp;
+    float forward;
+    float yaw;
+    float pitch;
+    float roll;
+    float height;
+    float split;
+    float tilt;
+    float forward_accel;
+    float yaw_accel;
+  };
+  struct RpcRequest
+  {
+    uint32_t timestamp;
+    uint16_t key;
+    uint32_t value;
+  };
+  struct motor_out
+  {
+    uint32_t timestamp;
+    float position;
+    float kp;
+    float velocity;
+    float kd;
+    float torque;
+  };
+
+  class MotorsCanSendApi
+  {
+  public:
+    MotorsCanSendApi(size_t size)
+    {
+      if (size % 8 == 0)
+        leg_dof_ = 4;
+      else if (size % 6 == 0)
+        leg_dof_ = 3;
+      leg_num_ = size / leg_dof_;
+    }
+    ~MotorsCanSendApi() = default;
+    bool send_motors_can(std::vector<motor_out> motors);
+    bool send_command_can_channel_input(ChannelInput data);
+    bool send_command_can_rpc_request(RpcRequest data);
+
+  private:
+#define MIN_TIME_OUT_US 1'000L     // 1ms
+#define MAX_TIME_OUT_US 3'000'000L // 3s
+    std::string can_interface = "can0";
+    std::string can_name = "motors_can_send";
+    int64_t timeout_us = MAX_TIME_OUT_US;
+    uint8_t can_id_offset = 0x00U;
+    bool can_extended_frame = false;
+    bool can_fd_mode = true;
+
+    std::shared_ptr<can_device::socket_can::CanDev> can_send_api_ =
+        std::make_shared<can_device::socket_can::CanDev>(
+            can_interface, can_name, can_extended_frame, can_fd_mode, timeout_us, can_id_offset);
+
+    inline uint32_t get_current_time()
+    {
+      struct timeval tv;
+      gettimeofday(&tv, NULL);
+      return std::move(tv.tv_sec * 1000000 + tv.tv_usec);
+    }
+    size_t leg_dof_{4}, leg_num_{2};
+  };
+} // namespace can_device
+
+#endif // MOTORS_CAN__MOTORS_CAN_SEND_API_HPP_

--- a/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/include/tita_robot/tita_robot.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/include/tita_robot/tita_robot.hpp
@@ -1,0 +1,154 @@
+#include "can_receiver.hpp"
+#include "can_sender.hpp"
+
+class tita_robot
+{
+public:
+    enum ReadyNext
+    {
+        READY_WAITING = 0x00U,
+        AUTO_LOCOMOTION = 0x01U,
+        FORCE_LOCOMOTION = 0x02U,
+        FORCE_DIRECT = 0x03U,
+        MOTOR_ZERO_CAL = 0x04U,
+        BOOT_RECOVERY_MODE = 0x05U,
+        ESTOP_MODE = 0x06U,
+    };
+    struct ChannelInput
+    {
+        uint32_t timestamp;
+        float forward;
+        float yaw;
+        float pitch;
+        float roll;
+        float height;
+        float split;
+        float tilt;
+        float forward_accel;
+        float yaw_accel;
+    };
+    tita_robot(size_t num_motors)
+    {
+        // Initialize the CAN receiver
+        can_receiver_ = std::make_unique<can_device::MotorsImuCanReceiveApi>(num_motors);
+        can_sender_ = std::make_unique<can_device::MotorsCanSendApi>(num_motors);
+        motor_num_ = num_motors;
+    }
+
+    /**
+     * @brief Get the current joint positions in joint space.
+     * @return std::vector<double>: current joint positions in radians.
+     */
+    std::vector<double> get_joint_q() const;
+
+    /**
+     * @brief Get the current joint velocities in joint space.
+     * @return std::vector<double>: current joint velocities in radians per second.
+     */
+    std::vector<double> get_joint_v() const;
+
+    /**
+     * @brief Get the current joint torques in joint space.
+     * @return std::vector<double>: current joint torques in Newton meters.
+     */
+    std::vector<double> get_joint_t() const;
+
+    /**
+     * @brief Get the current joint status.
+     * @note Joints status now is in bool value, true means the joint is online(TODO).
+     * @return std::vector<uint8_t>: current joint status.
+     */
+    std::vector<uint8_t> get_joint_status() const;
+
+    /**
+     * @brief Get the current imu quaternion of mcu.
+     * @note Quaternion sequence is x y z w.
+     * @return std::array<double, 4>: current quaternion.
+     */
+    std::array<double, 4> get_imu_quaternion() const; // x y z w
+
+    /**
+     * @brief Get the current imu acceleration of mcu.
+     * @return std::array<double, 3>: current acceleration.
+     */
+    std::array<double, 3> get_imu_acceleration() const;
+
+    /**
+     * @brief Get the current imu angular velocity of mcu.
+     * @return std::array<double, 3>: current angular velocity.
+     */
+    std::array<double, 3> get_imu_angular_velocity() const;
+
+    /**
+     * @brief Set the target joint feed-forward torques.
+     * @param t the target joint feed-forward torques.
+     * @return return true if the target is set successfully.
+     */
+    bool set_target_joint_t(const std::vector<double> &t);
+
+    /**
+     * @brief MIT control method. Set the target joint positions, velocities, kp, kd and feed-forward torques of the
+     motors.
+     * @param q the target joint positions in radians.
+     * @param v the target joint velocities in radians per second.
+     * @param kp the target joint proportional gains.
+     * @param kd the target joint derivative gains.
+     * @param t the target joint feed-forward torques.
+     *
+     * @return return true if the target is set successfully
+     */
+    bool set_target_joint_mit(const std::vector<double> &q, const std::vector<double> &v, const std::vector<double> &kp, const std::vector<double> &kd, const std::vector<double> &t);
+
+    // /**
+    //  * @brief Set mcu board control mode, maybe remove in the future.
+    //  * @param mode the target mcu mode, option: READY_WAITING AUTO_LOCOMOTION FORCE_DIRECT.
+    //  *
+    //  * @return return true if the target is set successfully
+    //  */
+    // bool set_board_mode(ReadyNext mode);
+    /**
+     * @brief Set mcu board can direct drive motors, default is auto_locomotion(use mcu control).
+     * @param if_sdk true means use control motors sdk, false means use mcu control.
+     *
+     * @return return true if the target is set successfully
+     */
+    bool set_motors_sdk(bool if_sdk);
+    /**
+     * @brief Set rc input to mcu. Only used in board mode is AUTO_LOCOMOTION.
+     * @param forward the target forward.
+     * @param yaw the target yaw.
+     * @param pitch the target pitch.
+     * @param roll the target roll.
+     * @param height the target height.
+     * @param split the target split.
+     * @param tilt the target tilt.
+     * @param forward_accel the target forward acceleration.
+     * @param yaw_accel the target yaw acceleration.
+     * @return return true if the target is set successfully
+     */
+    bool set_rc_input(ChannelInput input);    
+    /**
+     * @brief Set rc input to mcu. Only used in board mode is AUTO_LOCOMOTION.
+     * @param stand true if stand.
+     * @return return true if the target is set successfully
+     */
+    bool set_robot_stand(bool stand);
+
+    /**
+     * @brief Set rc input to mcu. Only used in board mode is AUTO_LOCOMOTION.
+     * @param jump true to start robot charge, then false change to start jump.
+     * @return return true if the target is set successfully
+     */
+    bool set_robot_jump(bool jump);
+    /**
+     * @brief Set rc input to mcu. Only used in board mode is AUTO_LOCOMOTION.
+     * @return return true if the target is set successfully
+     */
+    bool set_robot_stop();
+private:
+    std::unique_ptr<can_device::MotorsImuCanReceiveApi> can_receiver_;
+    std::unique_ptr<can_device::MotorsCanSendApi> can_sender_;
+    size_t motor_num_;
+};
+
+// class tita_robot

--- a/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/include/titati_canfd_router/canfd_router_can_receive_api.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/include/titati_canfd_router/canfd_router_can_receive_api.hpp
@@ -24,6 +24,7 @@
 #include <string>
 #include <thread>
 #include <vector>
+#include <sys/time.h>
 
 #include "protocol/can_utils.hpp"
 
@@ -61,11 +62,11 @@ private:
   uint8_t canfd_router_can_id_offset = 0x00U;
 
   void register_canfd_router_device_can_filter();
-  tita::socket_can::can_fd_callback canfd_router_can_receive_callback =
+  socket_can::can_fd_callback canfd_router_can_receive_callback =
     std::bind(&CanfdRouterCanReceiveApi::get_board_can_data, this, std::placeholders::_1);
 
-  std::shared_ptr<tita::socket_can::CanDev> canfd_router_can_receive_api =
-    std::make_shared<tita::socket_can::CanDev>(
+  std::shared_ptr<socket_can::CanDev> canfd_router_can_receive_api =
+    std::make_shared<socket_can::CanDev>(
       canfd_router_can_interface, canfd_router_can_name, canfd_router_can_extended_frame, canfd_router_can_receive_callback,
       canfd_router_can_rx_is_block, canfd_router_timeout_us, canfd_router_can_id_offset);
 
@@ -82,8 +83,8 @@ private:
   bool set_forcedirect_can_extended_frame = false;
   bool set_forcedirect_can_fd_mode = true;
 
-  std::shared_ptr<tita::socket_can::CanDev> set_forcedirect_can_send_api =
-    std::make_shared<tita::socket_can::CanDev>(
+  std::shared_ptr<socket_can::CanDev> set_forcedirect_can_send_api =
+    std::make_shared<socket_can::CanDev>(
       set_forcedirect_can_interface, set_forcedirect_can_name, set_forcedirect_can_extended_frame, set_forcedirect_can_fd_mode,
       set_forcedirect_timeout_us, set_forcedirect_can_id_offset);
   inline uint32_t get_current_time()

--- a/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/include/titati_canfd_router/canfd_router_can_receive_api.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/include/titati_canfd_router/canfd_router_can_receive_api.hpp
@@ -1,0 +1,102 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CANFD_ROUTER_CAN_API_HPP_
+#define CANFD_ROUTER_CAN_API_HPP_
+
+#include <algorithm>
+#include <atomic>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "protocol/can_utils.hpp"
+
+namespace can_device
+{
+#define CAN_ID_CANFD_ROUTER (0x09FU)
+
+class CanfdRouterCanReceiveApi
+{
+public:
+  CanfdRouterCanReceiveApi()
+  {
+    register_canfd_router_device_can_filter();
+  }
+  ~CanfdRouterCanReceiveApi() = default;
+
+  void set_forcedirect_mode(bool init_flag)
+  {
+    init_flag_ = init_flag;
+    forcedirect_done_.store(false);
+  }
+
+  bool forcedirect_complete() const { return forcedirect_done_.load(); }
+
+private:
+#define MIN_TIME_OUT_US 1'000L      // 1ms
+#define MAX_TIME_OUT_US 3'000'000L  // 3s
+#define CAN_ID_AS_CANFD_ROUTER_INFO (0x09FU)
+#define CAN_MASK_AS_CANFD_ROUTER_INFO (0x0FFU)
+  std::string canfd_router_can_interface = "can0";
+  std::string canfd_router_can_name = "canfd_can";
+  bool canfd_router_can_extended_frame = false;
+  bool canfd_router_can_rx_is_block = false;
+  int64_t canfd_router_timeout_us = MAX_TIME_OUT_US;
+  uint8_t canfd_router_can_id_offset = 0x00U;
+
+  void register_canfd_router_device_can_filter();
+  tita::socket_can::can_fd_callback canfd_router_can_receive_callback =
+    std::bind(&CanfdRouterCanReceiveApi::get_board_can_data, this, std::placeholders::_1);
+
+  std::shared_ptr<tita::socket_can::CanDev> canfd_router_can_receive_api =
+    std::make_shared<tita::socket_can::CanDev>(
+      canfd_router_can_interface, canfd_router_can_name, canfd_router_can_extended_frame, canfd_router_can_receive_callback,
+      canfd_router_can_rx_is_block, canfd_router_timeout_us, canfd_router_can_id_offset);
+
+  void get_board_can_data(std::shared_ptr<struct canfd_frame> recv_frame);
+
+  uint32_t timestamp_;
+  uint32_t mode_;
+  uint32_t heart_cnt_;
+
+  std::string set_forcedirect_can_interface = "can0";
+  std::string set_forcedirect_can_name = "set_forcedirect_can";
+  int64_t set_forcedirect_timeout_us = MAX_TIME_OUT_US;
+  uint8_t set_forcedirect_can_id_offset = 0x00U;
+  bool set_forcedirect_can_extended_frame = false;
+  bool set_forcedirect_can_fd_mode = true;
+
+  std::shared_ptr<tita::socket_can::CanDev> set_forcedirect_can_send_api =
+    std::make_shared<tita::socket_can::CanDev>(
+      set_forcedirect_can_interface, set_forcedirect_can_name, set_forcedirect_can_extended_frame, set_forcedirect_can_fd_mode,
+      set_forcedirect_timeout_us, set_forcedirect_can_id_offset);
+  inline uint32_t get_current_time()
+  {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return tv.tv_sec * 1000000 + tv.tv_usec;
+  }
+
+  bool init_flag_ = false;
+  std::atomic<bool> forcedirect_done_{false};
+};
+
+}  // namespace can_device
+
+#endif  // CANFD_ROUTER_CAN_API_HPP_

--- a/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/src/can_receiver.cpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/src/can_receiver.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tita_robot/can_receiver.hpp"
+
+namespace can_device
+{
+
+void MotorsImuCanReceiveApi::register_motors_device_can_filter()
+{
+  // if (!this->is_running.load()) {
+  //   throw std::runtime_error("MotorsImuCanReceiveApi is not running");
+  // }
+  struct can_filter motors_device_rx_filter;
+  motors_device_rx_filter.can_id = CAN_ID_MOTOR_IN;
+  motors_device_rx_filter.can_mask = CAN_MASK_AS_MOTORS_INFO;
+  this->motors_can_receive_api->set_filter(&motors_device_rx_filter, sizeof(struct can_filter));
+}
+
+void MotorsImuCanReceiveApi::board_can_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  if (recv_frame->can_id >= CAN_ID_MOTOR_IN && recv_frame->can_id < CAN_ID_MOTOR_IN + leg_num_) {
+    motors_data_callback(recv_frame);
+  } else if (recv_frame->can_id == CAN_ID_IMU1) {
+    imu_data_callback(recv_frame);
+  } else {
+    return;
+  }
+}
+void MotorsImuCanReceiveApi::motors_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  std::unique_lock<std::shared_mutex> lock(motors_in_mutex_);
+  for (size_t i = 0; i < leg_dof_; i++) {
+    api_motor_in_t motor;
+    std::memcpy(&motor, recv_frame->data + 16 * i, sizeof(api_motor_in_t));
+    auto it = recv_frame->can_id - CAN_ID_MOTOR_IN;
+    motors_in_[i + leg_dof_ * it] = motor;
+  }
+}
+void MotorsImuCanReceiveApi::imu_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  std::unique_lock<std::shared_mutex> lock(imu_mutex_);
+  std::memcpy(&imu_data_, recv_frame->data, sizeof(api_imu_data_t));
+  for (size_t i(0); i < 3; ++i) {
+    imu_data_.accl[i] *= GRAVITY;
+  }
+  return;
+}
+void MotorsImuCanReceiveApi::motors_status_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  std::memcpy(&motors_status_, recv_frame->data, sizeof(api_motor_status_t));
+}
+
+}  // namespace can_device

--- a/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/src/can_receiver.cpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/src/can_receiver.cpp
@@ -14,38 +14,45 @@
 
 #include "tita_robot/can_receiver.hpp"
 
+#include <vector>
+
 namespace can_device
 {
 
 void MotorsImuCanReceiveApi::register_motors_device_can_filter()
 {
-  // if (!this->is_running.load()) {
-  //   throw std::runtime_error("MotorsImuCanReceiveApi is not running");
-  // }
-  struct can_filter motors_device_rx_filter;
-  motors_device_rx_filter.can_id = CAN_ID_MOTOR_IN;
-  motors_device_rx_filter.can_mask = CAN_MASK_AS_MOTORS_INFO;
-  this->motors_can_receive_api->set_filter(&motors_device_rx_filter, sizeof(struct can_filter));
+  std::vector<struct can_filter> filters(board_count_);
+  for (size_t board = 0; board < board_count_; ++board) {
+    filters[board].can_id = CAN_ID_MOTOR_IN + board * can_board_stride_;
+    filters[board].can_mask = CAN_MASK_AS_MOTORS_INFO;
+  }
+  this->motors_can_receive_api->set_filter(filters.data(), filters.size() * sizeof(struct can_filter));
 }
 
 void MotorsImuCanReceiveApi::board_can_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)
 {
-  if (recv_frame->can_id >= CAN_ID_MOTOR_IN && recv_frame->can_id < CAN_ID_MOTOR_IN + leg_num_) {
-    motors_data_callback(recv_frame);
+  if (recv_frame->can_id >= CAN_ID_MOTOR_IN &&
+      recv_frame->can_id < CAN_ID_MOTOR_IN + board_count_ * can_board_stride_) {
+    auto raw_offset = recv_frame->can_id - CAN_ID_MOTOR_IN;
+    size_t board = raw_offset / can_board_stride_;
+    size_t frame_index = raw_offset % can_board_stride_;
+    if (board >= board_count_ || frame_index >= leg_num_per_board_) {
+      return;
+    }
+    motors_data_callback(recv_frame, board * leg_num_per_board_ + frame_index);
   } else if (recv_frame->can_id == CAN_ID_IMU1) {
     imu_data_callback(recv_frame);
   } else {
     return;
   }
 }
-void MotorsImuCanReceiveApi::motors_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+void MotorsImuCanReceiveApi::motors_data_callback(std::shared_ptr<struct canfd_frame> recv_frame, size_t frame_index)
 {
   std::unique_lock<std::shared_mutex> lock(motors_in_mutex_);
   for (size_t i = 0; i < leg_dof_; i++) {
     api_motor_in_t motor;
     std::memcpy(&motor, recv_frame->data + 16 * i, sizeof(api_motor_in_t));
-    auto it = recv_frame->can_id - CAN_ID_MOTOR_IN;
-    motors_in_[i + leg_dof_ * it] = motor;
+    motors_in_[i + leg_dof_ * frame_index] = motor;
   }
 }
 void MotorsImuCanReceiveApi::imu_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)

--- a/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/src/can_sender.cpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/src/can_sender.cpp
@@ -61,28 +61,32 @@ bool MotorsCanSendApi::send_motors_can(std::vector<motor_out> motors)
   struct canfd_frame frame;
   frame.len = 48U;
   auto now = get_current_time();
-  for (size_t id(0); id < motors.size()/2; id++) {
-    frame.can_id = CAN_ID_SEND_MOTORS + id;
-    memset(frame.data, 0x00U, sizeof(frame.data));
-    auto motor = motors[2 * id];
-    motor.timestamp = now;
-    std::memcpy(frame.data, &motor.timestamp, sizeof(motor.timestamp));
-    std::memcpy(frame.data + 4, &motor.position, sizeof(motor.position));
-    std::memcpy(frame.data + 8, &motor.kp, sizeof(motor.kp));
-    std::memcpy(frame.data + 12, &motor.velocity, sizeof(motor.velocity));
-    std::memcpy(frame.data + 16, &motor.kd, sizeof(motor.kd));
-    std::memcpy(frame.data + 20, &motor.torque, sizeof(motor.torque));
+  for (size_t board = 0; board < board_count_; ++board) {
+    const size_t base_index = board * motors_per_board_;
+    const canid_t base_can_id = static_cast<canid_t>(CAN_ID_SEND_MOTORS + board * can_board_stride_);
+    for (size_t frame_id = 0; frame_id < frames_per_board_; ++frame_id) {
+      frame.can_id = base_can_id + frame_id;
+      memset(frame.data, 0x00U, sizeof(frame.data));
+      auto motor = motors[base_index + 2 * frame_id];
+      motor.timestamp = now;
+      std::memcpy(frame.data, &motor.timestamp, sizeof(motor.timestamp));
+      std::memcpy(frame.data + 4, &motor.position, sizeof(motor.position));
+      std::memcpy(frame.data + 8, &motor.kp, sizeof(motor.kp));
+      std::memcpy(frame.data + 12, &motor.velocity, sizeof(motor.velocity));
+      std::memcpy(frame.data + 16, &motor.kd, sizeof(motor.kd));
+      std::memcpy(frame.data + 20, &motor.torque, sizeof(motor.torque));
 
-    motor = motors[2 * id + 1];
-    motor.timestamp = now;
-    std::memcpy(frame.data + 24, &motor.timestamp, sizeof(motor.timestamp));
-    std::memcpy(frame.data + 28, &motor.position, sizeof(motor.position));
-    std::memcpy(frame.data + 32, &motor.kp, sizeof(motor.kp));
-    std::memcpy(frame.data + 36, &motor.velocity, sizeof(motor.velocity));
-    std::memcpy(frame.data + 40, &motor.kd, sizeof(motor.kd));
-    std::memcpy(frame.data + 44, &motor.torque, sizeof(motor.torque));
-    send_success &= can_send_api_->send_can_message(frame);
-    std::this_thread::sleep_for(std::chrono::microseconds(150)); // 等待 100 微秒
+      motor = motors[base_index + 2 * frame_id + 1];
+      motor.timestamp = now;
+      std::memcpy(frame.data + 24, &motor.timestamp, sizeof(motor.timestamp));
+      std::memcpy(frame.data + 28, &motor.position, sizeof(motor.position));
+      std::memcpy(frame.data + 32, &motor.kp, sizeof(motor.kp));
+      std::memcpy(frame.data + 36, &motor.velocity, sizeof(motor.velocity));
+      std::memcpy(frame.data + 40, &motor.kd, sizeof(motor.kd));
+      std::memcpy(frame.data + 44, &motor.torque, sizeof(motor.torque));
+      send_success &= can_send_api_->send_can_message(frame);
+      std::this_thread::sleep_for(std::chrono::microseconds(150)); // 等待 100 微秒
+    }
   }
   return send_success;
 }

--- a/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/src/can_sender.cpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/src/can_sender.cpp
@@ -1,0 +1,90 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tita_robot/can_sender.hpp"
+
+namespace can_device
+{
+bool MotorsCanSendApi::send_command_can_channel_input(ChannelInput data)
+{
+  data.timestamp = get_current_time();
+  struct canfd_frame frame;
+  frame.can_id = CAN_ID_CHANNEL_INPUT;
+  frame.len = 40u;
+  memset(frame.data, 0x00U, sizeof(frame.data));
+  
+  std::memcpy(frame.data, &data, sizeof(data));
+
+  return can_send_api_->send_can_message(frame);
+}
+
+bool MotorsCanSendApi::send_command_can_rpc_request(RpcRequest data){
+  data.timestamp = get_current_time();
+
+  struct canfd_frame frame;
+  frame.can_id = CAN_ID_RPC_REQUEST;
+  frame.len = 10U;
+
+  memset(frame.data, 0x00U, sizeof(frame.data));
+
+  std::memcpy(frame.data, &data.timestamp, sizeof(data.timestamp));
+  std::memcpy(frame.data + 4, &data.key, sizeof(data.key));
+  std::memcpy(frame.data + 6, &data.value, sizeof(data.value));
+
+  return can_send_api_->send_can_message(frame);
+}
+
+bool MotorsCanSendApi::send_motors_can(std::vector<motor_out> motors)
+{
+  if (motors.size() != leg_dof_ * leg_num_) {
+    std::cerr << "[MOTORS_CAN_SEND] motors size not equal to robot dof" << std::endl;
+    return false;
+  }
+  if(leg_dof_ == 3){
+    motor_out motor = {};
+    auto it = motors.begin() + 3;
+    motors.insert(it, motor);
+    motors.push_back(motor);
+  }
+  bool send_success = true;
+  struct canfd_frame frame;
+  frame.len = 48U;
+  auto now = get_current_time();
+  for (size_t id(0); id < motors.size()/2; id++) {
+    frame.can_id = CAN_ID_SEND_MOTORS + id;
+    memset(frame.data, 0x00U, sizeof(frame.data));
+    auto motor = motors[2 * id];
+    motor.timestamp = now;
+    std::memcpy(frame.data, &motor.timestamp, sizeof(motor.timestamp));
+    std::memcpy(frame.data + 4, &motor.position, sizeof(motor.position));
+    std::memcpy(frame.data + 8, &motor.kp, sizeof(motor.kp));
+    std::memcpy(frame.data + 12, &motor.velocity, sizeof(motor.velocity));
+    std::memcpy(frame.data + 16, &motor.kd, sizeof(motor.kd));
+    std::memcpy(frame.data + 20, &motor.torque, sizeof(motor.torque));
+
+    motor = motors[2 * id + 1];
+    motor.timestamp = now;
+    std::memcpy(frame.data + 24, &motor.timestamp, sizeof(motor.timestamp));
+    std::memcpy(frame.data + 28, &motor.position, sizeof(motor.position));
+    std::memcpy(frame.data + 32, &motor.kp, sizeof(motor.kp));
+    std::memcpy(frame.data + 36, &motor.velocity, sizeof(motor.velocity));
+    std::memcpy(frame.data + 40, &motor.kd, sizeof(motor.kd));
+    std::memcpy(frame.data + 44, &motor.torque, sizeof(motor.torque));
+    send_success &= can_send_api_->send_can_message(frame);
+    std::this_thread::sleep_for(std::chrono::microseconds(150)); // 等待 100 微秒
+  }
+  return send_success;
+}
+
+}  // namespace can_device

--- a/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/src/canfd_router_can_receive_api.cpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/src/canfd_router_can_receive_api.cpp
@@ -1,0 +1,71 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "titati_canfd_router/canfd_router_can_receive_api.hpp"
+
+#include <chrono>
+#include <cstring>
+
+namespace can_device
+{
+
+void CanfdRouterCanReceiveApi::register_canfd_router_device_can_filter()
+{
+  struct can_filter canfd_router_device_rx_filter;
+  canfd_router_device_rx_filter.can_id = CAN_ID_AS_CANFD_ROUTER_INFO;
+  canfd_router_device_rx_filter.can_mask = CAN_MASK_AS_CANFD_ROUTER_INFO;
+  this->canfd_router_can_receive_api->set_filter(&canfd_router_device_rx_filter, sizeof(struct can_filter));
+}
+
+void CanfdRouterCanReceiveApi::get_board_can_data(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  if (recv_frame->can_id == CAN_ID_CANFD_ROUTER) {
+    std::memcpy(&mode_, recv_frame->data + 4, sizeof(mode_));
+    std::memcpy(&heart_cnt_, recv_frame->data + 8, sizeof(heart_cnt_));
+    std::cout << "[titati_canfd_router] mode: " << mode_ << ", heartbeats: " << heart_cnt_ << std::endl;
+    if (init_flag_ && (mode_ == 2 || mode_ == 1)) {
+      struct canfd_frame frame;
+      frame.can_id = 0x170U;
+      frame.len = 10U;
+      memset(frame.data, 0x00U, sizeof(frame.data));
+
+      uint32_t timestamp = get_current_time();
+      uint16_t key = 0x200;
+      uint32_t value = 0x00U;
+
+      std::memcpy(frame.data, &timestamp, sizeof(timestamp));
+      std::memcpy(frame.data + 4, &key, sizeof(key));
+      std::memcpy(frame.data + 6, &value, sizeof(value));
+
+      set_forcedirect_can_send_api->send_can_message(frame);
+
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+      timestamp = get_current_time();
+      key = 0x200;
+      value = 0x03U;
+
+      std::memcpy(frame.data, &timestamp, sizeof(timestamp));
+      std::memcpy(frame.data + 4, &key, sizeof(key));
+      std::memcpy(frame.data + 6, &value, sizeof(value));
+
+      set_forcedirect_can_send_api->send_can_message(frame);
+      std::cout << "[titati_canfd_router] Forced-direct command sent." << std::endl;
+      init_flag_ = false;
+      forcedirect_done_.store(true);
+    }
+  }
+}
+
+}  // namespace can_device

--- a/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/src/tita_robot.cpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/tita_sdk/src/tita_robot.cpp
@@ -1,0 +1,171 @@
+#include "tita_robot/tita_robot.hpp"
+
+std::vector<double> tita_robot::get_joint_q() const
+{
+  auto infos = can_receiver_->get_motors_in();
+  std::vector<double> joint;
+  for (const auto & info : *infos) {
+    joint.push_back(info.position);
+  }
+  return joint;
+}
+
+std::vector<double> tita_robot::get_joint_v() const
+{
+  auto infos = can_receiver_->get_motors_in();
+  std::vector<double> joint;
+  for (const auto & info : *infos) {
+    joint.push_back(info.velocity);
+  }
+  return joint;
+}
+
+std::vector<double> tita_robot::get_joint_t() const
+{
+  auto infos = can_receiver_->get_motors_in();
+  std::vector<double> joint;
+  for (const auto & info : *infos) {
+    joint.push_back(info.torque);
+  }
+  return joint;
+}
+
+std::vector<uint8_t> tita_robot::get_joint_status() const  // TODO: why 8
+{
+  auto infos = can_receiver_->get_motors_status();
+  std::vector<uint8_t> joint;
+  for (size_t id = 0; id < 8; id++) {
+    joint.push_back(infos->value[id]);
+  }
+  return joint;
+}
+
+std::array<double, 4> tita_robot::get_imu_quaternion() const
+{
+  auto infos = can_receiver_->get_imu_data();
+  std::array<double, 4> data;
+  for (size_t i = 0; i < 4; i++) {
+    data[i] = infos->quaternion[i];
+  }
+  return data;
+}
+
+std::array<double, 3> tita_robot::get_imu_acceleration() const
+{
+  auto infos = can_receiver_->get_imu_data();
+  std::array<double, 3> data;
+  for (size_t i = 0; i < 3; i++) {
+    data[i] = infos->accl[i];
+  }
+  return data;
+}
+
+std::array<double, 3> tita_robot::get_imu_angular_velocity() const
+{
+  auto infos = can_receiver_->get_imu_data();
+  std::array<double, 3> data;
+  for (size_t i = 0; i < 3; i++) {
+    data[i] = infos->gyro[i];
+  }
+  return data;
+}
+
+bool tita_robot::set_target_joint_t(const std::vector<double> & t)
+{
+  std::vector<can_device::motor_out> motors;
+  for (size_t id = 0; id < motor_num_; id++) {
+    can_device::motor_out motor;
+    motor.torque = t[id];
+    motor.kp = 0.0f;
+    motor.kd = 0.0f;
+    motor.velocity = 0.0f;
+    motor.position = 0.0f;
+    motors.push_back(motor);
+  }
+  return can_sender_->send_motors_can(motors);
+}
+
+bool tita_robot::set_target_joint_mit(
+  const std::vector<double> & q, const std::vector<double> & v, const std::vector<double> & kp,
+  const std::vector<double> & kd, const std::vector<double> & t)
+{
+  std::vector<can_device::motor_out> motors;
+  for (size_t id = 0; id < motor_num_; id++) {
+    can_device::motor_out motor;
+    motor.torque = t[id];
+    motor.kp = kp[id];
+    motor.kd = kd[id];
+    motor.velocity = v[id];
+    motor.position = q[id];
+    motors.push_back(motor);
+  }
+  return can_sender_->send_motors_can(motors);
+}
+
+// bool tita_robot::set_board_mode(ReadyNext mode)
+// {
+//   can_device::RpcRequest rpc_request;
+//   rpc_request.key = can_device::SET_READY_NEXT;
+//   rpc_request.value = mode;
+//   return can_sender_->send_command_can_rpc_request(rpc_request);
+// }
+
+bool tita_robot::set_motors_sdk(bool if_sdk)
+{
+  can_device::RpcRequest rpc_request;
+  rpc_request.key = can_device::SET_READY_NEXT;
+  rpc_request.value = READY_WAITING;
+  bool return_ok = can_sender_->send_command_can_rpc_request(rpc_request);
+  std::this_thread::sleep_for(std::chrono::microseconds(100));
+  if (if_sdk) {
+    rpc_request.value = FORCE_DIRECT;
+  } else {
+    rpc_request.value = AUTO_LOCOMOTION;
+  }
+  return_ok &= can_sender_->send_command_can_rpc_request(rpc_request);
+  return return_ok;
+}
+
+bool tita_robot::set_rc_input(ChannelInput input)
+{
+  can_device::ChannelInput can_input;
+  can_input.forward = input.forward;
+  can_input.yaw = input.yaw;
+  can_input.pitch = input.pitch;
+  can_input.roll = input.roll;
+  can_input.height = input.height;
+  can_input.split = input.split;
+  can_input.tilt = input.tilt;
+  can_input.forward_accel = input.forward_accel;
+  can_input.yaw_accel = input.yaw_accel;
+  return can_sender_->send_command_can_channel_input(can_input);
+}
+
+bool tita_robot::set_robot_stand(bool stand)
+{
+  can_device::RpcRequest rpc_request;
+  rpc_request.key = can_device::SET_STAND_MODE;
+  rpc_request.value = !stand ? 0x01U : 0x02U;
+  return can_sender_->send_command_can_rpc_request(rpc_request);
+}
+
+bool tita_robot::set_robot_jump(bool jump)
+{
+  can_device::RpcRequest rpc_request;
+  rpc_request.key = can_device::SET_JUMP;
+  rpc_request.value = !jump ? 0x01U : 0x02U;
+  return can_sender_->send_command_can_rpc_request(rpc_request);
+}
+
+bool tita_robot::set_robot_stop()
+{
+  can_device::RpcRequest rpc_request;
+  rpc_request.value = 0x01U;
+  rpc_request.key = can_device::SET_STAND_MODE;
+  bool return_ok = can_sender_->send_command_can_rpc_request(rpc_request);
+  std::this_thread::sleep_for(std::chrono::microseconds(200));
+  rpc_request.value = 0x02U;
+  rpc_request.key = can_device::SET_JUMP;
+  return_ok &= can_sender_->send_command_can_rpc_request(rpc_request);
+  return true;
+}

--- a/rl_sar/src/rl_sar/scripts/titati_can_setup_master.sh
+++ b/rl_sar/src/rl_sar/scripts/titati_can_setup_master.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+CAN_IFACE="${1:-can0}"
+
+sudo ip link set "${CAN_IFACE}" down || true
+sudo ip link set "${CAN_IFACE}" up type can bitrate 1000000 sample-point 0.80 \
+    dbitrate 8000000 dsample-point 0.80 fd on restart-ms 100
+sudo ifconfig "${CAN_IFACE}" txqueuelen 1000
+
+echo "[titati_can_setup_master] ${CAN_IFACE} configured for CAN-FD 1M/8M."

--- a/rl_sar/src/rl_sar/scripts/titati_can_setup_slave.sh
+++ b/rl_sar/src/rl_sar/scripts/titati_can_setup_slave.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+CAN_IFACE="${1:-can0}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RL_SAR_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+ROUTER_BIN="${RL_SAR_ROOT}/cmake_build/bin/titati_canfd_router_node"
+
+sudo ip link set "${CAN_IFACE}" down || true
+sudo ip link set "${CAN_IFACE}" up type can bitrate 1000000 sample-point 0.80 \
+    dbitrate 8000000 dsample-point 0.80 fd on restart-ms 100
+sudo ifconfig "${CAN_IFACE}" txqueuelen 1000
+
+echo "[titati_can_setup_slave] ${CAN_IFACE} configured for CAN-FD 1M/8M."
+
+echo "[titati_can_setup_slave] Launching Titati CAN-FD router..."
+if [[ ! -x "${ROUTER_BIN}" ]]; then
+    echo "Binary ${ROUTER_BIN} not found. Build rl_sar with CMake first." >&2
+    exit 1
+fi
+
+"${ROUTER_BIN}"

--- a/rl_sar/src/rl_sar/scripts/titati_can_setup_slave.sh
+++ b/rl_sar/src/rl_sar/scripts/titati_can_setup_slave.sh
@@ -13,10 +13,10 @@ sudo ifconfig "${CAN_IFACE}" txqueuelen 1000
 
 echo "[titati_can_setup_slave] ${CAN_IFACE} configured for CAN-FD 1M/8M."
 
-echo "[titati_can_setup_slave] Launching Titati CAN-FD router..."
+echo "[titati_can_setup_slave] Launching Titati CAN-FD router (Ctrl+C to stop)..."
 if [[ ! -x "${ROUTER_BIN}" ]]; then
     echo "Binary ${ROUTER_BIN} not found. Build rl_sar with CMake first." >&2
     exit 1
 fi
 
-"${ROUTER_BIN}"
+"${ROUTER_BIN}" --stay-alive

--- a/rl_sar/src/rl_sar/src/rl_real_titati.cpp
+++ b/rl_sar/src/rl_sar/src/rl_real_titati.cpp
@@ -11,8 +11,10 @@
 RL_Real::RL_Real(const std::string &robot_variant)
 #if defined(USE_ROS2) && defined(USE_ROS)
     : rclcpp::Node("rl_real_node")
-#endif
     , robot_variant_(robot_variant)
+#else
+    : robot_variant_(robot_variant)
+#endif
 {
 #if defined(USE_ROS1) && defined(USE_ROS)
     ros::NodeHandle nh;

--- a/rl_sar/src/rl_sar/src/rl_real_titati.cpp
+++ b/rl_sar/src/rl_sar/src/rl_real_titati.cpp
@@ -5,6 +5,7 @@
 
 #include "rl_real_titati.hpp"
 
+#include <algorithm>
 #include <cstring>
 #include <unistd.h>
 
@@ -29,6 +30,35 @@ RL_Real::RL_Real(const std::string &robot_variant)
     this->ang_vel_type = "ang_vel_body";
     this->robot_name = this->robot_variant_;
     this->ReadYamlBase(this->robot_name);
+
+    torque_limits_.assign(this->params.num_of_dofs, 0.0);
+    try
+    {
+        torch::Tensor limits = this->params.torque_limits.to(torch::kCPU).to(torch::kDouble);
+        limits = limits.reshape({limits.numel()});
+        if (limits.numel() == 1)
+        {
+            std::fill(torque_limits_.begin(), torque_limits_.end(), limits.item<double>());
+        }
+        else if (limits.numel() >= this->params.num_of_dofs)
+        {
+            for (int i = 0; i < this->params.num_of_dofs; ++i)
+            {
+                torque_limits_[i] = limits[i].item<double>();
+            }
+        }
+        else
+        {
+            std::fill(torque_limits_.begin(), torque_limits_.end(), 50.0);
+            std::cout << LOGGER::WARNING << "Torque limit tensor has insufficient entries; using 50Nm fallback." << std::endl;
+        }
+    }
+    catch (const c10::Error &err)
+    {
+        std::fill(torque_limits_.begin(), torque_limits_.end(), 50.0);
+        std::cout << LOGGER::WARNING << "Failed to parse torque limits tensor: " << err.what()
+                  << " Using 50Nm fallback." << std::endl;
+    }
 
     // auto load FSM by robot_name
     if (FSMManager::GetInstance().IsTypeSupported(this->robot_name))
@@ -145,23 +175,32 @@ void RL_Real::GetState(RobotState<double> *state)
 
 void RL_Real::SetCommand(const RobotCommand<double> *command)
 {
-    std::vector<double> q(this->params.num_of_dofs, 0.0);
-    std::vector<double> dq(this->params.num_of_dofs, 0.0);
-    std::vector<double> kp(this->params.num_of_dofs, 0.0);
-    std::vector<double> kd(this->params.num_of_dofs, 0.0);
-    std::vector<double> tau(this->params.num_of_dofs, 0.0);
+    std::vector<double> torques_hw(this->params.num_of_dofs, 0.0);
 
     for (int i = 0; i < this->params.num_of_dofs; ++i)
     {
         int mapped = this->params.joint_mapping[i];
-        q[mapped] = command->motor_command.q[i];
-        dq[mapped] = command->motor_command.dq[i];
-        kp[mapped] = command->motor_command.kp[i];
-        kd[mapped] = command->motor_command.kd[i];
-        tau[mapped] = command->motor_command.tau[i];
+        double q_des = command->motor_command.q[i];
+        double dq_des = command->motor_command.dq[i];
+        double kp = command->motor_command.kp[i];
+        double kd = command->motor_command.kd[i];
+        double ff = command->motor_command.tau[i];
+
+        double q_meas = this->robot_state.motor_state.q[i];
+        double dq_meas = this->robot_state.motor_state.dq[i];
+
+        double torque = kp * (q_des - q_meas) + kd * (dq_des - dq_meas) + ff;
+        if (i < static_cast<int>(torque_limits_.size()))
+        {
+            torque = std::clamp(torque, -torque_limits_[i], torque_limits_[i]);
+        }
+        torques_hw[mapped] = torque;
     }
 
-    robot_->set_target_joint_mit(q, dq, kp, kd, tau);
+    if (!robot_->set_target_joint_t(torques_hw))
+    {
+        std::cout << LOGGER::WARNING << "Failed to dispatch torque command on CAN-FD bus" << std::endl;
+    }
 }
 
 void RL_Real::RobotControl()

--- a/rl_sar/src/rl_sar/src/rl_real_titati.cpp
+++ b/rl_sar/src/rl_sar/src/rl_real_titati.cpp
@@ -1,0 +1,371 @@
+/*
+ * Copyright (c) 2024-2025 Ziqi Fan
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "rl_real_titati.hpp"
+
+#include <cstring>
+#include <unistd.h>
+
+RL_Real::RL_Real(const std::string &robot_variant)
+#if defined(USE_ROS2) && defined(USE_ROS)
+    : rclcpp::Node("rl_real_node")
+#endif
+    , robot_variant_(robot_variant)
+{
+#if defined(USE_ROS1) && defined(USE_ROS)
+    ros::NodeHandle nh;
+    this->cmd_vel_subscriber = nh.subscribe<geometry_msgs::Twist>("/cmd_vel", 10, &RL_Real::CmdvelCallback, this);
+#elif defined(USE_ROS2) && defined(USE_ROS)
+    this->cmd_vel_subscriber = this->create_subscription<geometry_msgs::msg::Twist>(
+        "/cmd_vel", rclcpp::SystemDefaultsQoS(),
+        [this](const geometry_msgs::msg::Twist::SharedPtr msg) { this->CmdvelCallback(msg); });
+#endif
+
+    // read params from yaml
+    this->ang_vel_type = "ang_vel_body";
+    this->robot_name = this->robot_variant_;
+    this->ReadYamlBase(this->robot_name);
+
+    // auto load FSM by robot_name
+    if (FSMManager::GetInstance().IsTypeSupported(this->robot_name))
+    {
+        auto fsm_ptr = FSMManager::GetInstance().CreateFSM(this->robot_name, this);
+        if (fsm_ptr)
+        {
+            this->fsm = *fsm_ptr;
+        }
+    }
+    else
+    {
+        std::cout << LOGGER::ERROR << "No FSM registered for robot: " << this->robot_name << std::endl;
+    }
+
+    // init torch
+    torch::autograd::GradMode::set_enabled(false);
+    torch::set_num_threads(4);
+
+    // init robot
+    robot_ = std::make_unique<tita_robot>(static_cast<size_t>(this->params.num_of_dofs));
+    if (!robot_->set_motors_sdk(true))
+    {
+        std::cout << LOGGER::ERROR << "Failed to switch motors to SDK direct-control mode" << std::endl;
+    }
+    std::vector<double> zero_torque(this->params.num_of_dofs, 0.0);
+    robot_->set_target_joint_t(zero_torque);
+
+    this->InitOutputs();
+    this->InitControl();
+
+    // loop
+    this->loop_keyboard = std::make_shared<LoopFunc>("loop_keyboard", 0.05, std::bind(&RL_Real::KeyboardInterface, this));
+    this->loop_control = std::make_shared<LoopFunc>("loop_control", this->params.dt, std::bind(&RL_Real::RobotControl, this));
+    this->loop_rl = std::make_shared<LoopFunc>("loop_rl", this->params.dt * this->params.decimation, std::bind(&RL_Real::RunModel, this));
+    this->loop_keyboard->start();
+    this->loop_control->start();
+    this->loop_rl->start();
+
+#ifdef PLOT
+    this->plot_t = std::vector<int>(this->plot_size, 0);
+    this->plot_real_joint_pos.resize(this->params.num_of_dofs);
+    this->plot_target_joint_pos.resize(this->params.num_of_dofs);
+    for (auto &vector : this->plot_real_joint_pos) { vector = std::vector<double>(this->plot_size, 0.0); }
+    for (auto &vector : this->plot_target_joint_pos) { vector = std::vector<double>(this->plot_size, 0.0); }
+    this->loop_plot = std::make_shared<LoopFunc>("loop_plot", 0.002, std::bind(&RL_Real::Plot, this));
+    this->loop_plot->start();
+#endif
+#ifdef CSV_LOGGER
+    this->CSVInit(this->robot_name);
+#endif
+}
+
+RL_Real::~RL_Real()
+{
+    this->loop_keyboard->shutdown();
+    this->loop_control->shutdown();
+    this->loop_rl->shutdown();
+#ifdef PLOT
+    if (this->loop_plot)
+    {
+        this->loop_plot->shutdown();
+    }
+#endif
+    if (robot_)
+    {
+        std::vector<double> zero_torque(this->params.num_of_dofs, 0.0);
+        robot_->set_target_joint_t(zero_torque);
+        robot_->set_motors_sdk(false);
+    }
+    std::cout << LOGGER::INFO << "RL_Real exit" << std::endl;
+}
+
+void RL_Real::GetState(RobotState<double> *state)
+{
+    if (this->control.navigation_mode)
+    {
+#if !defined(USE_CMAKE) && defined(USE_ROS)
+        this->control.x = this->cmd_vel.linear.x;
+        this->control.y = this->cmd_vel.linear.y;
+        this->control.yaw = this->cmd_vel.angular.z;
+#endif
+    }
+
+    auto quat = robot_->get_imu_quaternion();
+    state->imu.quaternion[0] = quat[3]; // w
+    state->imu.quaternion[1] = quat[0]; // x
+    state->imu.quaternion[2] = quat[1]; // y
+    state->imu.quaternion[3] = quat[2]; // z
+
+    auto gyro = robot_->get_imu_angular_velocity();
+    for (int i = 0; i < 3; ++i)
+    {
+        state->imu.gyroscope[i] = gyro[i];
+    }
+    auto accl = robot_->get_imu_acceleration();
+    for (int i = 0; i < 3; ++i)
+    {
+        state->imu.accelerometer[i] = accl[i];
+    }
+
+    auto joint_q = robot_->get_joint_q();
+    auto joint_dq = robot_->get_joint_v();
+    auto joint_tau = robot_->get_joint_t();
+
+    for (int i = 0; i < this->params.num_of_dofs; ++i)
+    {
+        int mapped = this->params.joint_mapping[i];
+        state->motor_state.q[i] = joint_q[mapped];
+        state->motor_state.dq[i] = joint_dq[mapped];
+        state->motor_state.tau_est[i] = joint_tau[mapped];
+    }
+}
+
+void RL_Real::SetCommand(const RobotCommand<double> *command)
+{
+    std::vector<double> q(this->params.num_of_dofs, 0.0);
+    std::vector<double> dq(this->params.num_of_dofs, 0.0);
+    std::vector<double> kp(this->params.num_of_dofs, 0.0);
+    std::vector<double> kd(this->params.num_of_dofs, 0.0);
+    std::vector<double> tau(this->params.num_of_dofs, 0.0);
+
+    for (int i = 0; i < this->params.num_of_dofs; ++i)
+    {
+        int mapped = this->params.joint_mapping[i];
+        q[mapped] = command->motor_command.q[i];
+        dq[mapped] = command->motor_command.dq[i];
+        kp[mapped] = command->motor_command.kp[i];
+        kd[mapped] = command->motor_command.kd[i];
+        tau[mapped] = command->motor_command.tau[i];
+    }
+
+    robot_->set_target_joint_mit(q, dq, kp, kd, tau);
+}
+
+void RL_Real::RobotControl()
+{
+    this->motiontime++;
+
+    if (this->control.current_keyboard == Input::Keyboard::W)
+    {
+        this->control.x += 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::S)
+    {
+        this->control.x -= 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::A)
+    {
+        this->control.y += 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::D)
+    {
+        this->control.y -= 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::Q)
+    {
+        this->control.yaw += 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::E)
+    {
+        this->control.yaw -= 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::Space)
+    {
+        this->control.x = 0.0;
+        this->control.y = 0.0;
+        this->control.yaw = 0.0;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::N || this->control.current_gamepad == Input::Gamepad::X)
+    {
+        this->control.navigation_mode = !this->control.navigation_mode;
+        std::cout << std::endl << LOGGER::INFO << "Navigation mode: " << (this->control.navigation_mode ? "ON" : "OFF") << std::endl;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+
+    this->GetState(&this->robot_state);
+    this->StateController(&this->robot_state, &this->robot_command);
+    this->SetCommand(&this->robot_command);
+}
+
+void RL_Real::RunModel()
+{
+    if (this->rl_init_done)
+    {
+        this->episode_length_buf += 1;
+        this->obs.ang_vel = torch::tensor(this->robot_state.imu.gyroscope).unsqueeze(0);
+        if (this->control.navigation_mode)
+        {
+#if !defined(USE_CMAKE) && defined(USE_ROS)
+            this->obs.commands = torch::tensor({{this->cmd_vel.linear.x, this->cmd_vel.linear.y, this->cmd_vel.angular.z}});
+#endif
+        }
+        else
+        {
+            this->obs.commands = torch::tensor({{this->control.x, this->control.y, this->control.yaw}});
+        }
+        this->obs.base_quat = torch::tensor(this->robot_state.imu.quaternion).unsqueeze(0);
+        this->obs.dof_pos = torch::tensor(this->robot_state.motor_state.q).narrow(0, 0, this->params.num_of_dofs).unsqueeze(0);
+        this->obs.dof_vel = torch::tensor(this->robot_state.motor_state.dq).narrow(0, 0, this->params.num_of_dofs).unsqueeze(0);
+
+        this->obs.actions = this->Forward();
+        this->ComputeOutput(this->obs.actions, this->output_dof_pos, this->output_dof_vel, this->output_dof_tau);
+
+        if (this->output_dof_pos.defined() && this->output_dof_pos.numel() > 0)
+        {
+            output_dof_pos_queue.push(this->output_dof_pos);
+        }
+        if (this->output_dof_vel.defined() && this->output_dof_vel.numel() > 0)
+        {
+            output_dof_vel_queue.push(this->output_dof_vel);
+        }
+        if (this->output_dof_tau.defined() && this->output_dof_tau.numel() > 0)
+        {
+            output_dof_tau_queue.push(this->output_dof_tau);
+        }
+
+        this->TorqueProtect(this->output_dof_tau);
+#ifdef CSV_LOGGER
+        torch::Tensor tau_est = torch::tensor(this->robot_state.motor_state.tau_est).unsqueeze(0);
+        this->CSVLogger(this->output_dof_tau, tau_est, this->obs.dof_pos, this->output_dof_pos, this->obs.dof_vel);
+#endif
+    }
+}
+
+torch::Tensor RL_Real::Forward()
+{
+    torch::autograd::GradMode::set_enabled(false);
+
+    torch::Tensor clamped_obs = this->ComputeObservation();
+
+    torch::Tensor actions;
+    if (!this->params.observations_history.empty())
+    {
+        this->history_obs_buf.insert(clamped_obs);
+        this->history_obs = this->history_obs_buf.get_obs_vec(this->params.observations_history);
+        actions = this->model.forward({this->history_obs}).toTensor();
+    }
+    else
+    {
+        actions = this->model.forward({clamped_obs}).toTensor();
+    }
+
+    if (this->params.clip_actions_upper.numel() != 0 && this->params.clip_actions_lower.numel() != 0)
+    {
+        return torch::clamp(actions, this->params.clip_actions_lower, this->params.clip_actions_upper);
+    }
+    else
+    {
+        return actions;
+    }
+}
+
+void RL_Real::Plot()
+{
+    this->plot_t.erase(this->plot_t.begin());
+    this->plot_t.push_back(this->motiontime);
+    plt::cla();
+    plt::clf();
+    for (int i = 0; i < this->params.num_of_dofs; ++i)
+    {
+        this->plot_real_joint_pos[i].erase(this->plot_real_joint_pos[i].begin());
+        this->plot_target_joint_pos[i].erase(this->plot_target_joint_pos[i].begin());
+        this->plot_real_joint_pos[i].push_back(this->robot_state.motor_state.q[i]);
+        this->plot_target_joint_pos[i].push_back(this->output_dof_pos[0][i].item<double>());
+        plt::subplot(this->params.num_of_dofs, 1, i + 1);
+        plt::named_plot("_real_joint_pos", this->plot_t, this->plot_real_joint_pos[i], "r");
+        plt::named_plot("_target_joint_pos", this->plot_t, this->plot_target_joint_pos[i], "b");
+        plt::xlim(this->plot_t.front(), this->plot_t.back());
+    }
+    plt::pause(0.0001);
+}
+
+#if !defined(USE_CMAKE) && defined(USE_ROS)
+void RL_Real::CmdvelCallback(
+#if defined(USE_ROS1) && defined(USE_ROS)
+    const geometry_msgs::Twist::ConstPtr &msg
+#elif defined(USE_ROS2) && defined(USE_ROS)
+    const geometry_msgs::msg::Twist::SharedPtr msg
+#endif
+)
+{
+    this->cmd_vel = *msg;
+}
+#endif
+
+#if defined(USE_ROS1) && defined(USE_ROS)
+void signalHandler(int signum)
+{
+    ros::shutdown();
+    exit(0);
+}
+#endif
+
+static std::string ParseRobotVariant(int argc, char **argv)
+{
+    std::string variant = "titati";
+    for (int i = 1; i < argc; ++i)
+    {
+        std::string arg(argv[i]);
+        if (arg.rfind("--robot=", 0) == 0)
+        {
+            variant = arg.substr(std::strlen("--robot="));
+        }
+        else if (arg.rfind("--robot_name=", 0) == 0)
+        {
+            variant = arg.substr(std::strlen("--robot_name="));
+        }
+    }
+    if (variant != "tita" && variant != "titati")
+    {
+        std::cout << LOGGER::WARNING << "Unknown robot variant '" << variant << "', fallback to titati" << std::endl;
+        variant = "titati";
+    }
+    return variant;
+}
+
+int main(int argc, char **argv)
+{
+    std::string robot_variant = ParseRobotVariant(argc, argv);
+#if defined(USE_ROS1) && defined(USE_ROS)
+    signal(SIGINT, signalHandler);
+    ros::init(argc, argv, "rl_sar");
+    RL_Real rl_sar(robot_variant);
+    ros::spin();
+#elif defined(USE_ROS2) && defined(USE_ROS)
+    rclcpp::init(argc, argv);
+    rclcpp::spin(std::make_shared<RL_Real>(robot_variant));
+    rclcpp::shutdown();
+#elif defined(USE_CMAKE) || !defined(USE_ROS)
+    RL_Real rl_sar(robot_variant);
+    while (1) { sleep(10); }
+#endif
+    return 0;
+}

--- a/rl_sar/src/rl_sar/src/titati_canfd_router_node.cpp
+++ b/rl_sar/src/rl_sar/src/titati_canfd_router_node.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2024-2025 Ziqi Fan
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "titati_canfd_router/canfd_router_can_receive_api.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <thread>
+
+namespace
+{
+std::atomic<bool> keep_running{true};
+
+void signal_handler(int)
+{
+    keep_running.store(false);
+}
+
+void PrintUsage(const char *argv0)
+{
+    std::cout << "Usage: " << argv0 << " [--stay-alive]" << std::endl;
+    std::cout << "  --stay-alive  Keep the program running after the forced-direct command is sent." << std::endl;
+}
+} // namespace
+
+int main(int argc, char **argv)
+{
+    bool stay_alive = false;
+
+    for (int i = 1; i < argc; ++i)
+    {
+        if (std::strcmp(argv[i], "--help") == 0 || std::strcmp(argv[i], "-h") == 0)
+        {
+            PrintUsage(argv[0]);
+            return 0;
+        }
+        if (std::strcmp(argv[i], "--stay-alive") == 0)
+        {
+            stay_alive = true;
+        }
+        else
+        {
+            std::cerr << "Unknown argument: " << argv[i] << std::endl;
+            PrintUsage(argv[0]);
+            return 1;
+        }
+    }
+
+    std::signal(SIGINT, signal_handler);
+    std::signal(SIGTERM, signal_handler);
+
+    std::cout << "[titati_canfd_router_node] Initialising CAN-FD router on can0..." << std::endl;
+    auto router = std::make_shared<can_device::CanfdRouterCanReceiveApi>();
+
+    std::cout << "[titati_canfd_router_node] Waiting for power-on self-test to finish (mode=1 or 2)." << std::endl;
+    router->set_forcedirect_mode(true);
+
+    while (keep_running.load())
+    {
+        if (router->forcedirect_complete())
+        {
+            std::cout << "[titati_canfd_router_node] Router switched to forced-direct relay mode." << std::endl;
+            if (!stay_alive)
+            {
+                break;
+            }
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    }
+
+    if (!router->forcedirect_complete())
+    {
+        std::cerr << "[titati_canfd_router_node] Forced-direct command not acknowledged."
+                  << " Check wiring and rerun after the self-test completes." << std::endl;
+        return 2;
+    }
+
+    if (stay_alive)
+    {
+        std::cout << "[titati_canfd_router_node] Staying alive - press Ctrl+C to exit." << std::endl;
+        while (keep_running.load())
+        {
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
+    }
+
+    std::cout << "[titati_canfd_router_node] Done." << std::endl;
+    return 0;
+}

--- a/rl_sar/src/rl_sar/src/titati_canfd_router_node.cpp
+++ b/rl_sar/src/rl_sar/src/titati_canfd_router_node.cpp
@@ -24,14 +24,15 @@ void signal_handler(int)
 
 void PrintUsage(const char *argv0)
 {
-    std::cout << "Usage: " << argv0 << " [--stay-alive]" << std::endl;
-    std::cout << "  --stay-alive  Keep the program running after the forced-direct command is sent." << std::endl;
+    std::cout << "Usage: " << argv0 << " [--stay-alive|--once]" << std::endl;
+    std::cout << "  --stay-alive  Keep the program running after the forced-direct command is sent (default)." << std::endl;
+    std::cout << "  --once        Exit after switching to forced-direct mode." << std::endl;
 }
 } // namespace
 
 int main(int argc, char **argv)
 {
-    bool stay_alive = false;
+    bool stay_alive = true;
 
     for (int i = 1; i < argc; ++i)
     {
@@ -43,6 +44,10 @@ int main(int argc, char **argv)
         if (std::strcmp(argv[i], "--stay-alive") == 0)
         {
             stay_alive = true;
+        }
+        else if (std::strcmp(argv[i], "--once") == 0)
+        {
+            stay_alive = false;
         }
         else
         {
@@ -61,11 +66,22 @@ int main(int argc, char **argv)
     std::cout << "[titati_canfd_router_node] Waiting for power-on self-test to finish (mode=1 or 2)." << std::endl;
     router->set_forcedirect_mode(true);
 
+    bool announced_switch = false;
+    bool announced_alive = false;
     while (keep_running.load())
     {
         if (router->forcedirect_complete())
         {
-            std::cout << "[titati_canfd_router_node] Router switched to forced-direct relay mode." << std::endl;
+            if (!announced_switch)
+            {
+                std::cout << "[titati_canfd_router_node] Router switched to forced-direct relay mode." << std::endl;
+                announced_switch = true;
+            }
+            if (stay_alive && !announced_alive)
+            {
+                std::cout << "[titati_canfd_router_node] Staying alive - press Ctrl+C to exit." << std::endl;
+                announced_alive = true;
+            }
             if (!stay_alive)
             {
                 break;
@@ -79,15 +95,6 @@ int main(int argc, char **argv)
         std::cerr << "[titati_canfd_router_node] Forced-direct command not acknowledged."
                   << " Check wiring and rerun after the self-test completes." << std::endl;
         return 2;
-    }
-
-    if (stay_alive)
-    {
-        std::cout << "[titati_canfd_router_node] Staying alive - press Ctrl+C to exit." << std::endl;
-        while (keep_running.load())
-        {
-            std::this_thread::sleep_for(std::chrono::seconds(1));
-        }
     }
 
     std::cout << "[titati_canfd_router_node] Done." << std::endl;

--- a/rl_sar/src/rl_sar/test/titati_motor_test.cpp
+++ b/rl_sar/src/rl_sar/test/titati_motor_test.cpp
@@ -12,6 +12,7 @@
 #include <cstring>
 #include <iostream>
 #include <memory>
+#include <optional>
 #include <string>
 #include <thread>
 #include <vector>
@@ -40,27 +41,142 @@ void SignalHandler(int)
     std::exit(0);
 }
 
-std::string ParseVariant(int argc, char **argv)
+struct Options
 {
-    std::string variant = "titati";
+    std::string variant {"titati"};
+    bool use_default_pose {false};
+    std::optional<size_t> single_joint {};
+    double leg_amplitude {0.3};
+    double wheel_amplitude {0.2};
+    double frequency {0.5};
+    double duration {3.0};
+    double hold_time {2.0};
+    double settle_time {0.5};
+    double kp_leg {40.0};
+    double kd_leg {2.0};
+    double kp_wheel {5.0};
+    double kd_wheel {0.5};
+    bool torque_mode {false};
+    double torque_amplitude {5.0};
+    double torque_bias {0.0};
+};
+
+void PrintHelp()
+{
+    std::cout << "Usage: titati_motor_test [options]\n"
+              << "  --robot=<tita|titati>        Select robot variant (default titati)\n"
+              << "  --pose=default               Hold the predefined default pose (otherwise use current pose)\n"
+              << "  --joint=<index>              Only excite the given joint (0-based)\n"
+              << "  --amplitude=<rad>            Leg joint amplitude (alias of --leg-amplitude)\n"
+              << "  --leg-amplitude=<rad>        Motion amplitude for leg joints\n"
+              << "  --wheel-amplitude=<rad>      Motion amplitude for wheel joints\n"
+              << "  --frequency=<hz>             Excitation frequency in Hertz\n"
+              << "  --duration=<sec>             Excitation duration per joint in seconds\n"
+              << "  --kp=<value>                 Proportional gain for leg joints\n"
+              << "  --kd=<value>                 Derivative gain for leg joints\n"
+              << "  --wheel-kp=<value>           Proportional gain for wheel joints\n"
+              << "  --wheel-kd=<value>           Derivative gain for wheel joints\n"
+              << "  --mode=torque                Drive the target joint with a pure torque waveform\n"
+              << "  --torque-amplitude=<Nm>      Sine torque amplitude (torque mode)\n"
+              << "  --torque-bias=<Nm>           Torque offset added to the sine wave\n"
+              << "  --hold-time=<sec>            Duration to stabilise before excitation\n"
+              << "  --settle-time=<sec>          Duration to settle between joints\n"
+              << std::endl;
+}
+
+bool ParseOptions(int argc, char **argv, Options &opts)
+{
     for (int i = 1; i < argc; ++i)
     {
         std::string arg(argv[i]);
+        if (arg == "--help" || arg == "-h")
+        {
+            PrintHelp();
+            return false;
+        }
         if (arg.rfind("--robot=", 0) == 0)
         {
-            variant = arg.substr(std::strlen("--robot="));
+            opts.variant = arg.substr(std::strlen("--robot="));
         }
         else if (arg.rfind("--robot_name=", 0) == 0)
         {
-            variant = arg.substr(std::strlen("--robot_name="));
+            opts.variant = arg.substr(std::strlen("--robot_name="));
+        }
+        else if (arg == "--pose=default")
+        {
+            opts.use_default_pose = true;
+        }
+        else if (arg.rfind("--joint=", 0) == 0)
+        {
+            opts.single_joint = static_cast<size_t>(std::stoul(arg.substr(std::strlen("--joint="))));
+        }
+        else if (arg.rfind("--amplitude=", 0) == 0 || arg.rfind("--leg-amplitude=", 0) == 0)
+        {
+            auto value = std::stod(arg.substr(arg.find('=') + 1));
+            opts.leg_amplitude = value;
+        }
+        else if (arg.rfind("--wheel-amplitude=", 0) == 0)
+        {
+            opts.wheel_amplitude = std::stod(arg.substr(std::strlen("--wheel-amplitude=")));
+        }
+        else if (arg.rfind("--frequency=", 0) == 0)
+        {
+            opts.frequency = std::stod(arg.substr(std::strlen("--frequency=")));
+        }
+        else if (arg.rfind("--duration=", 0) == 0)
+        {
+            opts.duration = std::stod(arg.substr(std::strlen("--duration=")));
+        }
+        else if (arg.rfind("--kp=", 0) == 0)
+        {
+            opts.kp_leg = std::stod(arg.substr(std::strlen("--kp=")));
+        }
+        else if (arg.rfind("--kd=", 0) == 0)
+        {
+            opts.kd_leg = std::stod(arg.substr(std::strlen("--kd=")));
+        }
+        else if (arg.rfind("--wheel-kp=", 0) == 0)
+        {
+            opts.kp_wheel = std::stod(arg.substr(std::strlen("--wheel-kp=")));
+        }
+        else if (arg.rfind("--wheel-kd=", 0) == 0)
+        {
+            opts.kd_wheel = std::stod(arg.substr(std::strlen("--wheel-kd=")));
+        }
+        else if (arg == "--mode=torque" || arg == "--torque-mode")
+        {
+            opts.torque_mode = true;
+        }
+        else if (arg.rfind("--torque-amplitude=", 0) == 0)
+        {
+            opts.torque_amplitude = std::stod(arg.substr(std::strlen("--torque-amplitude=")));
+        }
+        else if (arg.rfind("--torque-bias=", 0) == 0)
+        {
+            opts.torque_bias = std::stod(arg.substr(std::strlen("--torque-bias=")));
+        }
+        else if (arg.rfind("--hold-time=", 0) == 0)
+        {
+            opts.hold_time = std::stod(arg.substr(std::strlen("--hold-time=")));
+        }
+        else if (arg.rfind("--settle-time=", 0) == 0)
+        {
+            opts.settle_time = std::stod(arg.substr(std::strlen("--settle-time=")));
+        }
+        else
+        {
+            std::cout << "[MotorTest] Unknown option: " << arg << std::endl;
+            PrintHelp();
+            return false;
         }
     }
-    if (variant != "tita" && variant != "titati")
+
+    if (opts.variant != "tita" && opts.variant != "titati")
     {
-        std::cout << "[MotorTest] Unknown robot variant '" << variant << "', fallback to titati" << std::endl;
-        variant = "titati";
+        std::cout << "[MotorTest] Unknown robot variant '" << opts.variant << "', fallback to titati" << std::endl;
+        opts.variant = "titati";
     }
-    return variant;
+    return true;
 }
 
 std::vector<double> DefaultPose(const std::string &variant)
@@ -78,13 +194,13 @@ std::vector<double> DefaultPose(const std::string &variant)
             0.00, 0.00, 0.00, 0.00};
 }
 
-std::vector<double> GainVector(size_t dofs, size_t wheel_count)
+std::vector<double> GainVector(size_t dofs, size_t wheel_count, double kp_leg, double kp_wheel)
 {
-    std::vector<double> gains(dofs, 40.0);
+    std::vector<double> gains(dofs, kp_leg);
     size_t leg_dofs = dofs - wheel_count;
     for (size_t i = leg_dofs; i < dofs; ++i)
     {
-        gains[i] = 5.0;
+        gains[i] = kp_wheel;
     }
     return gains;
 }
@@ -144,22 +260,27 @@ void MaintainPose(const std::vector<double> &target,
 
 int main(int argc, char **argv)
 {
-    std::string variant = ParseVariant(argc, argv);
-    g_dofs = (variant == "tita") ? 8 : 16;
-    size_t wheel_count = (variant == "tita") ? 2 : 4;
-    std::vector<double> default_pose = DefaultPose(variant);
-    std::vector<double> kp = GainVector(g_dofs, wheel_count);
-    std::vector<double> kd(g_dofs, 2.0);
+    Options options;
+    if (!ParseOptions(argc, argv, options))
+    {
+        return 0;
+    }
+
+    g_dofs = (options.variant == "tita") ? 8 : 16;
+    size_t wheel_count = (options.variant == "tita") ? 2 : 4;
+    std::vector<double> predefined_pose = DefaultPose(options.variant);
+    std::vector<double> kp = GainVector(g_dofs, wheel_count, options.kp_leg, options.kp_wheel);
+    std::vector<double> kd(g_dofs, options.kd_leg);
     for (size_t i = g_dofs - wheel_count; i < g_dofs; ++i)
     {
-        kd[i] = 0.5;
+        kd[i] = options.kd_wheel;
     }
     g_torque_limits = TorqueLimits(g_dofs, wheel_count);
 
     std::signal(SIGINT, SignalHandler);
     std::signal(SIGTERM, SignalHandler);
 
-    std::cout << "[MotorTest] Initialising tita motors for variant '" << variant << "'" << std::endl;
+    std::cout << "[MotorTest] Initialising tita motors for variant '" << options.variant << "'" << std::endl;
     g_robot = std::make_unique<tita_robot>(g_dofs);
     if (!g_robot->set_motors_sdk(true))
     {
@@ -167,46 +288,99 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    std::vector<double> target = default_pose;
+    std::vector<double> hold_pose = options.use_default_pose ? predefined_pose : g_robot->get_joint_q();
+    if (hold_pose.size() != g_dofs)
+    {
+        hold_pose.resize(g_dofs, 0.0);
+    }
 
     std::vector<double> zeros(g_dofs, 0.0);
     g_robot->set_target_joint_t(zeros);
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
-    std::cout << "[MotorTest] Holding default posture before sweep..." << std::endl;
-    MaintainPose(target, kp, kd, std::chrono::seconds(2));
+    if (options.hold_time > 0.0)
+    {
+        std::cout << "[MotorTest] Stabilising pose for " << options.hold_time << " seconds..." << std::endl;
+        MaintainPose(hold_pose, kp, kd, std::chrono::milliseconds(static_cast<int>(options.hold_time * 1000.0)));
+    }
 
-    const double frequency = 0.5;      // Hz
-    const double duration = 3.0;       // seconds per joint
-    const double leg_amplitude = 0.3;  // radians
-    const double wheel_amplitude = 0.2;
-
-    for (size_t joint = 0; joint < g_dofs; ++joint)
+    auto excite_joint = [&](size_t joint)
     {
         std::cout << "[MotorTest] Exciting joint " << joint << std::endl;
         auto start = std::chrono::steady_clock::now();
+        std::vector<double> target = hold_pose;
+        std::vector<double> torques(g_dofs, 0.0);
         while (true)
         {
             auto now = std::chrono::steady_clock::now();
             double elapsed = std::chrono::duration<double>(now - start).count();
-            if (elapsed >= duration)
+            if (elapsed >= options.duration)
             {
                 break;
             }
-            double amplitude = (joint >= g_dofs - wheel_count) ? wheel_amplitude : leg_amplitude;
-            target[joint] = default_pose[joint] + amplitude * std::sin(2.0 * M_PI * frequency * elapsed);
-            if (!DispatchTorques(target, kp, kd))
+            if (options.torque_mode)
             {
-                std::cerr << "[MotorTest] Warning: torque dispatch failed during excitation." << std::endl;
-                break;
+                torques.assign(g_dofs, 0.0);
+                double cmd = options.torque_bias + options.torque_amplitude * std::sin(2.0 * M_PI * options.frequency * elapsed);
+                if (joint < g_torque_limits.size())
+                {
+                    cmd = std::clamp(cmd, -g_torque_limits[joint], g_torque_limits[joint]);
+                }
+                torques[joint] = cmd;
+                if (!g_robot->set_target_joint_t(torques))
+                {
+                    std::cerr << "[MotorTest] Warning: torque dispatch failed during excitation." << std::endl;
+                    break;
+                }
+            }
+            else
+            {
+                double amplitude = (joint >= g_dofs - wheel_count) ? options.wheel_amplitude : options.leg_amplitude;
+                target[joint] = hold_pose[joint] + amplitude * std::sin(2.0 * M_PI * options.frequency * elapsed);
+                if (!DispatchTorques(target, kp, kd))
+                {
+                    std::cerr << "[MotorTest] Warning: torque dispatch failed during excitation." << std::endl;
+                    break;
+                }
             }
             std::this_thread::sleep_for(std::chrono::milliseconds(5));
         }
-        target[joint] = default_pose[joint];
-        MaintainPose(target, kp, kd, std::chrono::milliseconds(500));
+        if (!options.torque_mode)
+        {
+            target[joint] = hold_pose[joint];
+            if (options.settle_time > 0.0)
+            {
+                MaintainPose(target, kp, kd, std::chrono::milliseconds(static_cast<int>(options.settle_time * 1000.0)));
+            }
+        }
+        else if (options.settle_time > 0.0)
+        {
+            g_robot->set_target_joint_t(zeros);
+            std::this_thread::sleep_for(std::chrono::milliseconds(static_cast<int>(options.settle_time * 1000.0)));
+        }
+    };
+
+    if (options.single_joint)
+    {
+        size_t joint = *options.single_joint;
+        if (joint >= g_dofs)
+        {
+            std::cerr << "[MotorTest] Joint index " << joint << " exceeds available DOFs (" << g_dofs << ")." << std::endl;
+        }
+        else
+        {
+            excite_joint(joint);
+        }
+    }
+    else
+    {
+        for (size_t joint = 0; joint < g_dofs; ++joint)
+        {
+            excite_joint(joint);
+        }
     }
 
-    std::cout << "[MotorTest] Sweep complete. Motors will be disabled." << std::endl;
+    std::cout << "[MotorTest] Test complete. Motors will be disabled." << std::endl;
     SafeShutdown();
     return 0;
 }

--- a/rl_sar/src/rl_sar/test/titati_motor_test.cpp
+++ b/rl_sar/src/rl_sar/test/titati_motor_test.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2024-2025 Ziqi Fan
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "tita_robot/tita_robot.hpp"
+
+#include <chrono>
+#include <cmath>
+#include <csignal>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+std::unique_ptr<tita_robot> g_robot;
+size_t g_dofs = 16;
+
+void SafeShutdown()
+{
+    if (g_robot)
+    {
+        std::vector<double> zero(g_dofs, 0.0);
+        g_robot->set_target_joint_t(zero);
+        g_robot->set_motors_sdk(false);
+        g_robot.reset();
+    }
+}
+
+void SignalHandler(int)
+{
+    SafeShutdown();
+    std::cout << "\n[MotorTest] Stop command received, motors disabled." << std::endl;
+    std::exit(0);
+}
+
+std::string ParseVariant(int argc, char **argv)
+{
+    std::string variant = "titati";
+    for (int i = 1; i < argc; ++i)
+    {
+        std::string arg(argv[i]);
+        if (arg.rfind("--robot=", 0) == 0)
+        {
+            variant = arg.substr(std::strlen("--robot="));
+        }
+        else if (arg.rfind("--robot_name=", 0) == 0)
+        {
+            variant = arg.substr(std::strlen("--robot_name="));
+        }
+    }
+    if (variant != "tita" && variant != "titati")
+    {
+        std::cout << "[MotorTest] Unknown robot variant '" << variant << "', fallback to titati" << std::endl;
+        variant = "titati";
+    }
+    return variant;
+}
+
+std::vector<double> DefaultPose(const std::string &variant)
+{
+    if (variant == "tita")
+    {
+        return {0.00, 0.80, -1.50,
+                0.00, 0.80, -1.50,
+                0.00, 0.00};
+    }
+    return {0.00, 0.40, -0.917,
+            0.00, 0.40, -0.917,
+            0.00, -0.40, 0.917,
+            0.00, -0.40, 0.917,
+            0.00, 0.00, 0.00, 0.00};
+}
+
+std::vector<double> GainVector(size_t dofs, size_t wheel_count)
+{
+    std::vector<double> gains(dofs, 40.0);
+    size_t leg_dofs = dofs - wheel_count;
+    for (size_t i = leg_dofs; i < dofs; ++i)
+    {
+        gains[i] = 5.0;
+    }
+    return gains;
+}
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+    std::string variant = ParseVariant(argc, argv);
+    g_dofs = (variant == "tita") ? 8 : 16;
+    std::vector<double> default_pose = DefaultPose(variant);
+    std::vector<double> kp = GainVector(g_dofs, variant == "tita" ? 2 : 4);
+    std::vector<double> kd(g_dofs, 1.0);
+
+    std::signal(SIGINT, SignalHandler);
+    std::signal(SIGTERM, SignalHandler);
+
+    std::cout << "[MotorTest] Initialising tita motors for variant '" << variant << "'" << std::endl;
+    g_robot = std::make_unique<tita_robot>(g_dofs);
+    if (!g_robot->set_motors_sdk(true))
+    {
+        std::cerr << "[MotorTest] Failed to enter direct control mode. Check CAN-FD setup." << std::endl;
+        return 1;
+    }
+
+    std::vector<double> zeros(g_dofs, 0.0);
+    g_robot->set_target_joint_t(zeros);
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    std::cout << "[MotorTest] Holding default posture before sweep..." << std::endl;
+    g_robot->set_target_joint_mit(default_pose, zeros, kp, kd, zeros);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    const double frequency = 0.5;      // Hz
+    const double duration = 3.0;       // seconds per joint
+    const double leg_amplitude = 0.3;  // radians
+    const double wheel_amplitude = 0.2;
+
+    for (size_t joint = 0; joint < g_dofs; ++joint)
+    {
+        std::cout << "[MotorTest] Exciting joint " << joint << std::endl;
+        auto pose = default_pose;
+        auto start = std::chrono::steady_clock::now();
+        while (true)
+        {
+            auto now = std::chrono::steady_clock::now();
+            double elapsed = std::chrono::duration<double>(now - start).count();
+            if (elapsed >= duration)
+            {
+                break;
+            }
+            double amplitude = (joint >= g_dofs - (variant == "tita" ? 2 : 4)) ? wheel_amplitude : leg_amplitude;
+            pose[joint] = default_pose[joint] + amplitude * std::sin(2.0 * M_PI * frequency * elapsed);
+            std::vector<double> v(g_dofs, 0.0);
+            g_robot->set_target_joint_mit(pose, v, kp, kd, zeros);
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+        g_robot->set_target_joint_mit(default_pose, zeros, kp, kd, zeros);
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
+
+    std::cout << "[MotorTest] Sweep complete. Motors will be disabled." << std::endl;
+    SafeShutdown();
+    return 0;
+}

--- a/rl_sar/src/rl_sar/test/titati_motor_test.cpp
+++ b/rl_sar/src/rl_sar/test/titati_motor_test.cpp
@@ -5,6 +5,7 @@
 
 #include "tita_robot/tita_robot.hpp"
 
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <csignal>
@@ -19,6 +20,7 @@ namespace
 {
 std::unique_ptr<tita_robot> g_robot;
 size_t g_dofs = 16;
+std::vector<double> g_torque_limits;
 
 void SafeShutdown()
 {
@@ -87,15 +89,72 @@ std::vector<double> GainVector(size_t dofs, size_t wheel_count)
     return gains;
 }
 
+std::vector<double> TorqueLimits(size_t dofs, size_t wheel_count)
+{
+    std::vector<double> limits(dofs, 85.0);
+    size_t leg_dofs = dofs - wheel_count;
+    for (size_t i = leg_dofs; i < dofs; ++i)
+    {
+        limits[i] = 7.5;
+    }
+    return limits;
+}
+
+bool DispatchTorques(const std::vector<double> &target,
+                     const std::vector<double> &kp,
+                     const std::vector<double> &kd)
+{
+    auto q = g_robot->get_joint_q();
+    auto dq = g_robot->get_joint_v();
+    std::vector<double> tau(g_dofs, 0.0);
+
+    for (size_t i = 0; i < g_dofs; ++i)
+    {
+        double err = target[i] - q[i];
+        double derr = -dq[i];
+        double cmd = kp[i] * err + kd[i] * derr;
+        if (i < g_torque_limits.size())
+        {
+            cmd = std::clamp(cmd, -g_torque_limits[i], g_torque_limits[i]);
+        }
+        tau[i] = cmd;
+    }
+    return g_robot->set_target_joint_t(tau);
+}
+
+void MaintainPose(const std::vector<double> &target,
+                  const std::vector<double> &kp,
+                  const std::vector<double> &kd,
+                  std::chrono::milliseconds duration)
+{
+    auto deadline = std::chrono::steady_clock::now() + duration;
+    bool warned = false;
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+        if (!DispatchTorques(target, kp, kd) && !warned)
+        {
+            std::cerr << "[MotorTest] Warning: failed to send torque command." << std::endl;
+            warned = true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+}
+
 } // namespace
 
 int main(int argc, char **argv)
 {
     std::string variant = ParseVariant(argc, argv);
     g_dofs = (variant == "tita") ? 8 : 16;
+    size_t wheel_count = (variant == "tita") ? 2 : 4;
     std::vector<double> default_pose = DefaultPose(variant);
-    std::vector<double> kp = GainVector(g_dofs, variant == "tita" ? 2 : 4);
-    std::vector<double> kd(g_dofs, 1.0);
+    std::vector<double> kp = GainVector(g_dofs, wheel_count);
+    std::vector<double> kd(g_dofs, 2.0);
+    for (size_t i = g_dofs - wheel_count; i < g_dofs; ++i)
+    {
+        kd[i] = 0.5;
+    }
+    g_torque_limits = TorqueLimits(g_dofs, wheel_count);
 
     std::signal(SIGINT, SignalHandler);
     std::signal(SIGTERM, SignalHandler);
@@ -108,13 +167,14 @@ int main(int argc, char **argv)
         return 1;
     }
 
+    std::vector<double> target = default_pose;
+
     std::vector<double> zeros(g_dofs, 0.0);
     g_robot->set_target_joint_t(zeros);
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
     std::cout << "[MotorTest] Holding default posture before sweep..." << std::endl;
-    g_robot->set_target_joint_mit(default_pose, zeros, kp, kd, zeros);
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    MaintainPose(target, kp, kd, std::chrono::seconds(2));
 
     const double frequency = 0.5;      // Hz
     const double duration = 3.0;       // seconds per joint
@@ -124,7 +184,6 @@ int main(int argc, char **argv)
     for (size_t joint = 0; joint < g_dofs; ++joint)
     {
         std::cout << "[MotorTest] Exciting joint " << joint << std::endl;
-        auto pose = default_pose;
         auto start = std::chrono::steady_clock::now();
         while (true)
         {
@@ -134,14 +193,17 @@ int main(int argc, char **argv)
             {
                 break;
             }
-            double amplitude = (joint >= g_dofs - (variant == "tita" ? 2 : 4)) ? wheel_amplitude : leg_amplitude;
-            pose[joint] = default_pose[joint] + amplitude * std::sin(2.0 * M_PI * frequency * elapsed);
-            std::vector<double> v(g_dofs, 0.0);
-            g_robot->set_target_joint_mit(pose, v, kp, kd, zeros);
+            double amplitude = (joint >= g_dofs - wheel_count) ? wheel_amplitude : leg_amplitude;
+            target[joint] = default_pose[joint] + amplitude * std::sin(2.0 * M_PI * frequency * elapsed);
+            if (!DispatchTorques(target, kp, kd))
+            {
+                std::cerr << "[MotorTest] Warning: torque dispatch failed during excitation." << std::endl;
+                break;
+            }
             std::this_thread::sleep_for(std::chrono::milliseconds(5));
         }
-        g_robot->set_target_joint_mit(default_pose, zeros, kp, kd, zeros);
-        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        target[joint] = default_pose[joint];
+        MaintainPose(target, kp, kd, std::chrono::milliseconds(500));
     }
 
     std::cout << "[MotorTest] Sweep complete. Motors will be disabled." << std::endl;


### PR DESCRIPTION
## Summary
- integrate the Direct Drive CAN hardware stack inside rl_sar and expose a new rl_real_tita executable for both Tita and Titati variants
- add a standalone titati_motor_test utility plus third-party CAN helpers to validate 16-actuator connectivity before running RL
- switch the build to C++17, introduce per-robot build toggles, and update English/Chinese docs with master/slave wiring, build, and run instructions

## Testing
- `cmake -S rl_sar/src/rl_sar -B rl_sar/cmake_build -DUSE_CMAKE=ON` *(fails: Torch is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d11702ad008321a563de1372da10fc