### PR TITLE
Fix Titati command mapping for hardware order

### DIFF
--- a/rl_sar/src/rl_sar/include/rl_real_titati.hpp
+++ b/rl_sar/src/rl_sar/include/rl_real_titati.hpp
@@ -58,6 +58,12 @@ private:
     std::vector<double> joint_velocities_;
     std::vector<double> joint_torques_;
 
+    bool mapping_warning_printed_{false};
+    bool state_mapping_warning_printed_{false};
+    bool command_log_printed_{false};
+    int sdk_fail_log_count_{0};
+    int mit_fail_log_count_{0};
+
 #if defined(USE_ROS1) && defined(USE_ROS)
     geometry_msgs::Twist cmd_vel;
     ros::Subscriber cmd_vel_subscriber;

--- a/rl_sar/src/rl_sar/include/rl_real_titati.hpp
+++ b/rl_sar/src/rl_sar/include/rl_real_titati.hpp
@@ -60,6 +60,7 @@ private:
 
     bool mapping_warning_printed_{false};
     bool state_mapping_warning_printed_{false};
+    bool state_signal_size_warning_printed_{false};
     bool command_log_printed_{false};
     int sdk_fail_log_count_{0};
     int mit_fail_log_count_{0};

--- a/rl_sar/src/rl_sar/src/rl_real_titati.cpp
+++ b/rl_sar/src/rl_sar/src/rl_real_titati.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <sstream>
 
 RL_Real::RL_Real()
 #if defined(USE_ROS2) && defined(USE_ROS)
@@ -95,8 +96,17 @@ void RL_Real::GetState(RobotState<double> *state)
     auto tau = robot_->get_joint_t();
 
     const int dof = this->params.num_of_dofs;
+    const int mapping_count = std::min<int>(this->params.joint_mapping.size(), dof);
+    if (!state_mapping_warning_printed_ && static_cast<int>(this->params.joint_mapping.size()) != dof)
+    {
+        std::cout << LOGGER::WARNING << "Titati joint_mapping size (" << this->params.joint_mapping.size()
+                  << ") does not match num_of_dofs (" << dof
+                  << ") when reading joint state. Using the first " << mapping_count << " entries." << std::endl;
+        state_mapping_warning_printed_ = true;
+    }
+
     std::vector<int> hardware_to_rl(dof, -1);
-    for (int rl_index = 0; rl_index < dof; ++rl_index)
+    for (int rl_index = 0; rl_index < mapping_count; ++rl_index)
     {
         const int hardware_index = this->params.joint_mapping[rl_index];
         if (hardware_index >= 0 && hardware_index < dof)
@@ -140,6 +150,51 @@ void RL_Real::GetState(RobotState<double> *state)
         state->motor_state.tau_est[rl_index] = 0.0;
     }
 
+    static bool state_log_printed = false;
+    if (!state_log_printed)
+    {
+        std::ostringstream hardware_log;
+        hardware_log << "Initial Titati joint feedback (hardware order q): [";
+        for (int hardware_index = 0; hardware_index < dof && hardware_index < static_cast<int>(q.size()); ++hardware_index)
+        {
+            hardware_log << q[hardware_index];
+            if (hardware_index + 1 < dof && hardware_index + 1 < static_cast<int>(q.size()))
+            {
+                hardware_log << ", ";
+            }
+        }
+        hardware_log << "]";
+        std::cout << LOGGER::DEBUG << hardware_log.str() << std::endl;
+
+        std::ostringstream rl_log;
+        rl_log << "Initial Titati joint feedback (RL order q): [";
+        for (int rl_index = 0; rl_index < dof; ++rl_index)
+        {
+            rl_log << state->motor_state.q[rl_index];
+            if (rl_index + 1 < dof)
+            {
+                rl_log << ", ";
+            }
+        }
+        rl_log << "]";
+        std::cout << LOGGER::DEBUG << rl_log.str() << std::endl;
+
+        std::ostringstream mapping_log;
+        mapping_log << "Titati joint_mapping rl->hw indices: [";
+        for (int rl_index = 0; rl_index < mapping_count; ++rl_index)
+        {
+            mapping_log << rl_index << "->" << this->params.joint_mapping[rl_index];
+            if (rl_index + 1 < mapping_count)
+            {
+                mapping_log << ", ";
+            }
+        }
+        mapping_log << "]";
+        std::cout << LOGGER::DEBUG << mapping_log.str() << std::endl;
+
+        state_log_printed = true;
+    }
+
     auto quat = robot_->get_imu_quaternion();
     state->imu.quaternion[0] = quat[3];
     state->imu.quaternion[1] = quat[0];
@@ -163,22 +218,61 @@ void RL_Real::SetCommand(const RobotCommand<double> *command)
 {
     if (!EnsureMotorsSdkMode())
     {
+        if (sdk_fail_log_count_ < 10 || sdk_fail_log_count_ % 200 == 0)
+        {
+            std::cout << LOGGER::WARNING
+                      << "Titati motors are not yet in SDK mode; skipping MIT command dispatch." << std::endl;
+        }
+        ++sdk_fail_log_count_;
         return;
     }
 
-    std::vector<double> q(this->params.num_of_dofs, 0.0);
-    std::vector<double> v(this->params.num_of_dofs, 0.0);
-    std::vector<double> kp(this->params.num_of_dofs, 0.0);
-    std::vector<double> kd(this->params.num_of_dofs, 0.0);
-    std::vector<double> tau(this->params.num_of_dofs, 0.0);
+    if (sdk_fail_log_count_ > 0)
+    {
+        std::cout << LOGGER::INFO << "Titati motors accepted SDK control after " << sdk_fail_log_count_
+                  << " skipped control cycles." << std::endl;
+        sdk_fail_log_count_ = 0;
+    }
 
-    for (int i = 0; i < this->params.num_of_dofs; ++i)
+    const int dof = this->params.num_of_dofs;
+    std::vector<double> q(dof, 0.0);
+    std::vector<double> v(dof, 0.0);
+    std::vector<double> kp(dof, 0.0);
+    std::vector<double> kd(dof, 0.0);
+    std::vector<double> tau(dof, 0.0);
+
+    bool mapping_issue_detected = false;
+    std::ostringstream mapping_issue_stream;
+    if (static_cast<int>(this->params.joint_mapping.size()) != dof)
+    {
+        mapping_issue_detected = true;
+        mapping_issue_stream << "joint_mapping has " << this->params.joint_mapping.size()
+                             << " entries, but Titati expects " << dof << ". ";
+    }
+
+    const int mapped_count = std::min<int>(this->params.joint_mapping.size(), dof);
+    std::vector<bool> hardware_assigned(dof, false);
+
+    for (int i = 0; i < mapped_count; ++i)
     {
         const auto hardware_index = this->params.joint_mapping[i];
         if (hardware_index < 0 || hardware_index >= this->params.num_of_dofs)
         {
+            mapping_issue_detected = true;
+            mapping_issue_stream << "Mapping entry rl[" << i << "] -> hw[" << hardware_index
+                                 << "] is out of range. ";
             continue;
         }
+
+        if (hardware_assigned[hardware_index])
+        {
+            mapping_issue_detected = true;
+            mapping_issue_stream << "Hardware index " << hardware_index
+                                 << " receives multiple RL joints. ";
+            continue;
+        }
+
+        hardware_assigned[hardware_index] = true;
 
         q[hardware_index] = command->motor_command.q[i];
         v[hardware_index] = command->motor_command.dq[i];
@@ -187,11 +281,64 @@ void RL_Real::SetCommand(const RobotCommand<double> *command)
         tau[hardware_index] = command->motor_command.tau[i];
     }
 
+    for (int hardware_index = 0; hardware_index < dof; ++hardware_index)
+    {
+        if (!hardware_assigned[hardware_index])
+        {
+            mapping_issue_detected = true;
+            mapping_issue_stream << "Hardware index " << hardware_index
+                                 << " is not covered by joint_mapping. ";
+        }
+    }
+
+    if (mapping_issue_detected && !mapping_warning_printed_)
+    {
+        std::cout << LOGGER::ERROR << "Titati joint_mapping configuration issue: "
+                  << mapping_issue_stream.str() << std::endl;
+        mapping_warning_printed_ = true;
+    }
+
     if (!robot_->set_target_joint_mit(q, v, kp, kd, tau) && motors_sdk_enabled_)
     {
         motors_sdk_enabled_ = false;
         last_sdk_retry_ = std::chrono::steady_clock::now();
-        std::cout << LOGGER::WARNING << "Failed to send MIT command to Titati motors. Retrying SDK handshake." << std::endl;
+        if (mit_fail_log_count_ < 10 || mit_fail_log_count_ % 200 == 0)
+        {
+            std::cout << LOGGER::WARNING
+                      << "Failed to send MIT command to Titati motors. Retrying SDK handshake." << std::endl;
+        }
+        ++mit_fail_log_count_;
+    }
+    else if (!motors_sdk_enabled_)
+    {
+        std::cout << LOGGER::INFO << "Titati motors resumed MIT command acceptance." << std::endl;
+        mit_fail_log_count_ = 0;
+    }
+    else
+    {
+        if (mit_fail_log_count_ > 0)
+        {
+            std::cout << LOGGER::INFO << "Titati MIT command transmission recovered after " << mit_fail_log_count_
+                      << " failed attempts." << std::endl;
+            mit_fail_log_count_ = 0;
+        }
+
+        if (!command_log_printed_)
+        {
+            std::ostringstream oss;
+            oss << "First Titati MIT command (hardware order q): [";
+            for (int hardware_index = 0; hardware_index < dof; ++hardware_index)
+            {
+                oss << q[hardware_index];
+                if (hardware_index + 1 < dof)
+                {
+                    oss << ", ";
+                }
+            }
+            oss << "]";
+            std::cout << LOGGER::DEBUG << oss.str() << std::endl;
+            command_log_printed_ = true;
+        }
     }
 }
 

--- a/rl_sar/src/rl_sar/src/rl_real_titati.cpp
+++ b/rl_sar/src/rl_sar/src/rl_real_titati.cpp
@@ -105,49 +105,85 @@ void RL_Real::GetState(RobotState<double> *state)
         state_mapping_warning_printed_ = true;
     }
 
-    std::vector<int> hardware_to_rl(dof, -1);
+    bool q_shortage_detected = false;
+    bool v_shortage_detected = false;
+    bool tau_shortage_detected = false;
+
+    std::vector<bool> q_assigned(dof, false);
+    std::vector<bool> v_assigned(dof, false);
+    std::vector<bool> tau_assigned(dof, false);
+
     for (int rl_index = 0; rl_index < mapping_count; ++rl_index)
     {
         const int hardware_index = this->params.joint_mapping[rl_index];
-        if (hardware_index >= 0 && hardware_index < dof)
-        {
-            hardware_to_rl[hardware_index] = rl_index;
-        }
-    }
-
-    std::vector<bool> rl_values_assigned(dof, false);
-    const std::size_t hardware_count = std::min({q.size(), v.size(), tau.size(), static_cast<std::size_t>(dof)});
-    for (std::size_t hardware_index = 0; hardware_index < hardware_count; ++hardware_index)
-    {
-        const int rl_index = hardware_to_rl[hardware_index];
-        if (rl_index < 0)
+        if (hardware_index < 0 || hardware_index >= dof)
         {
             continue;
         }
 
-        joint_positions_[rl_index] = q[hardware_index];
-        joint_velocities_[rl_index] = v[hardware_index];
-        joint_torques_[rl_index] = tau[hardware_index];
+        if (hardware_index < static_cast<int>(q.size()))
+        {
+            const double position = q[hardware_index];
+            joint_positions_[rl_index] = position;
+            state->motor_state.q[rl_index] = position;
+            q_assigned[rl_index] = true;
+        }
+        else
+        {
+            q_shortage_detected = true;
+        }
 
-        state->motor_state.q[rl_index] = joint_positions_[rl_index];
-        state->motor_state.dq[rl_index] = joint_velocities_[rl_index];
-        state->motor_state.tau_est[rl_index] = joint_torques_[rl_index];
-        rl_values_assigned[rl_index] = true;
+        if (hardware_index < static_cast<int>(v.size()))
+        {
+            const double velocity = v[hardware_index];
+            joint_velocities_[rl_index] = velocity;
+            state->motor_state.dq[rl_index] = velocity;
+            v_assigned[rl_index] = true;
+        }
+        else
+        {
+            v_shortage_detected = true;
+        }
+
+        if (hardware_index < static_cast<int>(tau.size()))
+        {
+            const double torque = tau[hardware_index];
+            joint_torques_[rl_index] = torque;
+            state->motor_state.tau_est[rl_index] = torque;
+            tau_assigned[rl_index] = true;
+        }
+        else
+        {
+            tau_shortage_detected = true;
+        }
     }
 
     for (int rl_index = 0; rl_index < dof; ++rl_index)
     {
-        if (rl_values_assigned[rl_index])
+        if (!q_assigned[rl_index])
         {
-            continue;
+            joint_positions_[rl_index] = 0.0;
+            state->motor_state.q[rl_index] = 0.0;
         }
+        if (!v_assigned[rl_index])
+        {
+            joint_velocities_[rl_index] = 0.0;
+            state->motor_state.dq[rl_index] = 0.0;
+        }
+        if (!tau_assigned[rl_index])
+        {
+            joint_torques_[rl_index] = 0.0;
+            state->motor_state.tau_est[rl_index] = 0.0;
+        }
+    }
 
-        joint_positions_[rl_index] = 0.0;
-        joint_velocities_[rl_index] = 0.0;
-        joint_torques_[rl_index] = 0.0;
-        state->motor_state.q[rl_index] = 0.0;
-        state->motor_state.dq[rl_index] = 0.0;
-        state->motor_state.tau_est[rl_index] = 0.0;
+    if (!state_signal_size_warning_printed_ && (q_shortage_detected || v_shortage_detected || tau_shortage_detected))
+    {
+        std::cout << LOGGER::WARNING
+                  << "Titati joint feedback vectors shorter than expected. Sizes -- q: " << q.size()
+                  << ", dq: " << v.size() << ", tau: " << tau.size()
+                  << ", expected at least: " << dof << std::endl;
+        state_signal_size_warning_printed_ = true;
     }
 
     static bool state_log_printed = false;

--- a/rl_sar/src/rl_sar/src/rl_real_titati.cpp
+++ b/rl_sar/src/rl_sar/src/rl_real_titati.cpp
@@ -129,24 +129,25 @@ void RL_Real::SetCommand(const RobotCommand<double> *command)
         return;
     }
 
-    std::vector<double> q;
-    std::vector<double> v;
-    std::vector<double> kp;
-    std::vector<double> kd;
-    std::vector<double> tau;
-    q.reserve(this->params.num_of_dofs);
-    v.reserve(this->params.num_of_dofs);
-    kp.reserve(this->params.num_of_dofs);
-    kd.reserve(this->params.num_of_dofs);
-    tau.reserve(this->params.num_of_dofs);
+    std::vector<double> q(this->params.num_of_dofs, 0.0);
+    std::vector<double> v(this->params.num_of_dofs, 0.0);
+    std::vector<double> kp(this->params.num_of_dofs, 0.0);
+    std::vector<double> kd(this->params.num_of_dofs, 0.0);
+    std::vector<double> tau(this->params.num_of_dofs, 0.0);
 
     for (int i = 0; i < this->params.num_of_dofs; ++i)
     {
-        q.push_back(command->motor_command.q[i]);
-        v.push_back(command->motor_command.dq[i]);
-        kp.push_back(command->motor_command.kp[i]);
-        kd.push_back(command->motor_command.kd[i]);
-        tau.push_back(command->motor_command.tau[i]);
+        const auto hardware_index = this->params.joint_mapping[i];
+        if (hardware_index < 0 || hardware_index >= this->params.num_of_dofs)
+        {
+            continue;
+        }
+
+        q[hardware_index] = command->motor_command.q[i];
+        v[hardware_index] = command->motor_command.dq[i];
+        kp[hardware_index] = command->motor_command.kp[i];
+        kd[hardware_index] = command->motor_command.kd[i];
+        tau[hardware_index] = command->motor_command.tau[i];
     }
 
     if (!robot_->set_target_joint_mit(q, v, kp, kd, tau) && motors_sdk_enabled_)

--- a/rl_sar/src/rl_sar/src/rl_real_titati.cpp
+++ b/rl_sar/src/rl_sar/src/rl_real_titati.cpp
@@ -5,6 +5,7 @@
 
 #include "rl_real_titati.hpp"
 
+#include <algorithm>
 #include <iostream>
 
 RL_Real::RL_Real()
@@ -93,14 +94,50 @@ void RL_Real::GetState(RobotState<double> *state)
     auto v = robot_->get_joint_v();
     auto tau = robot_->get_joint_t();
 
-    for (int i = 0; i < this->params.num_of_dofs; ++i)
+    const int dof = this->params.num_of_dofs;
+    std::vector<int> hardware_to_rl(dof, -1);
+    for (int rl_index = 0; rl_index < dof; ++rl_index)
     {
-        joint_positions_[i] = q[this->params.joint_mapping[i]];
-        joint_velocities_[i] = v[this->params.joint_mapping[i]];
-        joint_torques_[i] = tau[this->params.joint_mapping[i]];
-        state->motor_state.q[i] = joint_positions_[i];
-        state->motor_state.dq[i] = joint_velocities_[i];
-        state->motor_state.tau_est[i] = joint_torques_[i];
+        const int hardware_index = this->params.joint_mapping[rl_index];
+        if (hardware_index >= 0 && hardware_index < dof)
+        {
+            hardware_to_rl[hardware_index] = rl_index;
+        }
+    }
+
+    std::vector<bool> rl_values_assigned(dof, false);
+    const std::size_t hardware_count = std::min({q.size(), v.size(), tau.size(), static_cast<std::size_t>(dof)});
+    for (std::size_t hardware_index = 0; hardware_index < hardware_count; ++hardware_index)
+    {
+        const int rl_index = hardware_to_rl[hardware_index];
+        if (rl_index < 0)
+        {
+            continue;
+        }
+
+        joint_positions_[rl_index] = q[hardware_index];
+        joint_velocities_[rl_index] = v[hardware_index];
+        joint_torques_[rl_index] = tau[hardware_index];
+
+        state->motor_state.q[rl_index] = joint_positions_[rl_index];
+        state->motor_state.dq[rl_index] = joint_velocities_[rl_index];
+        state->motor_state.tau_est[rl_index] = joint_torques_[rl_index];
+        rl_values_assigned[rl_index] = true;
+    }
+
+    for (int rl_index = 0; rl_index < dof; ++rl_index)
+    {
+        if (rl_values_assigned[rl_index])
+        {
+            continue;
+        }
+
+        joint_positions_[rl_index] = 0.0;
+        joint_velocities_[rl_index] = 0.0;
+        joint_torques_[rl_index] = 0.0;
+        state->motor_state.q[rl_index] = 0.0;
+        state->motor_state.dq[rl_index] = 0.0;
+        state->motor_state.tau_est[rl_index] = 0.0;
     }
 
     auto quat = robot_->get_imu_quaternion();

--- a/rl_sar/src/rl_sar/src/rl_real_titati.cpp
+++ b/rl_sar/src/rl_sar/src/rl_real_titati.cpp
@@ -6,6 +6,7 @@
 #include "rl_real_titati.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <iostream>
 #include <sstream>
 
@@ -53,6 +54,7 @@ RL_Real::RL_Real()
     }
     else
     {
+        std::cout << LOGGER::INFO << "Titati motors switched to SDK control mode." << std::endl;
         last_sdk_retry_ = std::chrono::steady_clock::now();
     }
 
@@ -94,6 +96,8 @@ void RL_Real::GetState(RobotState<double> *state)
     auto q = robot_->get_joint_q();
     auto v = robot_->get_joint_v();
     auto tau = robot_->get_joint_t();
+
+    static int state_snapshot_count = 0;
 
     const int dof = this->params.num_of_dofs;
     const int mapping_count = std::min<int>(this->params.joint_mapping.size(), dof);
@@ -231,6 +235,50 @@ void RL_Real::GetState(RobotState<double> *state)
         state_log_printed = true;
     }
 
+    if (state_snapshot_count < 5)
+    {
+        bool nonzero_detected = false;
+        for (int rl_index = 0; rl_index < dof; ++rl_index)
+        {
+            if (std::fabs(state->motor_state.q[rl_index]) > 1e-4 || std::fabs(state->motor_state.dq[rl_index]) > 1e-4)
+            {
+                nonzero_detected = true;
+                break;
+            }
+        }
+
+        if (nonzero_detected)
+        {
+            std::ostringstream oss;
+            oss << "Titati RL-order joint state snapshot " << state_snapshot_count << " (q): [";
+            for (int rl_index = 0; rl_index < dof; ++rl_index)
+            {
+                oss << state->motor_state.q[rl_index];
+                if (rl_index + 1 < dof)
+                {
+                    oss << ", ";
+                }
+            }
+            oss << "]";
+            std::cout << LOGGER::DEBUG << oss.str() << std::endl;
+
+            std::ostringstream dq_log;
+            dq_log << "Titati RL-order joint state snapshot " << state_snapshot_count << " (dq): [";
+            for (int rl_index = 0; rl_index < dof; ++rl_index)
+            {
+                dq_log << state->motor_state.dq[rl_index];
+                if (rl_index + 1 < dof)
+                {
+                    dq_log << ", ";
+                }
+            }
+            dq_log << "]";
+            std::cout << LOGGER::DEBUG << dq_log.str() << std::endl;
+
+            ++state_snapshot_count;
+        }
+    }
+
     auto quat = robot_->get_imu_quaternion();
     state->imu.quaternion[0] = quat[3];
     state->imu.quaternion[1] = quat[0];
@@ -271,6 +319,55 @@ void RL_Real::SetCommand(const RobotCommand<double> *command)
     }
 
     const int dof = this->params.num_of_dofs;
+
+    auto log_vector = [](const char *label, const std::vector<double> &values) {
+        std::ostringstream oss;
+        oss << label << " [";
+        for (std::size_t i = 0; i < values.size(); ++i)
+        {
+            oss << values[i];
+            if (i + 1 < values.size())
+            {
+                oss << ", ";
+            }
+        }
+        oss << "]";
+        std::cout << LOGGER::DEBUG << oss.str() << std::endl;
+    };
+
+    const std::size_t rl_command_size = command->motor_command.q.size();
+    if (rl_command_size < static_cast<std::size_t>(dof))
+    {
+        std::cout << LOGGER::ERROR << "RobotCommand motor_command.q has size " << rl_command_size
+                  << " but Titati expects " << dof << " DoFs." << std::endl;
+    }
+
+    static bool rl_command_log_printed = false;
+    if (!rl_command_log_printed)
+    {
+        std::vector<double> rl_q(dof, 0.0);
+        std::vector<double> rl_dq(dof, 0.0);
+        std::vector<double> rl_kp(dof, 0.0);
+        std::vector<double> rl_kd(dof, 0.0);
+        std::vector<double> rl_tau(dof, 0.0);
+
+        for (int i = 0; i < dof && i < static_cast<int>(rl_command_size); ++i)
+        {
+            rl_q[i] = command->motor_command.q[i];
+            rl_dq[i] = command->motor_command.dq[i];
+            rl_kp[i] = command->motor_command.kp[i];
+            rl_kd[i] = command->motor_command.kd[i];
+            rl_tau[i] = command->motor_command.tau[i];
+        }
+
+        log_vector("First Titati MIT command (RL order q):", rl_q);
+        log_vector("First Titati MIT command (RL order dq):", rl_dq);
+        log_vector("First Titati MIT command (RL order kp):", rl_kp);
+        log_vector("First Titati MIT command (RL order kd):", rl_kd);
+        log_vector("First Titati MIT command (RL order tau):", rl_tau);
+        rl_command_log_printed = true;
+    }
+
     std::vector<double> q(dof, 0.0);
     std::vector<double> v(dof, 0.0);
     std::vector<double> kp(dof, 0.0);


### PR DESCRIPTION
## Summary
- map RL-generated MIT joint commands back to the Titati hardware joint order using the configured joint_mapping
- guard against invalid mapping indices when populating hardware command vectors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3c1fa23d88321a46285e7bf08848c