### PR TITLE
Handle SIGINT to restore Titati motors

### DIFF
--- a/rl_sar/src/rl_sar/src/rl_real_titati.cpp
+++ b/rl_sar/src/rl_sar/src/rl_real_titati.cpp
@@ -5,7 +5,20 @@
 
 #include "rl_real_titati.hpp"
 
+#include <chrono>
+#include <csignal>
 #include <iostream>
+#include <thread>
+
+namespace
+{
+volatile std::sig_atomic_t g_shutdown_requested = 0;
+
+void HandleSignal(int)
+{
+    g_shutdown_requested = 1;
+}
+} // namespace
 
 RL_Real::RL_Real()
 #if defined(USE_ROS2) && defined(USE_ROS)
@@ -335,8 +348,14 @@ int main(int argc, char **argv)
     rclcpp::spin(std::make_shared<RL_Real>());
     rclcpp::shutdown();
 #elif defined(USE_CMAKE) || !defined(USE_ROS)
+    std::signal(SIGINT, HandleSignal);
+    std::signal(SIGTERM, HandleSignal);
+
     RL_Real rl_sar;
-    while (1) { sleep(10); }
+    while (!g_shutdown_requested)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
 #endif
     return 0;
 }

--- a/rl_sar/src/rl_sar/src/test_titati_motors.cpp
+++ b/rl_sar/src/rl_sar/src/test_titati_motors.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <chrono>
+#include <csignal>
 #include <iostream>
 #include <limits>
 #include <sstream>
@@ -12,6 +13,12 @@
 namespace
 {
 constexpr std::size_t kNumMotors = 16;
+volatile std::sig_atomic_t g_shutdown_requested = 0;
+
+void HandleSignal(int)
+{
+    g_shutdown_requested = 1;
+}
 void PrintState(const tita_robot &robot)
 {
     auto positions = robot.get_joint_q();
@@ -39,6 +46,9 @@ int main()
         return 1;
     }
 
+    std::signal(SIGINT, HandleSignal);
+    std::signal(SIGTERM, HandleSignal);
+
     std::cout << "Titati motor test utility" << std::endl;
     std::cout << "Commands:\n"
               << "  <index> <torque>        - set torque (Nm) on motor index 0-15\n"
@@ -51,8 +61,18 @@ int main()
     std::vector<double> torques(kNumMotors, 0.0);
     std::string line;
     bool running = true;
-    while (running && std::getline(std::cin, line))
+    while (running)
     {
+        if (g_shutdown_requested)
+        {
+            break;
+        }
+
+        if (!std::getline(std::cin, line))
+        {
+            break;
+        }
+
         std::istringstream iss(line);
         std::string command;
         if (!(iss >> command))


### PR DESCRIPTION
## Summary
- add SIGINT/SIGTERM handling in the Titati motor test utility so cleanup runs before exit
- install signal handlers in the rl_real_titati entry point so the control loops release the motors when the process stops

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3b9ab4d0883218131ed998ad326d5