### PR TITLE
Reorder Titati MIT commands to follow joint mapping

### DIFF
--- a/rl_sar/src/rl_sar/include/rl_real_titati.hpp
+++ b/rl_sar/src/rl_sar/include/rl_real_titati.hpp
@@ -58,12 +58,16 @@ private:
     std::vector<double> joint_positions_;
     std::vector<double> joint_velocities_;
     std::vector<double> joint_torques_;
+    std::vector<double> last_hw_positions_;
+    std::vector<double> last_hw_velocities_;
+    std::vector<double> last_hw_torques_;
 
     std::uint64_t ensure_sdk_skip_count_{0};
     std::uint64_t ensure_sdk_success_count_{0};
     std::uint64_t mit_send_fail_count_{0};
     std::uint64_t mit_send_success_count_{0};
     bool invalid_joint_mapping_reported_{false};
+    std::uint64_t state_update_count_{0};
 
 #if defined(USE_ROS1) && defined(USE_ROS)
     geometry_msgs::Twist cmd_vel;

--- a/rl_sar/src/rl_sar/include/rl_real_titati.hpp
+++ b/rl_sar/src/rl_sar/include/rl_real_titati.hpp
@@ -20,6 +20,7 @@
 #include <memory>
 #include <vector>
 #include <chrono>
+#include <cstdint>
 
 #if defined(USE_ROS1) && defined(USE_ROS)
 #include <ros/ros.h>
@@ -57,6 +58,12 @@ private:
     std::vector<double> joint_positions_;
     std::vector<double> joint_velocities_;
     std::vector<double> joint_torques_;
+
+    std::uint64_t ensure_sdk_skip_count_{0};
+    std::uint64_t ensure_sdk_success_count_{0};
+    std::uint64_t mit_send_fail_count_{0};
+    std::uint64_t mit_send_success_count_{0};
+    bool invalid_joint_mapping_reported_{false};
 
 #if defined(USE_ROS1) && defined(USE_ROS)
     geometry_msgs::Twist cmd_vel;

--- a/rl_sar/src/rl_sar/src/rl_real_titati.cpp
+++ b/rl_sar/src/rl_sar/src/rl_real_titati.cpp
@@ -6,6 +6,8 @@
 #include "rl_real_titati.hpp"
 
 #include <iostream>
+#include <iomanip>
+#include <algorithm>
 
 RL_Real::RL_Real()
 #if defined(USE_ROS2) && defined(USE_ROS)
@@ -126,34 +128,110 @@ void RL_Real::SetCommand(const RobotCommand<double> *command)
 {
     if (!EnsureMotorsSdkMode())
     {
+        ++ensure_sdk_skip_count_;
+        if (ensure_sdk_skip_count_ <= 5 || ensure_sdk_skip_count_ % 100 == 0)
+        {
+            std::cout << LOGGER::WARNING
+                      << "SetCommand skipped because motors are not in SDK mode."
+                      << " skip_count=" << ensure_sdk_skip_count_
+                      << " last_retry_elapsed_ms="
+                      << std::chrono::duration_cast<std::chrono::milliseconds>(
+                             std::chrono::steady_clock::now() - last_sdk_retry_)
+                             .count()
+                      << std::endl;
+        }
         return;
     }
 
-    std::vector<double> q;
-    std::vector<double> v;
-    std::vector<double> kp;
-    std::vector<double> kd;
-    std::vector<double> tau;
-    q.reserve(this->params.num_of_dofs);
-    v.reserve(this->params.num_of_dofs);
-    kp.reserve(this->params.num_of_dofs);
-    kd.reserve(this->params.num_of_dofs);
-    tau.reserve(this->params.num_of_dofs);
-
-    for (int i = 0; i < this->params.num_of_dofs; ++i)
+    if (ensure_sdk_skip_count_ > 0)
     {
-        q.push_back(command->motor_command.q[i]);
-        v.push_back(command->motor_command.dq[i]);
-        kp.push_back(command->motor_command.kp[i]);
-        kd.push_back(command->motor_command.kd[i]);
-        tau.push_back(command->motor_command.tau[i]);
+        std::cout << LOGGER::INFO
+                  << "SetCommand resumed after SDK mode was restored. skipped_frames="
+                  << ensure_sdk_skip_count_ << std::endl;
+        ensure_sdk_skip_count_ = 0;
     }
 
-    if (!robot_->set_target_joint_mit(q, v, kp, kd, tau) && motors_sdk_enabled_)
+    ++ensure_sdk_success_count_;
+
+    const auto num_dofs = this->params.num_of_dofs;
+    std::vector<double> q(num_dofs, 0.0);
+    std::vector<double> v(num_dofs, 0.0);
+    std::vector<double> kp(num_dofs, 0.0);
+    std::vector<double> kd(num_dofs, 0.0);
+    std::vector<double> tau(num_dofs, 0.0);
+
+    const bool has_valid_mapping =
+        static_cast<std::size_t>(num_dofs) == this->params.joint_mapping.size();
+    if (!has_valid_mapping && !invalid_joint_mapping_reported_)
     {
+        std::cout << LOGGER::WARNING
+                  << "Joint mapping size (" << this->params.joint_mapping.size()
+                  << ") does not match number of dofs (" << num_dofs
+                  << "). Falling back to identity mapping." << std::endl;
+        invalid_joint_mapping_reported_ = true;
+    }
+
+    for (int i = 0; i < num_dofs; ++i)
+    {
+        int hw_index = has_valid_mapping ? this->params.joint_mapping[i] : i;
+        if (hw_index < 0 || hw_index >= num_dofs)
+        {
+            if (!invalid_joint_mapping_reported_)
+            {
+                std::cout << LOGGER::WARNING
+                          << "Joint mapping index " << hw_index
+                          << " is out of range for dof count " << num_dofs
+                          << ". Ignoring this entry." << std::endl;
+                invalid_joint_mapping_reported_ = true;
+            }
+            continue;
+        }
+
+        q[hw_index] = command->motor_command.q[i];
+        v[hw_index] = command->motor_command.dq[i];
+        kp[hw_index] = command->motor_command.kp[i];
+        kd[hw_index] = command->motor_command.kd[i];
+        tau[hw_index] = command->motor_command.tau[i];
+    }
+
+    const bool mit_result = robot_->set_target_joint_mit(q, v, kp, kd, tau);
+    if (!mit_result && motors_sdk_enabled_)
+    {
+        ++mit_send_fail_count_;
         motors_sdk_enabled_ = false;
         last_sdk_retry_ = std::chrono::steady_clock::now();
         std::cout << LOGGER::WARNING << "Failed to send MIT command to Titati motors. Retrying SDK handshake." << std::endl;
+        if (mit_send_fail_count_ <= 5 || mit_send_fail_count_ % 50 == 0)
+        {
+            std::cout << LOGGER::WARNING
+                      << "Last MIT command snapshot (first 6 joints):";
+            for (int i = 0; i < std::min<int>(6, this->params.num_of_dofs); ++i)
+            {
+                std::cout << " [" << i
+                          << ": q=" << std::fixed << std::setprecision(3) << q[i]
+                          << ", dq=" << v[i]
+                          << ", kp=" << kp[i]
+                          << ", kd=" << kd[i]
+                          << ", tau=" << tau[i]
+                          << "]";
+            }
+            std::cout << std::endl;
+        }
+    }
+    else if (mit_result)
+    {
+        ++mit_send_success_count_;
+        if (mit_send_success_count_ <= 5 || mit_send_success_count_ % 200 == 0)
+        {
+            std::cout << LOGGER::DEBUG
+                      << "MIT command sent successfully. success_count=" << mit_send_success_count_;
+            std::cout << " first_joint=[q=" << std::fixed << std::setprecision(3) << q[0]
+                      << ", dq=" << v[0]
+                      << ", kp=" << kp[0]
+                      << ", kd=" << kd[0]
+                      << ", tau=" << tau[0]
+                      << "]" << std::endl;
+        }
     }
 }
 
@@ -161,6 +239,12 @@ bool RL_Real::EnsureMotorsSdkMode()
 {
     if (motors_sdk_enabled_)
     {
+        if (ensure_sdk_success_count_ <= 5 || ensure_sdk_success_count_ % 200 == 0)
+        {
+            std::cout << LOGGER::DEBUG
+                      << "EnsureMotorsSdkMode OK. success_count=" << ensure_sdk_success_count_ + 1
+                      << " motors_sdk_enabled=" << motors_sdk_enabled_ << std::endl;
+        }
         return true;
     }
 
@@ -175,12 +259,16 @@ bool RL_Real::EnsureMotorsSdkMode()
     if (robot_->set_motors_sdk(true))
     {
         motors_sdk_enabled_ = true;
+        ++ensure_sdk_success_count_;
         std::cout << LOGGER::INFO << "Titati motors switched to SDK control mode." << std::endl;
         robot_->set_target_joint_t(std::vector<double>(this->params.num_of_dofs, 0.0));
         return true;
     }
 
-    std::cout << LOGGER::WARNING << "Retrying to switch Titati motors to SDK control mode..." << std::endl;
+    std::cout << LOGGER::WARNING
+              << "Retrying to switch Titati motors to SDK control mode... retry_interval_ms="
+              << std::chrono::duration_cast<std::chrono::milliseconds>(kRetryInterval).count()
+              << std::endl;
     return false;
 }
 

--- a/rl_sar/src/rl_sar/src/rl_real_titati.cpp
+++ b/rl_sar/src/rl_sar/src/rl_real_titati.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <iomanip>
 #include <algorithm>
+#include <limits>
 
 RL_Real::RL_Real()
 #if defined(USE_ROS2) && defined(USE_ROS)
@@ -59,6 +60,9 @@ RL_Real::RL_Real()
     joint_positions_.assign(this->params.num_of_dofs, 0.0);
     joint_velocities_.assign(this->params.num_of_dofs, 0.0);
     joint_torques_.assign(this->params.num_of_dofs, 0.0);
+    last_hw_positions_.assign(this->params.num_of_dofs, 0.0);
+    last_hw_velocities_.assign(this->params.num_of_dofs, 0.0);
+    last_hw_torques_.assign(this->params.num_of_dofs, 0.0);
 
     this->InitOutputs();
     this->InitControl();
@@ -95,6 +99,13 @@ void RL_Real::GetState(RobotState<double> *state)
     auto v = robot_->get_joint_v();
     auto tau = robot_->get_joint_t();
 
+    last_hw_positions_ = q;
+    last_hw_velocities_ = v;
+    last_hw_torques_ = tau;
+
+    ++state_update_count_;
+    const bool should_log_feedback = state_update_count_ <= 5 || state_update_count_ % 200 == 0;
+
     for (int i = 0; i < this->params.num_of_dofs; ++i)
     {
         joint_positions_[i] = q[this->params.joint_mapping[i]];
@@ -103,6 +114,39 @@ void RL_Real::GetState(RobotState<double> *state)
         state->motor_state.q[i] = joint_positions_[i];
         state->motor_state.dq[i] = joint_velocities_[i];
         state->motor_state.tau_est[i] = joint_torques_[i];
+    }
+
+    if (should_log_feedback)
+    {
+        std::cout << LOGGER::DEBUG
+                  << "Hardware feedback snapshot. count=" << state_update_count_;
+        for (int idx : {0, 1, 2, 3, 4, 5})
+        {
+            if (idx >= static_cast<int>(q.size()))
+            {
+                break;
+            }
+            std::cout << " [hw " << idx
+                      << ": q=" << std::fixed << std::setprecision(3) << q[idx]
+                      << ", dq=" << v[idx]
+                      << ", tau=" << tau[idx]
+                      << "]";
+        }
+        std::cout << std::endl;
+        std::cout << LOGGER::DEBUG << "RL-order feedback q:";
+        for (int idx : {0, 1, 2, 3, 4, 5})
+        {
+            if (idx >= static_cast<int>(state->motor_state.q.size()))
+            {
+                break;
+            }
+            std::cout << " [" << idx
+                      << ": q=" << std::fixed << std::setprecision(3) << state->motor_state.q[idx]
+                      << ", dq=" << state->motor_state.dq[idx]
+                      << ", tau=" << state->motor_state.tau_est[idx]
+                      << "]";
+        }
+        std::cout << std::endl;
     }
 
     auto quat = robot_->get_imu_quaternion();
@@ -216,6 +260,23 @@ void RL_Real::SetCommand(const RobotCommand<double> *command)
                           << "]";
             }
             std::cout << std::endl;
+            std::cout << LOGGER::WARNING << "Hardware feedback vs command:";
+            for (int idx : {0, 1, 2, 3, 4, 5})
+            {
+                if (idx >= static_cast<int>(q.size()))
+                {
+                    break;
+                }
+                const double measured = idx < static_cast<int>(last_hw_positions_.size())
+                                            ? last_hw_positions_[idx]
+                                            : std::numeric_limits<double>::quiet_NaN();
+                std::cout << " [hw " << idx
+                          << ": tgt=" << std::fixed << std::setprecision(3) << q[idx]
+                          << ", meas=" << measured
+                          << ", err=" << (q[idx] - measured)
+                          << "]";
+            }
+            std::cout << std::endl;
         }
     }
     else if (mit_result)
@@ -231,6 +292,49 @@ void RL_Real::SetCommand(const RobotCommand<double> *command)
                       << ", kd=" << kd[0]
                       << ", tau=" << tau[0]
                       << "]" << std::endl;
+            std::cout << LOGGER::DEBUG << "MIT targets vs feedback (hw order):";
+            for (int idx : {0, 1, 2, 3, 4, 5})
+            {
+                if (idx >= static_cast<int>(q.size()))
+                {
+                    break;
+                }
+                const double measured = idx < static_cast<int>(last_hw_positions_.size())
+                                            ? last_hw_positions_[idx]
+                                            : std::numeric_limits<double>::quiet_NaN();
+                const double measured_vel = idx < static_cast<int>(last_hw_velocities_.size())
+                                                 ? last_hw_velocities_[idx]
+                                                 : std::numeric_limits<double>::quiet_NaN();
+                const double measured_tau = idx < static_cast<int>(last_hw_torques_.size())
+                                                 ? last_hw_torques_[idx]
+                                                 : std::numeric_limits<double>::quiet_NaN();
+                std::cout << " [hw " << idx
+                          << ": tgt_q=" << std::fixed << std::setprecision(3) << q[idx]
+                          << ", meas_q=" << measured
+                          << ", err_q=" << (q[idx] - measured)
+                          << ", tgt_dq=" << v[idx]
+                          << ", meas_dq=" << measured_vel
+                          << ", tgt_tau=" << tau[idx]
+                          << ", meas_tau=" << measured_tau
+                          << "]";
+            }
+            std::cout << std::endl;
+            std::cout << LOGGER::DEBUG << "MIT command (RL order snapshot):";
+            for (int idx : {0, 1, 2, 3, 4, 5})
+            {
+                if (idx >= static_cast<int>(command->motor_command.q.size()))
+                {
+                    break;
+                }
+                std::cout << " [" << idx
+                          << ": q=" << std::fixed << std::setprecision(3) << command->motor_command.q[idx]
+                          << ", dq=" << command->motor_command.dq[idx]
+                          << ", kp=" << command->motor_command.kp[idx]
+                          << ", kd=" << command->motor_command.kd[idx]
+                          << ", tau=" << command->motor_command.tau[idx]
+                          << "]";
+            }
+            std::cout << std::endl;
         }
     }
 }

--- a/rl_sar/src/rl_sar/src/test_titati_motors.cpp
+++ b/rl_sar/src/rl_sar/src/test_titati_motors.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <chrono>
 #include <iostream>
+#include <iomanip>
 #include <limits>
 #include <sstream>
 #include <string>
@@ -12,6 +13,9 @@
 namespace
 {
 constexpr std::size_t kNumMotors = 16;
+constexpr double kHoldKp = 20.0;
+constexpr double kHoldKd = 1.0;
+constexpr std::chrono::milliseconds kCommandPeriod{5};
 void PrintState(const tita_robot &robot)
 {
     auto positions = robot.get_joint_q();
@@ -41,10 +45,12 @@ int main()
 
     std::cout << "Titati motor test utility" << std::endl;
     std::cout << "Commands:\n"
-              << "  <index> <torque>  - set torque (Nm) on motor index 0-15\n"
-              << "  read              - print current joint states\n"
-              << "  zero              - zero all joint torques\n"
-              << "  exit              - stop test and restore MCU control\n";
+              << "  <index> <torque>        - set torque (Nm) on motor index 0-15\n"
+              << "  mit <index> <pos> [kp] [kd] [vel] [tau] [hold_ms]" << std::endl
+              << "                        - single joint MIT test (rad, rad/s, Nm, ms)\n"
+              << "  read                    - print current joint states\n"
+              << "  zero                    - zero all joint torques\n"
+              << "  exit                    - stop test and restore MCU control\n";
 
     std::vector<double> torques(kNumMotors, 0.0);
     std::string line;
@@ -69,6 +75,126 @@ int main()
             std::fill(torques.begin(), torques.end(), 0.0);
             robot.set_target_joint_t(torques);
             std::cout << "All torques cleared." << std::endl;
+            continue;
+        }
+
+        if (command == "mit")
+        {
+            std::size_t motor_index;
+            double target_position;
+            if (!(iss >> motor_index >> target_position))
+            {
+                std::cerr << "[WARNING] Usage: mit <index> <pos> [kp] [kd] [vel] [tau]" << std::endl;
+                continue;
+            }
+
+            if (motor_index >= kNumMotors)
+            {
+                std::cerr << "[WARNING] Motor index out of range. Expected 0-" << kNumMotors - 1 << std::endl;
+                continue;
+            }
+
+            double kp_value = 50.0;
+            double kd_value = 5.0;
+            double velocity_value = 0.0;
+            double torque_value = 0.0;
+            int hold_duration_ms = 1500;
+
+            std::vector<double> optional_values;
+            double parsed_optional = 0.0;
+            while (iss >> parsed_optional)
+            {
+                optional_values.push_back(parsed_optional);
+            }
+
+            if (!optional_values.empty())
+            {
+                kp_value = optional_values[0];
+            }
+            if (optional_values.size() > 1)
+            {
+                kd_value = optional_values[1];
+            }
+            if (optional_values.size() > 2)
+            {
+                velocity_value = optional_values[2];
+            }
+            if (optional_values.size() > 3)
+            {
+                torque_value = optional_values[3];
+            }
+            if (optional_values.size() > 4)
+            {
+                hold_duration_ms = static_cast<int>(optional_values[4]);
+            }
+
+            if (hold_duration_ms < 0)
+            {
+                hold_duration_ms = 0;
+            }
+
+            auto measured_positions = robot.get_joint_q();
+
+            auto q_targets = measured_positions;
+            auto v_targets = std::vector<double>(kNumMotors, 0.0);
+            auto kp_targets = std::vector<double>(kNumMotors, kHoldKp);
+            auto kd_targets = std::vector<double>(kNumMotors, kHoldKd);
+            auto tau_targets = std::vector<double>(kNumMotors, 0.0);
+
+            q_targets[motor_index] = target_position;
+            v_targets[motor_index] = velocity_value;
+            kp_targets[motor_index] = kp_value;
+            kd_targets[motor_index] = kd_value;
+            tau_targets[motor_index] = torque_value;
+
+            const auto start = std::chrono::steady_clock::now();
+            std::size_t successful_frames = 0;
+            std::size_t failed_frames = 0;
+
+            while (true)
+            {
+                const bool ok = robot.set_target_joint_mit(q_targets, v_targets, kp_targets, kd_targets, tau_targets);
+                if (!ok)
+                {
+                    ++failed_frames;
+                    std::cerr << "[ERROR] Failed to send MIT command frame." << std::endl;
+                    break;
+                }
+
+                ++successful_frames;
+
+                if (hold_duration_ms == 0)
+                {
+                    break;
+                }
+
+                const auto elapsed = std::chrono::steady_clock::now() - start;
+                if (elapsed >= std::chrono::milliseconds(hold_duration_ms))
+                {
+                    break;
+                }
+
+                std::this_thread::sleep_for(kCommandPeriod);
+            }
+
+            auto final_positions = robot.get_joint_q();
+            const double initial_position = measured_positions[motor_index];
+            const double final_position = final_positions[motor_index];
+
+            std::cout << std::fixed << std::setprecision(4)
+                      << "Applied MIT target to motor " << motor_index
+                      << ": q_target=" << target_position
+                      << " rad, kp=" << kp_value
+                      << ", kd=" << kd_value
+                      << ", vel=" << velocity_value
+                      << " rad/s, tau=" << torque_value
+                      << " Nm, hold=" << hold_duration_ms << " ms" << std::endl;
+            std::cout << "  Position feedback: initial=" << initial_position
+                      << " rad, final=" << final_position
+                      << " rad, delta=" << (final_position - initial_position) << " rad" << std::endl;
+            std::cout << "  MIT frames sent: success=" << successful_frames
+                      << ", failed=" << failed_frames << std::endl;
+
             continue;
         }
 


### PR DESCRIPTION
## Summary
- store a joint-mapping warning flag on the Titati real-robot runner so we can report invalid mappings only once
- reorder outgoing MIT command vectors according to the configured joint mapping (with graceful fallbacks) before streaming them to the CAN bus

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d39586f44483218a490679fe40a6bc