### PR TITLE
Handle SIGINT to restore Titati motors

### DIFF
--- a/rl_sar/src/rl_sar/src/rl_real_titati.cpp
+++ b/rl_sar/src/rl_sar/src/rl_real_titati.cpp
@@ -5,7 +5,26 @@
 
 #include "rl_real_titati.hpp"
 
+#include <atomic>
+#include <csignal>
 #include <iostream>
+#include <thread>
+#include <chrono>
+
+namespace
+{
+std::atomic_bool g_shutdown_requested{false};
+
+void HandleSignal(int)
+{
+    g_shutdown_requested.store(true);
+#if defined(USE_ROS1) && defined(USE_ROS)
+    ros::shutdown();
+#elif defined(USE_ROS2) && defined(USE_ROS)
+    rclcpp::shutdown();
+#endif
+}
+} // namespace
 
 RL_Real::RL_Real()
 #if defined(USE_ROS2) && defined(USE_ROS)
@@ -79,6 +98,7 @@ RL_Real::~RL_Real()
     {
         robot_->set_target_joint_t(std::vector<double>(this->params.num_of_dofs, 0.0));
         robot_->set_motors_sdk(false);
+        motors_sdk_enabled_ = false;
     }
 
     this->loop_keyboard->shutdown();
@@ -315,28 +335,40 @@ void RL_Real::CmdvelCallback(
 }
 #endif
 
-#if defined(USE_ROS1) && defined(USE_ROS)
-void signalHandler(int signum)
-{
-    ros::shutdown();
-    exit(0);
-}
-#endif
-
 int main(int argc, char **argv)
 {
 #if defined(USE_ROS1) && defined(USE_ROS)
-    signal(SIGINT, signalHandler);
+    std::signal(SIGINT, HandleSignal);
+    std::signal(SIGTERM, HandleSignal);
     ros::init(argc, argv, "rl_sar");
     RL_Real rl_sar;
     ros::spin();
 #elif defined(USE_ROS2) && defined(USE_ROS)
+    std::signal(SIGINT, HandleSignal);
+    std::signal(SIGTERM, HandleSignal);
     rclcpp::init(argc, argv);
-    rclcpp::spin(std::make_shared<RL_Real>());
-    rclcpp::shutdown();
+    auto node = std::make_shared<RL_Real>();
+    while (rclcpp::ok() && !g_shutdown_requested.load())
+    {
+        rclcpp::spin_some(node);
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
 #elif defined(USE_CMAKE) || !defined(USE_ROS)
+    std::signal(SIGINT, HandleSignal);
+    std::signal(SIGTERM, HandleSignal);
     RL_Real rl_sar;
-    while (1) { sleep(10); }
+    while (!g_shutdown_requested.load())
+    {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
 #endif
+    if (!g_shutdown_requested.load())
+    {
+#if defined(USE_ROS1) && defined(USE_ROS)
+        ros::shutdown();
+#elif defined(USE_ROS2) && defined(USE_ROS)
+        rclcpp::shutdown();
+#endif
+    }
     return 0;
 }

--- a/rl_sar/src/rl_sar/src/test_titati_motors.cpp
+++ b/rl_sar/src/rl_sar/src/test_titati_motors.cpp
@@ -1,5 +1,7 @@
 #include <algorithm>
+#include <atomic>
 #include <chrono>
+#include <csignal>
 #include <iostream>
 #include <limits>
 #include <sstream>
@@ -12,6 +14,13 @@
 namespace
 {
 constexpr std::size_t kNumMotors = 16;
+std::atomic_bool g_shutdown_requested{false};
+
+void SignalHandler(int)
+{
+    g_shutdown_requested.store(true);
+}
+
 void PrintState(const tita_robot &robot)
 {
     auto positions = robot.get_joint_q();
@@ -32,6 +41,9 @@ void PrintState(const tita_robot &robot)
 
 int main()
 {
+    std::signal(SIGINT, SignalHandler);
+    std::signal(SIGTERM, SignalHandler);
+
     tita_robot robot(kNumMotors);
     if (!robot.set_motors_sdk(true))
     {
@@ -51,8 +63,24 @@ int main()
     std::vector<double> torques(kNumMotors, 0.0);
     std::string line;
     bool running = true;
-    while (running && std::getline(std::cin, line))
+    while (running && !g_shutdown_requested.load())
     {
+        if (!std::getline(std::cin, line))
+        {
+            if (g_shutdown_requested.load())
+            {
+                break;
+            }
+
+            if (std::cin.eof())
+            {
+                break;
+            }
+
+            std::cin.clear();
+            continue;
+        }
+
         std::istringstream iss(line);
         std::string command;
         if (!(iss >> command))
@@ -178,10 +206,22 @@ int main()
         }
 
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+        if (g_shutdown_requested.load())
+        {
+            break;
+        }
     }
 
     robot.set_target_joint_t(std::vector<double>(kNumMotors, 0.0));
     robot.set_motors_sdk(false);
-    std::cout << "Test finished." << std::endl;
+    if (g_shutdown_requested.load())
+    {
+        std::cout << "\n[INFO] Interrupt received. Motors restored to MCU control." << std::endl;
+    }
+    else
+    {
+        std::cout << "Test finished." << std::endl;
+    }
     return 0;
 }


### PR DESCRIPTION
## Summary
- add SIGINT/SIGTERM handlers to test_titati_motors so the SDK session is closed and torques are cleared even on Ctrl+C
- install shared shutdown handling for rl_real_titati to break its main loop cleanly and let the destructor restore MCU control
- ensure rl_real_titati destructor marks the SDK flag as disabled after cleanup

## Testing
- cmake --build rl_sar/cmake_build *(fails: /workspace/test/rl_sar/cmake_build is not a directory)*

------
https://chatgpt.com/codex/tasks/task_e_68d3b1fdbb94832181d3d03fe3492f3c