### PR TITLE
Add Titati hardware integration and real controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# test
+# Titati RL bring-up workspace
+
+This workspace combines the upstream `rl_sar` reinforcement-learning stack with the legacy `titati_control` utilities so that Titati (two Tita robots joined through the connector box) can be driven directly by learned policies.
+
+If you are looking for day-to-day usage instructions, start with [`rl_sar/README.md`](rl_sar/README.md). The new **DDT Titati** section under “Real Robots” walks through:
+
+- preparing the CAN-FD interface on the master and slave Jetsons,
+- placing the trained policy inside `rl_sar/src/rl_sar/policy/titati/robot_lab/`,
+- compiling and launching `rl_real_titati` via ROS1, ROS2, or the pure CMake binary, and
+- safety checks to perform before letting the robot support itself.
+
+The original `titati_control` scripts are still available under `titati_control/src` for reference (for example, to reuse their CAN configuration commands).

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This workspace combines the upstream `rl_sar` reinforcement-learning stack with 
 If you are looking for day-to-day usage instructions, start with [`rl_sar/README.md`](rl_sar/README.md). The new **DDT Titati** section under “Real Robots” walks through:
 
 - preparing the CAN-FD interface on the master and slave Jetsons,
+- validating all 16 actuators with the standalone motor tester once CAN is online,
 - placing the trained policy inside `rl_sar/src/rl_sar/policy/titati/robot_lab/`,
 - compiling and launching `rl_real_titati` via ROS1, ROS2, or the pure CMake binary, and
 - safety checks to perform before letting the robot support itself.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This workspace combines the upstream `rl_sar` reinforcement-learning stack with 
 If you are looking for day-to-day usage instructions, start with [`rl_sar/README.md`](rl_sar/README.md). The new **DDT Titati** section under “Real Robots” walks through:
 
 - preparing the CAN-FD interface on the master and slave Jetsons,
+- replaying the vendor FORCE_DIRECT handshake with `titati_can_router` on both Jetsons,
 - validating all 16 actuators with the standalone motor tester once CAN is online,
 - placing the trained policy inside `rl_sar/src/rl_sar/policy/titati/robot_lab/`,
 - compiling and launching `rl_real_titati` via ROS1, ROS2, or the pure CMake binary, and

--- a/rl_sar/README.md
+++ b/rl_sar/README.md
@@ -385,9 +385,23 @@ ros2 run rl_sar rl_real_lite3
 
 The Titati platform is assembled from two Tita wheeled-legged robots that share a CAN-FD backbone. Each half has a Jetson Orin NX 16G acting as a **master** or **slave** controller. To switch the hardware stack over to the reinforcement-learning controller shipped in `rl_real_titati`, follow the steps below on both computers.
 
-#### 0. Validate the CAN backbone with the motor tester
+#### 0. Prepare the CAN interface
 
-Before streaming a policy, bring the platform into direct-SDK mode and confirm every actuator responds. Build the standalone tools with CMake (`./build.sh -m`) and then launch the tester:
+Stop the vendor bringup service and configure the CAN-FD port before launching any control software. The helper scripts from `titati_control/src` are left in this workspace (`can_setup_8m_master.sh` / `can_setup_8m_slave.sh`) and show the exact sequence. The relevant commands are:
+
+```bash
+sudo systemctl stop tita-bringup.service
+sudo ip link set can0 down
+sudo ip link set can0 up type can bitrate 1000000 sample-point 0.80 \
+    dbitrate 8000000 dsample-point 0.80 fd on restart-ms 100
+sudo ifconfig can0 txqueuelen 1000
+```
+
+Run the commands on the Jetson that acts as the **master** first. Repeat the CAN bring-up on the **slave** Jetson that drives the other pair of legs so both sides appear on the shared CAN bus. The hardware drivers in `rl_real_titati` expect the interface to be called `can0`; adjust the source in `library/hardware/titati/tita_robot/include/tita_robot/*` only if your network uses a different device name.
+
+#### 1. Validate the CAN backbone with the motor tester
+
+Once both Jetsons have the CAN interface online, bring the platform into direct-SDK mode and confirm every actuator responds before streaming a policy. Build the standalone tools with CMake (`./build.sh -m`) and then launch the tester:
 
 ```bash
 # CMake
@@ -412,20 +426,6 @@ Key commands inside the shell:
 - `exit` – stop commanding and quit (the tester also zeros the torques during shutdown).
 
 Leave the robot lifted while validating torque polarity. When the tester shows that all 16 actuators report reasonable state feedback, continue with the policy bring-up below.
-
-#### 1. Prepare the CAN interface
-
-Stop the vendor bringup service and configure the CAN-FD port before launching any control software. The helper scripts from `titati_control/src` are left in this workspace (`can_setup_8m_master.sh` / `can_setup_8m_slave.sh`) and show the exact sequence. The relevant commands are:
-
-```bash
-sudo systemctl stop tita-bringup.service
-sudo ip link set can0 down
-sudo ip link set can0 up type can bitrate 1000000 sample-point 0.80 \
-    dbitrate 8000000 dsample-point 0.80 fd on restart-ms 100
-sudo ifconfig can0 txqueuelen 1000
-```
-
-Run the commands on the Jetson that acts as the **master** first. Repeat the CAN bring-up on the **slave** Jetson that drives the other pair of legs so both sides appear on the shared CAN bus. The hardware drivers in `rl_real_titati` expect the interface to be called `can0`; adjust the source in `library/hardware/titati/tita_robot/include/tita_robot/*` only if your network uses a different device name.
 
 #### 2. Deploy the RL controller
 

--- a/rl_sar/README.md
+++ b/rl_sar/README.md
@@ -399,7 +399,29 @@ sudo ifconfig can0 txqueuelen 1000
 
 Run the commands on the Jetson that acts as the **master** first. Repeat the CAN bring-up on the **slave** Jetson that drives the other pair of legs so both sides appear on the shared CAN bus. The hardware drivers in `rl_real_titati` expect the interface to be called `can0`; adjust the source in `library/hardware/titati/tita_robot/include/tita_robot/*` only if your network uses a different device name.
 
-#### 1. Validate the CAN backbone with the motor tester
+#### 1. Start the Titati CAN router on both Jetsons
+
+The Titati control box expects each Jetson to request **FORCE_DIRECT** mode once the CAN link is up. Launch the router helper on
+both machines to replay the vendor handshake before you try to command any motors:
+
+```bash
+# CMake
+./cmake_build/bin/titati_can_router
+
+# ROS1
+source devel/setup.bash
+rosrun rl_sar titati_can_router
+
+# ROS2
+source install/setup.bash
+ros2 run rl_sar titati_can_router
+```
+
+Run the tool on the **slave** Jetson first, then start it on the **master**. Each instance prints the router heartbeat and exits
+when you press `Ctrl+C`. If your wiring uses a different CAN device name, add `--interface can1` (and optionally
+`--rpc-interface canX`) to override the defaults.
+
+#### 2. Validate the CAN backbone with the motor tester
 
 Once both Jetsons have the CAN interface online, bring the platform into direct-SDK mode and confirm every actuator responds before streaming a policy. Build the standalone tools with CMake (`./build.sh -m`) and then launch the tester:
 
@@ -427,7 +449,7 @@ Key commands inside the shell:
 
 Leave the robot lifted while validating torque polarity. When the tester shows that all 16 actuators report reasonable state feedback, continue with the policy bring-up below.
 
-#### 2. Deploy the RL controller
+#### 3. Deploy the RL controller
 
 1. Copy the trained policy to `rl_sar/src/rl_sar/policy/titati/robot_lab/policy.pt`. Tune the gains, torque limits, and joint remapping in `policy/titati/base.yaml` and `policy/titati/robot_lab/config.yaml` before first power-on.
 2. Export `Torch_DIR` to point at a libtorch installation that matches your target architecture.
@@ -454,7 +476,7 @@ Leave the robot lifted while validating torque polarity. When the tester shows t
 
 The executable starts in manual keyboard mode (`W`, `A`, `S`, `D`, `Q`, `E` for planar motion, `Space` to stop). Press `N` to toggle navigation mode when you want the controller to consume `/cmd_vel` commands from ROS instead. When shutting down, the node automatically zeroes commanded torques before exiting.
 
-#### 3. Safety checks
+#### 4. Safety checks
 
 - Keep the robot lifted while validating the torque polarity and joint mapping.
 - Confirm the CAN interface shows traffic (`candump can0`) before handing control over to the RL policy.

--- a/rl_sar/README.md
+++ b/rl_sar/README.md
@@ -127,10 +127,11 @@ To clean the build, use the following command. This will remove all compiled out
 ./build.sh -c  # or ./build.sh --clean
 ```
 
-If simulation is not needed and you only want to run on the robot, you can compile using CMake while disabling ROS (the compiled executables will be in `cmake_build/bin` and libraries in `cmake_build/lib`):
+If simulation is not needed and you only want to run on the robot, you can compile using CMake while disabling ROS (the compiled executables will be in `cmake_build/bin` and libraries in `cmake_build/lib`). By default the script configures a Titati-only toolchain; pass `--all-robots` together with `-m` if you still need the other hardware targets:
 
 ```bash
-./build.sh -m  # or ./build.sh --cmake
+./build.sh -m  # or ./build.sh --cmake (Titati-only build)
+./build.sh -m --all-robots
 ```
 
 For detailed usage instructions, you can check them via `./build.sh -h`:
@@ -141,6 +142,7 @@ Usage: ./build.sh [OPTIONS] [PACKAGE_NAMES...]
 Options:
   -c, --clean    Clean workspace (remove symlinks and build artifacts)
   -m, --cmake    Build using CMake (for hardware deployment only)
+      --all-robots  Build every hardware controller when used with --cmake
   -h, --help     Show this help message
 
 Examples:
@@ -148,7 +150,8 @@ Examples:
   ./build.sh package1 package2  # Build specific ROS packages
   ./build.sh -c                 # Clean all symlinks and build artifacts
   ./build.sh --clean package1   # Clean specific package and build artifacts
-  ./build.sh -m                 # Build with CMake for hardware deployment
+  ./build.sh -m                 # Build Titati controllers with CMake
+  ./build.sh -m --all-robots    # Build every hardware controller with CMake
 ```
 
 > [!TIP]
@@ -431,7 +434,7 @@ Run the commands on the Jetson that acts as the **master** first. Repeat the CAN
 3. Compile the standalone controller on the Jetson that talks to the CAN backbone:
 
     ```bash
-    ./build.sh -m rl_real_titati
+    ./build.sh -m  # add --all-robots if you also need the other platforms
     ```
 
 4. Launch the controller. The ROS and pure CMake entry points are both available—pick whichever matches your runtime environment:

--- a/rl_sar/README.md
+++ b/rl_sar/README.md
@@ -382,6 +382,34 @@ ros2 run rl_sar rl_real_lite3
 
 The Titati platform is assembled from two Tita wheeled-legged robots that share a CAN-FD backbone. Each half has a Jetson Orin NX 16G acting as a **master** or **slave** controller. To switch the hardware stack over to the reinforcement-learning controller shipped in `rl_real_titati`, follow the steps below on both computers.
 
+#### 0. Validate the CAN backbone with the motor tester
+
+Before streaming a policy, bring the platform into direct-SDK mode and confirm every actuator responds. Build the standalone tools with CMake (`./build.sh -m`) and then launch the tester:
+
+```bash
+# CMake
+./cmake_build/bin/titati_motor_test --mode torque --monitor 1000
+
+# ROS1
+source devel/setup.bash
+rosrun rl_sar titati_motor_test --mode torque
+
+# ROS2
+source install/setup.bash
+ros2 run rl_sar titati_motor_test --mode torque
+```
+
+Key commands inside the shell:
+
+- `status` / `status 5` – print all joints or a single joint (indices are zero-based).
+- `monitor 500` – stream the table every 500 ms (toggle off with `monitor off`).
+- `set 3 0.3` – command motor 3 with 0.3 Nm in torque mode.
+- `mode mit` followed by `set 7 0.0 0.0 20.0 1.0 0.0` – drive motor 7 with MIT gains (`q`, `dq`, `kp`, `kd`, `tau`).
+- `zero 3` / `zero all` – clear the active command.
+- `exit` – stop commanding and quit (the tester also zeros the torques during shutdown).
+
+Leave the robot lifted while validating torque polarity. When the tester shows that all 16 actuators report reasonable state feedback, continue with the policy bring-up below.
+
 #### 1. Prepare the CAN interface
 
 Stop the vendor bringup service and configure the CAN-FD port before launching any control software. The helper scripts from `titati_control/src` are left in this workspace (`can_setup_8m_master.sh` / `can_setup_8m_slave.sh`) and show the exact sequence. The relevant commands are:

--- a/rl_sar/README.md
+++ b/rl_sar/README.md
@@ -376,6 +376,61 @@ ros2 run rl_sar rl_real_lite3
 
 </details>
 
+<details>
+
+<summary>DDT Titati (Click to expand)</summary>
+
+The Titati platform is assembled from two Tita wheeled-legged robots that share a CAN-FD backbone. Each half has a Jetson Orin NX 16G acting as a **master** or **slave** controller. To switch the hardware stack over to the reinforcement-learning controller shipped in `rl_real_titati`, follow the steps below on both computers.
+
+#### 1. Prepare the CAN interface
+
+Stop the vendor bringup service and configure the CAN-FD port before launching any control software. The helper scripts from `titati_control/src` are left in this workspace (`can_setup_8m_master.sh` / `can_setup_8m_slave.sh`) and show the exact sequence. The relevant commands are:
+
+```bash
+sudo systemctl stop tita-bringup.service
+sudo ip link set can0 down
+sudo ip link set can0 up type can bitrate 1000000 sample-point 0.80 \
+    dbitrate 8000000 dsample-point 0.80 fd on restart-ms 100
+sudo ifconfig can0 txqueuelen 1000
+```
+
+Run the commands on the Jetson that acts as the **master** first. Repeat the CAN bring-up on the **slave** Jetson that drives the other pair of legs so both sides appear on the shared CAN bus. The hardware drivers in `rl_real_titati` expect the interface to be called `can0`; adjust the source in `library/hardware/titati/tita_robot/include/tita_robot/*` only if your network uses a different device name.
+
+#### 2. Deploy the RL controller
+
+1. Copy the trained policy to `rl_sar/src/rl_sar/policy/titati/robot_lab/policy.pt`. Tune the gains, torque limits, and joint remapping in `policy/titati/base.yaml` and `policy/titati/robot_lab/config.yaml` before first power-on.
+2. Export `Torch_DIR` to point at a libtorch installation that matches your target architecture.
+3. Compile the standalone controller on the Jetson that talks to the CAN backbone:
+
+    ```bash
+    ./build.sh -m rl_real_titati
+    ```
+
+4. Launch the controller. The ROS and pure CMake entry points are both available—pick whichever matches your runtime environment:
+
+    ```bash
+    # ROS1
+    source devel/setup.bash
+    rosrun rl_sar rl_real_titati
+
+    # ROS2
+    source install/setup.bash
+    ros2 run rl_sar rl_real_titati
+
+    # CMake (no ROS)
+    ./cmake_build/bin/rl_real_titati
+    ```
+
+The executable starts in manual keyboard mode (`W`, `A`, `S`, `D`, `Q`, `E` for planar motion, `Space` to stop). Press `N` to toggle navigation mode when you want the controller to consume `/cmd_vel` commands from ROS instead. When shutting down, the node automatically zeroes commanded torques before exiting.
+
+#### 3. Safety checks
+
+- Keep the robot lifted while validating the torque polarity and joint mapping.
+- Confirm the CAN interface shows traffic (`candump can0`) before handing control over to the RL policy.
+- Re-run the CAN configuration commands whenever the interface is reset.
+
+</details>
+
 ### Train the actuator network
 
 Take A1 as an example below

--- a/rl_sar/build.sh
+++ b/rl_sar/build.sh
@@ -64,11 +64,21 @@ ask_confirmation() {
 # ========================
 
 run_cmake_build() {
+    local build_all_robots="$1"
+
     print_header "[Running CMake Build]"
     print_warning "NOTE: CMake build is for hardware deployment only, not for simulation."
+    if [ "$build_all_robots" != "true" ]; then
+        print_info "Configuring Titati-only targets (pass --all-robots to enable every controller)."
+    fi
     print_separator
 
-    cmake src/rl_sar/ -B cmake_build -DUSE_CMAKE=ON
+    local cmake_args=(-B cmake_build -DUSE_CMAKE=ON)
+    if [ "$build_all_robots" != "true" ]; then
+        cmake_args+=(-DBUILD_TITATI_ONLY=ON)
+    fi
+
+    cmake src/rl_sar/ "${cmake_args[@]}"
     cmake --build cmake_build -j4
 
     print_success "CMake build completed!"
@@ -317,6 +327,7 @@ show_usage() {
     echo -e "${COLOR_INFO}Options:${COLOR_RESET}"
     echo -e "  -c, --clean    Clean workspace (remove symlinks and build artifacts)"
     echo -e "  -m, --cmake    Build using CMake (for hardware deployment only)"
+    echo -e "      --all-robots  Build every hardware controller when used with --cmake"
     echo -e "  -h, --help     Show this help message"
     echo ""
     echo -e "${COLOR_INFO}Examples:${COLOR_RESET}"
@@ -324,19 +335,22 @@ show_usage() {
     echo -e "  $0 package1 package2  # Build specific ROS packages"
     echo -e "  $0 -c                 # Clean all symlinks and build artifacts"
     echo -e "  $0 --clean package1   # Clean specific package and build artifacts"
-    echo -e "  $0 -m                 # Build with CMake for hardware deployment"
+    echo -e "  $0 -m                 # Build Titati controllers with CMake"
+    echo -e "  $0 -m --all-robots    # Build every hardware controller with CMake"
 }
 
 main() {
     local packages=()
     local clean_mode=false
     local cmake_mode=false
+    local build_all_robots=false
 
     # Parse command line arguments
     while [[ $# -gt 0 ]]; do
         case $1 in
             -c|--clean) clean_mode=true; shift ;;
             -m|--cmake) cmake_mode=true; shift ;;
+            --all-robots) build_all_robots=true; shift ;;
             -h|--help) show_usage; exit 0 ;;
             --) shift; packages+=("$@"); break ;;
             -*) print_error "Unknown option: $1"; show_usage; exit 1 ;;
@@ -346,7 +360,7 @@ main() {
 
     # Handle CMake build mode
     if [ "$cmake_mode" = true ]; then
-        run_cmake_build
+        run_cmake_build "$build_all_robots"
         exit 0
     fi
 

--- a/rl_sar/src/rl_sar/CMakeLists.txt
+++ b/rl_sar/src/rl_sar/CMakeLists.txt
@@ -333,6 +333,19 @@ if(NOT USE_CMAKE)
     endif()
 endif()
 
+add_executable(titati_motor_test src/titati_motor_test.cpp)
+target_link_libraries(titati_motor_test
+    titati_hardware
+    Threads::Threads
+)
+if(NOT USE_CMAKE)
+    if($ENV{ROS_DISTRO} MATCHES "noetic")
+        target_link_libraries(titati_motor_test ${catkin_LIBRARIES})
+    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+        install(TARGETS titati_motor_test DESTINATION lib/${PROJECT_NAME})
+    endif()
+endif()
+
 add_executable(rl_real_l4w4 src/rl_real_l4w4.cpp)
 target_link_libraries(rl_real_l4w4
     l4w4_sdk

--- a/rl_sar/src/rl_sar/CMakeLists.txt
+++ b/rl_sar/src/rl_sar/CMakeLists.txt
@@ -9,6 +9,9 @@ if(USE_CMAKE)
     set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 endif()
 
+option(BUILD_TITATI_ONLY "Build only Titati-specific hardware targets" OFF)
+message(STATUS "BUILD_TITATI_ONLY: ${BUILD_TITATI_ONLY}")
+
 if(NOT USE_CMAKE)
     if($ENV{ROS_DISTRO} MATCHES "noetic")
         add_compile_definitions(USE_ROS1)
@@ -93,31 +96,33 @@ else()
     message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
 endif()
 
-# unitree_legged_sdk-3.2
-add_library(unitree_legged_sdk SHARED IMPORTED)
-set_target_properties(unitree_legged_sdk PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/unitree_legged_sdk-3.2/include"
-    IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/unitree_legged_sdk-3.2/lib/${UNITREE_LIB}.so"
-)
-set(UNITREE_A1_LIBS Threads::Threads unitree_legged_sdk lcm)
-if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-    file(GLOB GLOB_UNITREE_LEGGED_SDK "${CMAKE_CURRENT_SOURCE_DIR}/library/unitree_legged_sdk-3.2/lib/${UNITREE_LIB}.so")
-    install(FILES
-        ${GLOB_UNITREE_LEGGED_SDK}
-        DESTINATION lib/
+if(NOT BUILD_TITATI_ONLY)
+    # unitree_legged_sdk-3.2
+    add_library(unitree_legged_sdk SHARED IMPORTED)
+    set_target_properties(unitree_legged_sdk PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/unitree_legged_sdk-3.2/include"
+        IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/unitree_legged_sdk-3.2/lib/${UNITREE_LIB}.so"
     )
+    set(UNITREE_A1_LIBS Threads::Threads unitree_legged_sdk lcm)
+    if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+        file(GLOB GLOB_UNITREE_LEGGED_SDK "${CMAKE_CURRENT_SOURCE_DIR}/library/unitree_legged_sdk-3.2/lib/${UNITREE_LIB}.so")
+        install(FILES
+            ${GLOB_UNITREE_LEGGED_SDK}
+            DESTINATION lib/
+        )
+    endif()
+
+    # unitree_sdk2-2.0.0
+    set(BUILD_EXAMPLES OFF CACHE BOOL "Disable examples build for unitree_sdk2" FORCE)
+    add_subdirectory(library/thirdparty/unitree_sdk2-2.0.0)
+
+    # l4w4_sdk
+    add_library(l4w4_sdk INTERFACE)
+    target_include_directories(l4w4_sdk INTERFACE
+        library/thirdparty/l4w4_sdk
+    )
+    target_link_libraries(l4w4_sdk INTERFACE Threads::Threads)
 endif()
-
-# unitree_sdk2-2.0.0
-set(BUILD_EXAMPLES OFF CACHE BOOL "Disable examples build for unitree_sdk2" FORCE)
-add_subdirectory(library/thirdparty/unitree_sdk2-2.0.0)
-
-# l4w4_sdk
-add_library(l4w4_sdk INTERFACE)
-target_include_directories(l4w4_sdk INTERFACE
-    library/thirdparty/l4w4_sdk
-)
-target_link_libraries(l4w4_sdk INTERFACE Threads::Threads)
 
 # Titati hardware
 add_library(titati_hardware
@@ -131,27 +136,29 @@ target_include_directories(titati_hardware PUBLIC
 )
 target_link_libraries(titati_hardware PUBLIC Threads::Threads)
 
-# Lite3_MotionSDK
-add_library(lite3_motionsdk SHARED IMPORTED)
-set_target_properties(lite3_motionsdk PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/include"
-    IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/lib/libdeeprobotics_legged_sdk_${ARCH_DIR}.so"
-)
-set(LITE3_REAL_LIBS Threads::Threads lite3_motionsdk)
-if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-    file(GLOB GLOB_LITE3_SDK_SO "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/lib/libdeeprobotics_legged_sdk_${ARCH_DIR}.so")
-    install(FILES
-        ${GLOB_LITE3_SDK_SO}
-        DESTINATION lib/
+if(NOT BUILD_TITATI_ONLY)
+    # Lite3_MotionSDK
+    add_library(lite3_motionsdk SHARED IMPORTED)
+    set_target_properties(lite3_motionsdk PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/include"
+        IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/lib/libdeeprobotics_legged_sdk_${ARCH_DIR}.so"
+    )
+    set(LITE3_REAL_LIBS Threads::Threads lite3_motionsdk)
+    if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+        file(GLOB GLOB_LITE3_SDK_SO "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/lib/libdeeprobotics_legged_sdk_${ARCH_DIR}.so")
+        install(FILES
+            ${GLOB_LITE3_SDK_SO}
+            DESTINATION lib/
+        )
+    endif()
+
+    # Retroid Gamepad
+    set(GAMEPAD_SRC
+        ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/gamepad/src/gamepad.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/gamepad/src/retroid_gamepad.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/gamepad/src/udp_receiver.cpp
     )
 endif()
-
-# Retroid Gamepad
-set(GAMEPAD_SRC
-    ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/gamepad/src/gamepad.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/gamepad/src/retroid_gamepad.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/gamepad/src/udp_receiver.cpp
-)
 
 if(NOT USE_CMAKE)
     if($ENV{ROS_DISTRO} MATCHES "noetic")
@@ -204,113 +211,115 @@ if(NOT USE_CMAKE)
     endif()
 endif()
 
-if(NOT USE_CMAKE)
-    add_executable(rl_sim src/rl_sim.cpp)
-    target_link_libraries(rl_sim
+if(NOT BUILD_TITATI_ONLY)
+    if(NOT USE_CMAKE)
+        add_executable(rl_sim src/rl_sim.cpp)
+        target_link_libraries(rl_sim
+            rl_sdk
+            observation_buffer
+            yaml-cpp
+            Threads::Threads
+        )
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_sim ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_sim
+                joint_state_broadcaster
+                robot_state_publisher
+                rclcpp
+                gazebo_ros
+                std_msgs
+                robot_msgs
+                robot_joint_controller
+                rclpy
+                gazebo_msgs
+                std_srvs
+                geometry_msgs
+            )
+            install(TARGETS rl_sim DESTINATION lib/${PROJECT_NAME})
+        endif()
+    endif()
+
+    add_executable(rl_real_a1 src/rl_real_a1.cpp)
+    target_link_libraries(rl_real_a1
+        ${UNITREE_A1_LIBS}
         rl_sdk
         observation_buffer
         yaml-cpp
-        Threads::Threads
     )
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_sim ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_sim
-            joint_state_broadcaster
-            robot_state_publisher
-            rclcpp
-            gazebo_ros
-            std_msgs
-            robot_msgs
-            robot_joint_controller
-            rclpy
-            gazebo_msgs
-            std_srvs
-            geometry_msgs
-        )
-        install(TARGETS rl_sim DESTINATION lib/${PROJECT_NAME})
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_a1 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_a1
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_a1 DESTINATION lib/${PROJECT_NAME})
+        endif()
     endif()
-endif()
 
-add_executable(rl_real_a1 src/rl_real_a1.cpp)
-target_link_libraries(rl_real_a1
-    ${UNITREE_A1_LIBS}
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
-if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_a1 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_a1
-            rclcpp
-            geometry_msgs
-        )
-        install(TARGETS rl_real_a1 DESTINATION lib/${PROJECT_NAME})
+    add_executable(rl_real_lite3
+        src/rl_real_lite3.cpp
+        ${GAMEPAD_SRC}
+    )
+    target_link_libraries(rl_real_lite3
+        ${LITE3_REAL_LIBS}
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    target_include_directories(rl_real_lite3 PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/gamepad/include
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_lite3 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_lite3
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_lite3 DESTINATION lib/${PROJECT_NAME})
+        endif()
     endif()
-endif()
 
-add_executable(rl_real_lite3
-    src/rl_real_lite3.cpp
-    ${GAMEPAD_SRC}
-)
-target_link_libraries(rl_real_lite3
-    ${LITE3_REAL_LIBS}
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
-target_include_directories(rl_real_lite3 PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/gamepad/include
-)
-if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_lite3 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_lite3
-            rclcpp
-            geometry_msgs
-        )
-        install(TARGETS rl_real_lite3 DESTINATION lib/${PROJECT_NAME})
+    add_executable(rl_real_go2 src/rl_real_go2.cpp)
+    target_link_libraries(rl_real_go2
+        unitree_sdk2
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_go2 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_go2
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_go2 DESTINATION lib/${PROJECT_NAME})
+        endif()
     endif()
-endif()
 
-add_executable(rl_real_go2 src/rl_real_go2.cpp)
-target_link_libraries(rl_real_go2
-    unitree_sdk2
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
-if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_go2 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_go2
-            rclcpp
-            geometry_msgs
-        )
-        install(TARGETS rl_real_go2 DESTINATION lib/${PROJECT_NAME})
-    endif()
-endif()
-
-add_executable(rl_real_g1 src/rl_real_g1.cpp)
-target_link_libraries(rl_real_g1
-    unitree_sdk2
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
-if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_g1 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_g1
-            rclcpp
-            geometry_msgs
-        )
-        install(TARGETS rl_real_g1 DESTINATION lib/${PROJECT_NAME})
+    add_executable(rl_real_g1 src/rl_real_g1.cpp)
+    target_link_libraries(rl_real_g1
+        unitree_sdk2
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_g1 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_g1
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_g1 DESTINATION lib/${PROJECT_NAME})
+        endif()
     endif()
 endif()
 
@@ -346,22 +355,24 @@ if(NOT USE_CMAKE)
     endif()
 endif()
 
-add_executable(rl_real_l4w4 src/rl_real_l4w4.cpp)
-target_link_libraries(rl_real_l4w4
-    l4w4_sdk
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
-if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_l4w4 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_l4w4
-            rclcpp
-            geometry_msgs
-        )
-        install(TARGETS rl_real_l4w4 DESTINATION lib/${PROJECT_NAME})
+if(NOT BUILD_TITATI_ONLY)
+    add_executable(rl_real_l4w4 src/rl_real_l4w4.cpp)
+    target_link_libraries(rl_real_l4w4
+        l4w4_sdk
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_l4w4 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_l4w4
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_l4w4 DESTINATION lib/${PROJECT_NAME})
+        endif()
     endif()
 endif()
 

--- a/rl_sar/src/rl_sar/CMakeLists.txt
+++ b/rl_sar/src/rl_sar/CMakeLists.txt
@@ -135,6 +135,23 @@ target_include_directories(titati_hardware PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/library/hardware/titati
 )
 target_link_libraries(titati_hardware PUBLIC Threads::Threads)
+set_target_properties(titati_hardware PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+)
+
+add_library(titati_router
+    library/hardware/titati/router/src/canfd_router_can_receive_api.cpp
+)
+target_include_directories(titati_router PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/library/hardware/titati/router/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/library/hardware/titati/router
+)
+target_link_libraries(titati_router PUBLIC Threads::Threads)
+set_target_properties(titati_router PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+)
 
 if(NOT BUILD_TITATI_ONLY)
     # Lite3_MotionSDK
@@ -352,6 +369,23 @@ if(NOT USE_CMAKE)
         target_link_libraries(titati_motor_test ${catkin_LIBRARIES})
     elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
         install(TARGETS titati_motor_test DESTINATION lib/${PROJECT_NAME})
+    endif()
+endif()
+
+add_executable(titati_can_router src/titati_can_router.cpp)
+target_link_libraries(titati_can_router
+    titati_router
+    Threads::Threads
+)
+set_target_properties(titati_can_router PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+)
+if(NOT USE_CMAKE)
+    if($ENV{ROS_DISTRO} MATCHES "noetic")
+        target_link_libraries(titati_can_router ${catkin_LIBRARIES})
+    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+        install(TARGETS titati_can_router DESTINATION lib/${PROJECT_NAME})
     endif()
 endif()
 

--- a/rl_sar/src/rl_sar/CMakeLists.txt
+++ b/rl_sar/src/rl_sar/CMakeLists.txt
@@ -171,7 +171,7 @@ include_directories(
 
 add_library(rl_sdk library/core/rl_sdk/rl_sdk.cpp)
 set_target_properties(rl_sdk PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED ON
 )
 target_link_libraries(rl_sdk PUBLIC
@@ -195,7 +195,7 @@ endif()
 add_library(observation_buffer library/core/observation_buffer/observation_buffer.cpp)
 target_link_libraries(observation_buffer PUBLIC "${TORCH_LIBRARIES}")
 set_target_properties(observation_buffer PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED ON
 )
 if(NOT USE_CMAKE)

--- a/rl_sar/src/rl_sar/CMakeLists.txt
+++ b/rl_sar/src/rl_sar/CMakeLists.txt
@@ -119,6 +119,18 @@ target_include_directories(l4w4_sdk INTERFACE
 )
 target_link_libraries(l4w4_sdk INTERFACE Threads::Threads)
 
+# Titati hardware
+add_library(titati_hardware
+    library/hardware/titati/tita_robot/src/can_receiver.cpp
+    library/hardware/titati/tita_robot/src/can_sender.cpp
+    library/hardware/titati/tita_robot/src/tita_robot.cpp
+)
+target_include_directories(titati_hardware PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/library/hardware/titati/tita_robot/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/library/hardware/titati
+)
+target_link_libraries(titati_hardware PUBLIC Threads::Threads)
+
 # Lite3_MotionSDK
 add_library(lite3_motionsdk SHARED IMPORTED)
 set_target_properties(lite3_motionsdk PROPERTIES
@@ -299,6 +311,25 @@ if(NOT USE_CMAKE)
             geometry_msgs
         )
         install(TARGETS rl_real_g1 DESTINATION lib/${PROJECT_NAME})
+    endif()
+endif()
+
+add_executable(rl_real_titati src/rl_real_titati.cpp)
+target_link_libraries(rl_real_titati
+    titati_hardware
+    rl_sdk
+    observation_buffer
+    yaml-cpp
+)
+if(NOT USE_CMAKE)
+    if($ENV{ROS_DISTRO} MATCHES "noetic")
+        target_link_libraries(rl_real_titati ${catkin_LIBRARIES})
+    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+        ament_target_dependencies(rl_real_titati
+            rclcpp
+            geometry_msgs
+        )
+        install(TARGETS rl_real_titati DESTINATION lib/${PROJECT_NAME})
     endif()
 endif()
 

--- a/rl_sar/src/rl_sar/include/rl_real_titati.hpp
+++ b/rl_sar/src/rl_sar/include/rl_real_titati.hpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2024-2025 Ziqi Fan
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef RL_REAL_TITATI_HPP
+#define RL_REAL_TITATI_HPP
+
+// #define PLOT
+// #define CSV_LOGGER
+// #define USE_ROS
+
+#include "rl_sdk.hpp"
+#include "observation_buffer.hpp"
+#include "loop.hpp"
+#include "fsm.hpp"
+
+#include <memory>
+#include <vector>
+
+#include "tita_robot/tita_robot.hpp"
+#include <csignal>
+
+#if defined(USE_ROS1) && defined(USE_ROS)
+#include <ros/ros.h>
+#include <geometry_msgs/Twist.h>
+#elif defined(USE_ROS2) && defined(USE_ROS)
+#include <rclcpp/rclcpp.hpp>
+#include <geometry_msgs/msg/twist.hpp>
+#endif
+
+#include "matplotlibcpp.h"
+namespace plt = matplotlibcpp;
+
+class RL_Real : public RL
+#if defined(USE_ROS2) && defined(USE_ROS)
+    , public rclcpp::Node
+#endif
+{
+public:
+    RL_Real();
+    ~RL_Real();
+
+private:
+    // rl functions
+    torch::Tensor Forward() override;
+    void GetState(RobotState<double> *state) override;
+    void SetCommand(const RobotCommand<double> *command) override;
+    void RunModel();
+    void RobotControl();
+
+    // loop
+    std::shared_ptr<LoopFunc> loop_keyboard;
+    std::shared_ptr<LoopFunc> loop_control;
+    std::shared_ptr<LoopFunc> loop_rl;
+    std::shared_ptr<LoopFunc> loop_plot;
+
+    // plot
+    const int plot_size = 100;
+    std::vector<int> plot_t;
+    std::vector<std::vector<double>> plot_real_joint_pos, plot_target_joint_pos;
+    void Plot();
+
+    // titati interface
+    std::unique_ptr<tita_robot> tita_hw;
+    size_t hardware_dofs = 0;
+
+    // cache
+    int motiontime = 0;
+    std::vector<double> mapped_joint_positions;
+    std::vector<double> mapped_joint_velocities;
+
+#if defined(USE_ROS1) && defined(USE_ROS)
+    geometry_msgs::Twist cmd_vel;
+    ros::Subscriber cmd_vel_subscriber;
+    void CmdvelCallback(const geometry_msgs::Twist::ConstPtr &msg);
+#elif defined(USE_ROS2) && defined(USE_ROS)
+    geometry_msgs::msg::Twist cmd_vel;
+    rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_subscriber;
+    void CmdvelCallback(const geometry_msgs::msg::Twist::SharedPtr msg);
+#endif
+};
+
+#endif // RL_REAL_TITATI_HPP

--- a/rl_sar/src/rl_sar/library/hardware/titati/protocol/can_utils.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/protocol/can_utils.hpp
@@ -1,0 +1,468 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__CAN_UTILS_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__CAN_UTILS_HPP_
+
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "linux/can.h"
+#include "linux/can/error.h"
+#include "linux/can/raw.h"
+#include "socket_can_receiver.hpp"
+#include "socket_can_sender.hpp"
+
+#define C_END "\033[m"
+// #define C_RED "\033[0;32;31m"
+#define C_RED "\033[0;31m"
+#define C_YELLOW "\033[1;33m"
+
+#ifdef GCC_OPTIMIZE_03
+#pragma GCC optimize("O3")
+#else
+#pragma GCC optimize("O0")
+#endif
+namespace tita
+{
+namespace socket_can
+{
+using can_std_callback = std::function<void(std::shared_ptr<struct can_frame> recv_frame)>;
+using can_fd_callback = std::function<void(std::shared_ptr<struct canfd_frame> recv_frame)>;
+class CanRxDev
+{
+public:
+  explicit CanRxDev(
+    const std::string & interface, const std::string & name, can_std_callback recv_callback,
+    bool is_block, int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    init(interface, name, false, recv_callback, nullptr, is_block, nano_timeout);
+  }
+  explicit CanRxDev(
+    const std::string & interface, const std::string & name, can_fd_callback recv_callback,
+    bool is_block, int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    init(interface, name, true, nullptr, recv_callback, is_block, nano_timeout);
+  }
+
+  ~CanRxDev()
+  {
+    ready_ = false;
+    isthreadrunning_ = false;
+    if (main_T_ != nullptr) {
+      main_T_->join();
+    }
+    main_T_ = nullptr;
+    receiver_ = nullptr;
+  }
+
+  bool is_ready() { return ready_; }
+  bool is_timeout() { return is_timeout_; }
+  void set_filter(const struct can_filter filter[], size_t s)
+  {
+    if (receiver_ != nullptr) {
+      receiver_->set_filter(filter, s);
+    }
+  }
+
+  std::shared_ptr<canfd_frame> wait_for_can_data_block()
+  {
+    tita::socket_can::CanId receive_id{};
+    std::string can_type;
+    if (canfd_) {
+      can_type = "FD";
+      rx_fd_frame_ = std::make_shared<struct canfd_frame>();
+    } else {
+      can_type = "STD";
+      rx_std_frame_ = std::make_shared<struct can_frame>();
+    }
+    if (receiver_ != nullptr) {
+      try {
+        bool result =
+          canfd_ ? receiver_->receive(rx_fd_frame_, std::chrono::nanoseconds(nano_timeout_))
+                 : receiver_->receive(rx_std_frame_, std::chrono::nanoseconds(nano_timeout_));
+        if (result) {
+          is_timeout_ = false;
+          return rx_fd_frame_;
+        } else {
+          return nullptr;
+        }
+      } catch (const std::exception & ex) {
+        if (ex.what()[0] == '$') {
+          is_timeout_ = true;
+          return nullptr;
+        }
+      }
+    } else {
+      isthreadrunning_ = false;
+      printf(
+        C_RED
+        "[CAN_RX %s][ERROR][%s] Error receiving CAN %s message: %s, "
+        "no receiver init\r\n" C_END,
+        can_type.c_str(), name_.c_str(), can_type.c_str(), interface_.c_str());
+    }
+    return nullptr;
+  }
+
+#ifdef COMMON_PROTOCOL_TEST
+  bool testing_setcandata(can_frame frame)
+  {
+    if (can_std_callback_ != nullptr) {
+      can_std_callback_(std::make_shared<struct can_frame>(frame));
+      return true;
+    }
+    return false;
+  }
+  bool testing_setcandata(canfd_frame frame)
+  {
+    if (can_fd_callback_ != nullptr) {
+      can_fd_callback_(std::make_shared<struct canfd_frame>(frame));
+      return true;
+    }
+    return false;
+  }
+#endif  // COMMON_PROTOCOL_TEST
+
+private:
+  bool ready_;
+  bool canfd_;
+  bool is_timeout_;
+  bool extended_frame_;
+  bool isthreadrunning_;
+  int64_t nano_timeout_;
+  std::string name_;
+  std::string interface_;
+  can_std_callback can_std_callback_;
+  can_fd_callback can_fd_callback_;
+  std::unique_ptr<std::thread> main_T_;
+  std::shared_ptr<struct can_frame> rx_std_frame_;
+  std::shared_ptr<struct canfd_frame> rx_fd_frame_;
+  std::unique_ptr<tita::socket_can::SocketCanReceiver> receiver_;
+  uint8_t can_id_offset_ = 0;
+  void init(
+    const std::string & interface, const std::string & name, bool canfd_on,
+    can_std_callback std_callback, can_fd_callback fd_callback, bool is_block, int64_t nano_timeout)
+  {
+    name_ = name;
+    interface_ = interface;
+    canfd_ = canfd_on;
+    nano_timeout_ = nano_timeout;
+    is_timeout_ = false;
+    interface_ = interface;
+    can_std_callback_ = std_callback;
+    can_fd_callback_ = fd_callback;
+    try {
+      receiver_ = std::make_unique<tita::socket_can::SocketCanReceiver>(interface_, canfd_);
+      if (!is_block) {
+        isthreadrunning_ = true;
+        ready_ = true;
+        main_T_ = std::make_unique<std::thread>(std::bind(&CanRxDev::main_recv_func, this));
+      }
+    } catch (const std::exception & ex) {
+      printf(
+        C_RED "[CAN_RX][ERROR][%s] %s receiver creat error! %s\r\n" C_END, name_.c_str(),
+        interface_.c_str(), ex.what());
+      return;
+    }
+  }
+
+  bool wait_for_can_data()
+  {
+    tita::socket_can::CanId receive_id{};
+    std::string can_type;
+    if (canfd_) {
+      can_type = "FD";
+      rx_fd_frame_ = std::make_shared<struct canfd_frame>();
+    } else {
+      can_type = "STD";
+      rx_std_frame_ = std::make_shared<struct can_frame>();
+    }
+
+    if (receiver_ != nullptr) {
+      try {
+        bool result =
+          canfd_ ? receiver_->receive(rx_fd_frame_, std::chrono::nanoseconds(nano_timeout_))
+                 : receiver_->receive(rx_std_frame_, std::chrono::nanoseconds(nano_timeout_));
+        if (result) {
+          is_timeout_ = false;
+        }
+        return result;
+      } catch (const std::exception & ex) {
+        if (ex.what()[0] == '$') {
+          is_timeout_ = true;
+          return false;
+        }
+        printf(
+          C_RED "[CAN_RX %s][ERROR][%s] Error receiving CAN %s message: %s - %s\n" C_END,
+          can_type.c_str(), name_.c_str(), can_type.c_str(), interface_.c_str(), ex.what());
+      }
+    } else {
+      isthreadrunning_ = false;
+      printf(
+        C_RED
+        "[CAN_RX %s][ERROR][%s] Error receiving CAN %s message: %s, "
+        "no receiver init\r\n" C_END,
+        can_type.c_str(), name_.c_str(), can_type.c_str(), interface_.c_str());
+    }
+    return false;
+  }
+
+  void main_recv_func()
+  {
+#ifdef DEBUG_LOG
+    printf("[CAN_RX][INFO][%s] Start recv thread: %s\r\n", interface_.c_str(), name_.c_str());
+#endif  // DEBUG_LOG
+    while (isthreadrunning_ && ready_) {
+      if (wait_for_can_data()) {
+        if (!canfd_ && can_std_callback_ != nullptr) {
+          can_std_callback_(rx_std_frame_);
+        } else if (canfd_ && can_fd_callback_ != nullptr) {
+          can_fd_callback_(rx_fd_frame_);
+        }
+      }
+    }
+#ifdef DEBUG_LOG
+    printf("[CAN_RX][INFO][%s] Exit recv thread: %s\r\n", interface_.c_str(), name_.c_str());
+#endif  // DEBUG_LOG
+  }
+};
+
+class CanTxDev
+{
+public:
+  explicit CanTxDev(
+    const std::string & interface, const std::string & name, bool extended_frame, bool canfd_on,
+    int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    can_id_offset_ = can_id_offset;
+    ready_ = false;
+    name_ = name;
+    nano_timeout_ = nano_timeout;
+    is_timeout_ = false;
+    canfd_on_ = canfd_on;
+    interface_ = interface;
+    extended_frame_ = extended_frame;
+    try {
+      sender_ = std::make_unique<tita::socket_can::SocketCanSender>(interface_, canfd_on_);
+    } catch (const std::exception & ex) {
+      printf(
+        C_RED "[CAN_TX][ERROR][%s] %s sender creat error! %s\r\n" C_END, name_.c_str(),
+        interface_.c_str(), ex.what());
+      return;
+    }
+    ready_ = true;
+  }
+
+  ~CanTxDev()
+  {
+    ready_ = false;
+    sender_ = nullptr;
+  }
+
+  bool send_can_message(struct can_frame & tx_frame)
+  {
+    return send_can_message(&tx_frame, nullptr);
+  }
+  bool send_can_message(struct canfd_frame & tx_frame)
+  {
+    return send_can_message(nullptr, &tx_frame);
+  }
+
+  bool is_ready() { return ready_; }
+  bool is_timeout() { return is_timeout_; }
+
+private:
+  bool ready_;
+  bool canfd_on_;
+  bool is_timeout_;
+  bool extended_frame_;
+  int64_t nano_timeout_;
+  std::string name_;
+  std::string interface_;
+  std::unique_ptr<tita::socket_can::SocketCanSender> sender_;
+  uint8_t can_id_offset_;
+
+  bool send_can_message(struct can_frame * std_frame, struct canfd_frame * fd_frame)
+  {
+    bool self_fd = (fd_frame != nullptr);
+    std::string can_type = self_fd ? "FD" : "STD";
+    if (canfd_on_ != self_fd) {
+      printf(
+        C_RED
+        "[CAN_TX %s][ERROR][%s] Error sending CAN message: %s - "
+        "Not support can/canfd frame mixed\r\n" C_END,
+        can_type.c_str(), name_.c_str(), interface_.c_str());
+      return false;
+    }
+    canid_t * canid = self_fd ? &fd_frame->can_id : &std_frame->can_id;
+
+    bool result = true;
+    tita::socket_can::CanId send_id =
+      extended_frame_
+        ? tita::socket_can::CanId(
+            *canid, tita::socket_can::FrameType::DATA, tita::socket_can::ExtendedFrame)
+        : tita::socket_can::CanId(
+            *canid, tita::socket_can::FrameType::DATA, tita::socket_can::StandardFrame);
+    if (sender_ != nullptr) {
+      try {
+        if (self_fd) {
+          sender_->send_fd(
+            fd_frame->data, (fd_frame->len == 0) ? 64 : fd_frame->len, send_id,
+            std::chrono::nanoseconds(nano_timeout_));
+          is_timeout_ = false;
+        } else {
+          sender_->send(
+            std_frame->data, (std_frame->can_dlc == 0) ? 8 : std_frame->can_dlc, send_id,
+            std::chrono::nanoseconds(nano_timeout_));
+          is_timeout_ = false;
+        }
+      } catch (const std::exception & ex) {
+        if (ex.what()[0] == '$') {
+          is_timeout_ = true;
+          return false;
+        }
+        result = false;
+        printf(
+          C_RED "[CAN_TX %s][ERROR][%s] Error sending CAN message: %s - %s\r\n" C_END,
+          can_type.c_str(), name_.c_str(), interface_.c_str(), ex.what());
+      }
+    } else {
+      result = false;
+      printf(
+        C_RED "[CAN_TX %s][ERROR][%s] Error sending CAN message: %s - No device\r\n" C_END,
+        can_type.c_str(), name_.c_str(), interface_.c_str());
+    }
+    return result;
+  }
+};
+
+class CanDev
+{
+public:
+  explicit CanDev(
+    const std::string & interface, const std::string & name, bool extended_frame,
+    can_std_callback recv_callback, bool is_block, int64_t nano_timeout = -1,
+    uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    name_ = name;
+    send_only_ = false;
+    tx_op_ = std::make_unique<CanTxDev>(
+      interface, name_, extended_frame, false, nano_timeout, can_id_offset_);
+    rx_op_ = std::make_unique<CanRxDev>(
+      interface, name_, recv_callback, is_block, nano_timeout, can_id_offset_);
+  }
+  explicit CanDev(
+    const std::string & interface, const std::string & name, bool extended_frame,
+    can_fd_callback recv_callback, bool is_block, int64_t nano_timeout = -1,
+    uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    name_ = name;
+    send_only_ = false;
+    tx_op_ = std::make_unique<CanTxDev>(
+      interface, name_, extended_frame, true, nano_timeout, can_id_offset_);
+    rx_op_ = std::make_unique<CanRxDev>(
+      interface, name_, recv_callback, is_block, nano_timeout, can_id_offset_);
+  }
+  explicit CanDev(
+    const std::string & interface, const std::string & name, bool extended_frame, bool canfd_on,
+    int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    name_ = name;
+    send_only_ = true;
+    tx_op_ = std::make_unique<CanTxDev>(
+      interface, name_, extended_frame, canfd_on, nano_timeout, can_id_offset_);
+  }
+
+  ~CanDev()
+  {
+    rx_op_ = nullptr;
+    tx_op_ = nullptr;
+  }
+
+  std::shared_ptr<canfd_frame> receive_can_message_block()
+  {
+    return rx_op_->wait_for_can_data_block();
+  }
+
+  bool send_can_message(struct can_frame & tx_frame)
+  {
+#ifdef COMMON_PROTOCOL_TEST
+    if (rx_op_ != nullptr) {
+      return rx_op_->testing_setcandata(tx_frame);
+    }
+    return false;
+#else
+    if (tx_op_ != nullptr) {
+      return tx_op_->send_can_message(tx_frame);
+    }
+    return false;
+#endif  // COMMON_PROTOCOL_TEST
+  }
+
+  bool send_can_message(struct canfd_frame & tx_frame)
+  {
+#ifdef COMMON_PROTOCOL_TEST
+    if (rx_op_ != nullptr) {
+      return rx_op_->testing_setcandata(tx_frame);
+    }
+    return false;
+#else
+    if (tx_op_ != nullptr) {
+      return tx_op_->send_can_message(tx_frame);
+    }
+    return false;
+#endif  // COMMON_PROTOCOL_TEST
+  }
+
+  void set_filter(const struct can_filter filter[], size_t s)
+  {
+    if (rx_op_ != nullptr) {
+      rx_op_->set_filter(filter, s);
+    }
+  }
+  bool is_send_only() { return send_only_; }
+  bool is_ready()
+  {
+    bool result = (tx_op_ == nullptr) ? false : tx_op_->is_ready();
+    if (send_only_) {
+      return result;
+    } else {
+      return result && ((rx_op_ == nullptr) ? false : rx_op_->is_ready());
+    }
+  }
+  bool is_rx_timeout() { return rx_op_->is_timeout(); }
+  bool is_tx_timeout() { return tx_op_->is_timeout(); }
+
+private:
+  bool send_only_;
+  std::string name_;
+  std::unique_ptr<CanRxDev> rx_op_;
+  std::unique_ptr<CanTxDev> tx_op_;
+  uint8_t can_id_offset_ = 0;
+};
+
+}  // namespace socket_can
+}  // namespace tita
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__CAN_UTILS_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/protocol/can_utils.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/protocol/can_utils.hpp
@@ -38,7 +38,7 @@
 #else
 #pragma GCC optimize("O0")
 #endif
-namespace tita
+namespace can_device
 {
 namespace socket_can
 {
@@ -84,7 +84,7 @@ public:
 
   std::shared_ptr<canfd_frame> wait_for_can_data_block()
   {
-    tita::socket_can::CanId receive_id{};
+    can_device::socket_can::CanId receive_id{};
     std::string can_type;
     if (canfd_) {
       can_type = "FD";
@@ -154,7 +154,7 @@ private:
   std::unique_ptr<std::thread> main_T_;
   std::shared_ptr<struct can_frame> rx_std_frame_;
   std::shared_ptr<struct canfd_frame> rx_fd_frame_;
-  std::unique_ptr<tita::socket_can::SocketCanReceiver> receiver_;
+  std::unique_ptr<can_device::socket_can::SocketCanReceiver> receiver_;
   uint8_t can_id_offset_ = 0;
   void init(
     const std::string & interface, const std::string & name, bool canfd_on,
@@ -169,7 +169,7 @@ private:
     can_std_callback_ = std_callback;
     can_fd_callback_ = fd_callback;
     try {
-      receiver_ = std::make_unique<tita::socket_can::SocketCanReceiver>(interface_, canfd_);
+      receiver_ = std::make_unique<can_device::socket_can::SocketCanReceiver>(interface_, canfd_);
       if (!is_block) {
         isthreadrunning_ = true;
         ready_ = true;
@@ -185,7 +185,7 @@ private:
 
   bool wait_for_can_data()
   {
-    tita::socket_can::CanId receive_id{};
+    can_device::socket_can::CanId receive_id{};
     std::string can_type;
     if (canfd_) {
       can_type = "FD";
@@ -261,7 +261,7 @@ public:
     interface_ = interface;
     extended_frame_ = extended_frame;
     try {
-      sender_ = std::make_unique<tita::socket_can::SocketCanSender>(interface_, canfd_on_);
+      sender_ = std::make_unique<can_device::socket_can::SocketCanSender>(interface_, canfd_on_);
     } catch (const std::exception & ex) {
       printf(
         C_RED "[CAN_TX][ERROR][%s] %s sender creat error! %s\r\n" C_END, name_.c_str(),
@@ -297,7 +297,7 @@ private:
   int64_t nano_timeout_;
   std::string name_;
   std::string interface_;
-  std::unique_ptr<tita::socket_can::SocketCanSender> sender_;
+  std::unique_ptr<can_device::socket_can::SocketCanSender> sender_;
   uint8_t can_id_offset_;
 
   bool send_can_message(struct can_frame * std_frame, struct canfd_frame * fd_frame)
@@ -315,12 +315,12 @@ private:
     canid_t * canid = self_fd ? &fd_frame->can_id : &std_frame->can_id;
 
     bool result = true;
-    tita::socket_can::CanId send_id =
+    can_device::socket_can::CanId send_id =
       extended_frame_
-        ? tita::socket_can::CanId(
-            *canid, tita::socket_can::FrameType::DATA, tita::socket_can::ExtendedFrame)
-        : tita::socket_can::CanId(
-            *canid, tita::socket_can::FrameType::DATA, tita::socket_can::StandardFrame);
+        ? can_device::socket_can::CanId(
+            *canid, can_device::socket_can::FrameType::DATA, can_device::socket_can::ExtendedFrame)
+        : can_device::socket_can::CanId(
+            *canid, can_device::socket_can::FrameType::DATA, can_device::socket_can::StandardFrame);
     if (sender_ != nullptr) {
       try {
         if (self_fd) {
@@ -463,6 +463,6 @@ private:
 };
 
 }  // namespace socket_can
-}  // namespace tita
+}  // namespace can_device
 
 #endif  // POWER_CONTROLLER__UTILS__PROTOCOL__CAN_UTILS_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/protocol/socket_can_common.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/protocol/socket_can_common.hpp
@@ -1,0 +1,122 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_COMMON_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_COMMON_HPP_
+
+#include <linux/can.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <sys/time.h>
+
+#include <chrono>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+
+#define GCC_OPTIMIZE_03
+
+#ifdef GCC_OPTIMIZE_03
+#pragma GCC optimize("O3")
+#else
+#pragma GCC optimize("O0")
+#endif
+
+namespace tita
+{
+namespace socket_can
+{
+inline bool bind_can_socket(int & fd, const std::string & interface, const bool canfd_on = false)
+{
+  if (interface.length() >= static_cast<std::string::size_type>(IFNAMSIZ)) {
+    throw std::domain_error{"CAN interface name too long"};
+    return false;
+  }
+
+  fd = socket(PF_CAN, static_cast<int32_t>(SOCK_RAW), CAN_RAW);
+  if (0 > fd) {
+    throw std::runtime_error{"Failed to open CAN socket"};
+    return false;
+  }
+
+  // Make it non-blocking so we can use timeouts
+
+  struct ifreq ifr;
+  (void)strncpy(&ifr.ifr_name[0U], interface.c_str(), IFNAMSIZ - 1);
+  ifr.ifr_name[IFNAMSIZ - 1] = '\0';
+  ifr.ifr_ifindex = if_nametoindex(ifr.ifr_name);
+  if (!ifr.ifr_ifindex) {
+    perror("if_nametoindex");
+    return false;
+  }
+
+  struct sockaddr_can addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.can_family = AF_CAN;
+  addr.can_ifindex = ifr.ifr_ifindex;
+
+  if (canfd_on) {
+    if (ioctl(fd, SIOCGIFMTU, &ifr) < 0) {
+      throw std::runtime_error{"Failed to set CAN FD socket name via ioctl()"};
+      return false;
+    }
+    if (ifr.ifr_mtu != CANFD_MTU) {
+      throw std::runtime_error{"Interface does not support CAN FD"};
+      return false;
+    }
+    int _canfd_on = canfd_on ? 1 : 0;
+    auto ret = setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FD_FRAMES, &_canfd_on, sizeof(_canfd_on));
+    if (ret) {
+      throw std::runtime_error{"error whem enable canfd"};
+      return false;
+    }
+  }
+
+  /* disable default receive filter on this RAW socket */
+  /* This is obsolete as we do not read from the socket at all, but for */
+  /* this reason we can remove the receive list in the Kernel to save a */
+  /* little (really a very little!) CPU usage.                          */
+  setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FILTER, NULL, 0);
+
+  if (0 > bind(fd, (struct sockaddr *)&addr, sizeof(addr))) {
+    throw std::runtime_error{"Failed to bind CAN socket"};
+    return false;
+  }
+
+  return true;
+}
+
+inline struct timeval to_timeval(const std::chrono::nanoseconds timeout) noexcept
+{
+  const auto count = timeout.count();
+  constexpr auto BILLION = 1'000'000'000LL;
+  struct timeval c_timeout;
+  c_timeout.tv_sec = static_cast<decltype(c_timeout.tv_sec)>(count / BILLION);
+  c_timeout.tv_usec = static_cast<decltype(c_timeout.tv_usec)>((count % BILLION) * (0.001));
+
+  return c_timeout;
+}
+
+inline fd_set single_set(int32_t file_descriptor) noexcept
+{
+  fd_set descriptor_set;
+  FD_ZERO(&descriptor_set);
+  FD_SET(file_descriptor, &descriptor_set);
+
+  return descriptor_set;
+}
+}  // namespace socket_can
+}  // namespace tita
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_COMMON_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/protocol/socket_can_common.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/protocol/socket_can_common.hpp
@@ -33,7 +33,7 @@
 #pragma GCC optimize("O0")
 #endif
 
-namespace tita
+namespace can_device
 {
 namespace socket_can
 {
@@ -117,6 +117,6 @@ inline fd_set single_set(int32_t file_descriptor) noexcept
   return descriptor_set;
 }
 }  // namespace socket_can
-}  // namespace tita
+}  // namespace can_device
 
 #endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_COMMON_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/protocol/socket_can_id.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/protocol/socket_can_id.hpp
@@ -1,0 +1,188 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_ID_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_ID_HPP_
+
+#include <linux/can.h>
+
+#include <stdexcept>
+#include <utility>
+
+#include "visibility_control.hpp"
+
+namespace tita
+{
+namespace socket_can
+{
+using IdT = uint32_t;
+using LengthT = uint32_t;
+
+constexpr std::size_t MAX_DATA_LENGTH = 64U;
+
+static_assert(
+  MAX_DATA_LENGTH == sizeof(std::declval<struct canfd_frame>().data),
+  "Unexpected CAN frame data size");
+static_assert(std::is_same<IdT, canid_t>::value, "Underlying type of CanId is incorrect");
+constexpr IdT EXTENDED_MASK = CAN_EFF_FLAG;
+constexpr IdT REMOTE_MASK = CAN_RTR_FLAG;
+constexpr IdT ERROR_MASK = CAN_ERR_FLAG;
+constexpr IdT EXTENDED_ID_MASK = CAN_EFF_MASK;
+constexpr IdT STANDARD_ID_MASK = CAN_SFF_MASK;
+
+class SOCKETCAN_PUBLIC SocketCanTimeout : public std::runtime_error
+{
+public:
+  explicit SocketCanTimeout(const char * const what) : runtime_error{what} {};
+};  // class SocketCanTimeout
+
+enum class FrameType : uint32_t { DATA, ERROR, REMOTE };
+
+struct StandardFrame_
+{
+};
+
+constexpr StandardFrame_ StandardFrame;
+
+struct ExtendedFrame_
+{
+};
+
+constexpr ExtendedFrame_ ExtendedFrame;
+
+class SOCKETCAN_PUBLIC CanId
+{
+public:
+  CanId() = default;
+  explicit CanId(const IdT raw_id, const LengthT data_length = 0U)
+  : m_id{raw_id}, m_data_length{data_length}
+  {
+    (void)frame_type();
+  }
+
+  CanId(const IdT id, FrameType type, StandardFrame_) : CanId{id, type, false} {}
+  CanId(const IdT id, FrameType type, ExtendedFrame_) : CanId{id, type, true} {}
+
+  CanId & standard() noexcept
+  {
+    m_id = m_id & (~EXTENDED_MASK);
+    return *this;
+  }
+
+  CanId & extended() noexcept
+  {
+    m_id = m_id | EXTENDED_MASK;
+    return *this;
+  }
+
+  CanId & error_frame() noexcept
+  {
+    m_id = m_id & (~REMOTE_MASK);
+    m_id = m_id | ERROR_MASK;
+    return *this;
+  }
+
+  CanId & remote_frame() noexcept
+  {
+    m_id = m_id & (~ERROR_MASK);
+    m_id = m_id | REMOTE_MASK;
+    return *this;
+  }
+
+  CanId & data_frame() noexcept
+  {
+    m_id = m_id & (~ERROR_MASK);
+    m_id = m_id & (~REMOTE_MASK);
+    return *this;
+  }
+
+  CanId & frame_type(const FrameType type)
+  {
+    switch (type) {
+      case FrameType::DATA:
+        (void)data_frame();
+        break;
+      case FrameType::ERROR:
+        (void)error_frame();
+        break;
+      case FrameType::REMOTE:
+        (void)remote_frame();
+        break;
+      default:
+        throw std::logic_error{"CanId: No such type"};
+    }
+    return *this;
+  }
+
+  CanId & identifier(const IdT id)
+  {
+    constexpr auto MAX_EXTENDED = 0x1FBF'FFFFU;
+    constexpr auto MAX_STANDARD = 0x7FFU;
+
+    static_assert(MAX_EXTENDED <= EXTENDED_ID_MASK, "Max extended id value is wrong");
+    static_assert(MAX_STANDARD <= STANDARD_ID_MASK, "Max standed id value is wrong");
+    const auto max_id = is_extended() ? MAX_EXTENDED : MAX_STANDARD;
+    if (max_id < id) {
+      throw std::domain_error{"CanId would be truncated!"};
+    }
+    m_id = m_id & (~EXTENDED_ID_MASK);
+    m_id = m_id | id;
+    return *this;
+  }
+
+  IdT identifier() const noexcept
+  {
+    const auto mask = is_extended() ? EXTENDED_ID_MASK : STANDARD_ID_MASK;
+    return m_id & mask;
+  }
+
+  IdT get() const noexcept { return m_id; }
+
+  bool is_extended() const noexcept { return (m_id & EXTENDED_MASK) == EXTENDED_MASK; }
+
+  FrameType frame_type() const
+  {
+    const auto is_error = (m_id & ERROR_MASK) == ERROR_MASK;
+    const auto is_remote = (m_id & REMOTE_MASK) == REMOTE_MASK;
+    if (is_error && is_remote) {
+      throw std::domain_error{"CanId has both bit 29 and 30 set! Inconsistent"};
+    }
+    if (is_error) {
+      return FrameType::ERROR;
+    }
+    if (is_remote) {
+      return FrameType::REMOTE;
+    }
+    return FrameType::DATA;
+  }
+
+  LengthT length() const noexcept { return m_data_length; }
+  IdT m_id{};
+
+private:
+  SOCKETCAN_LOCAL CanId(const IdT id, FrameType type, bool is_extended)
+  {
+    if (is_extended) {
+      (void)extended();
+    }
+    (void)frame_type(type);
+    (void)identifier(id);
+  }
+
+  LengthT m_data_length{};
+};  // class CanId
+}  // namespace socket_can
+}  // namespace tita
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_ID_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/protocol/socket_can_id.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/protocol/socket_can_id.hpp
@@ -22,7 +22,7 @@
 
 #include "visibility_control.hpp"
 
-namespace tita
+namespace can_device
 {
 namespace socket_can
 {
@@ -183,6 +183,6 @@ private:
   LengthT m_data_length{};
 };  // class CanId
 }  // namespace socket_can
-}  // namespace tita
+}  // namespace can_device
 
 #endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_ID_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/protocol/socket_can_receiver.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/protocol/socket_can_receiver.hpp
@@ -1,0 +1,147 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_RECEIVER_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_RECEIVER_HPP_
+#include <linux/can.h>
+#include <linux/can/raw.h>
+#include <sys/socket.h>
+#include <unistd.h>  // for close()
+
+#include <chrono>
+#include <cstring>
+#include <memory>
+#include <string>
+
+#include "socket_can_common.hpp"
+#include "socket_can_id.hpp"
+#include "visibility_control.hpp"
+
+#define TARGET_CAN_DEVICE "vcan0"
+
+namespace tita
+{
+namespace socket_can
+{
+// using target_can_device = static_cast<std::string>(TARGET_CAN_DEVICE);
+
+class SOCKETCAN_PUBLIC SocketCanReceiver
+{
+public:
+  explicit SocketCanReceiver(
+    const std::string & interface = TARGET_CAN_DEVICE, bool canfd_on = false)
+  {
+    if (!bind_can_socket(fd_, interface, canfd_on)) {
+      printf("bind_can_socket failed!\r\n");
+      return;
+    }
+  }
+
+  ~SocketCanReceiver() noexcept { (void)close(fd_); }
+
+  bool receive(
+    std::shared_ptr<struct can_frame> rx_frame,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero())
+  {
+    wait(timeout);
+
+    struct canfd_frame frame;
+    memset(&frame, 0, sizeof(frame));
+    const auto nbytes = read(fd_, &frame, sizeof(frame));
+
+    if (nbytes < 0) {
+      throw std::runtime_error{strerror(errno)};
+    }
+    if (static_cast<std::size_t>(nbytes) < CAN_MTU) {
+      throw std::logic_error{"read: incomplete CAN frame"};
+    }
+    if (static_cast<std::size_t>(nbytes) != CAN_MTU) {
+      throw std::logic_error{"Message was wrong size"};
+    }
+
+    auto receive_id = CanId{frame.can_id, frame.len};
+    if (receive_id.frame_type() == tita::socket_can::FrameType::DATA) {
+      rx_frame->can_id = receive_id.standard().get();
+      rx_frame->can_id = receive_id.length();
+      std::memcpy(rx_frame->data, frame.data, sizeof(rx_frame->data));
+      return true;
+    }
+    return false;
+  }
+
+  bool receive(
+    std::shared_ptr<struct canfd_frame> rx_frame,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero())
+  {
+    wait(timeout);
+
+    struct canfd_frame frame;
+    const auto nbytes = read(fd_, &frame, sizeof(frame));
+
+    uint8_t except_len = CAN_MTU - 8 + frame.len;
+    if (nbytes < 0) {
+      throw std::runtime_error{strerror(errno)};
+    }
+    if (static_cast<std::size_t>(nbytes) < except_len) {
+      throw std::runtime_error{"read: incomplete CAN frame"};
+    }
+
+    auto receive_id = CanId{frame.can_id, frame.len};
+    if (receive_id.frame_type() == tita::socket_can::FrameType::DATA) {
+      rx_frame->can_id = receive_id.standard().get();
+      rx_frame->len = receive_id.length();
+      std::memcpy(rx_frame->data, frame.data, sizeof(rx_frame->data));
+      return true;
+    }
+    return false;
+  }
+
+  void set_filter(const struct can_filter filter[], size_t s)
+  {
+    setsockopt(fd_, SOL_CAN_RAW, CAN_RAW_FILTER, filter, s);
+  }
+
+private:
+  SOCKETCAN_LOCAL void wait(const std::chrono::nanoseconds timeout) const
+  {
+    if (decltype(timeout)::zero() < timeout) {
+      auto c_timeout = to_timeval(timeout);
+      auto read_set = single_set(fd_);
+
+      if (0 == select(fd_ + 1, &read_set, NULL, NULL, &c_timeout)) {
+        throw SocketCanTimeout{"$CAN Receive Timeout 1"};
+      }
+
+      if (!FD_ISSET(fd_, &read_set)) {
+        throw SocketCanTimeout{"$CAN Receive Timeout 2"};
+      }
+    } else {
+      auto read_set = single_set(fd_);
+
+      if (0 == select(fd_ + 1, &read_set, NULL, NULL, NULL)) {
+        throw SocketCanTimeout{"$CAN Receive Timeout 1"};
+      }
+
+      if (!FD_ISSET(fd_, &read_set)) {
+        throw SocketCanTimeout{"CAN Receive Timeout 2"};
+      }
+    }
+  }
+
+  int32_t fd_;
+};  // class SocketCanReceiver
+}  // namespace socket_can
+}  // namespace tita
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_RECEIVER_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/protocol/socket_can_receiver.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/protocol/socket_can_receiver.hpp
@@ -28,9 +28,7 @@
 #include "socket_can_id.hpp"
 #include "visibility_control.hpp"
 
-#define TARGET_CAN_DEVICE "vcan0"
-
-namespace tita
+namespace can_device
 {
 namespace socket_can
 {
@@ -40,7 +38,7 @@ class SOCKETCAN_PUBLIC SocketCanReceiver
 {
 public:
   explicit SocketCanReceiver(
-    const std::string & interface = TARGET_CAN_DEVICE, bool canfd_on = false)
+    const std::string & interface = "can0", bool canfd_on = false)
   {
     if (!bind_can_socket(fd_, interface, canfd_on)) {
       printf("bind_can_socket failed!\r\n");
@@ -71,7 +69,7 @@ public:
     }
 
     auto receive_id = CanId{frame.can_id, frame.len};
-    if (receive_id.frame_type() == tita::socket_can::FrameType::DATA) {
+    if (receive_id.frame_type() == can_device::socket_can::FrameType::DATA) {
       rx_frame->can_id = receive_id.standard().get();
       rx_frame->can_id = receive_id.length();
       std::memcpy(rx_frame->data, frame.data, sizeof(rx_frame->data));
@@ -98,7 +96,7 @@ public:
     }
 
     auto receive_id = CanId{frame.can_id, frame.len};
-    if (receive_id.frame_type() == tita::socket_can::FrameType::DATA) {
+    if (receive_id.frame_type() == can_device::socket_can::FrameType::DATA) {
       rx_frame->can_id = receive_id.standard().get();
       rx_frame->len = receive_id.length();
       std::memcpy(rx_frame->data, frame.data, sizeof(rx_frame->data));
@@ -142,6 +140,6 @@ private:
   int32_t fd_;
 };  // class SocketCanReceiver
 }  // namespace socket_can
-}  // namespace tita
+}  // namespace can_device
 
 #endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_RECEIVER_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/protocol/socket_can_sender.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/protocol/socket_can_sender.hpp
@@ -1,0 +1,168 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_SENDER_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_SENDER_HPP_
+
+#include <linux/can.h>
+#include <linux/can/raw.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <stdexcept>
+#include <string>
+
+#include "socket_can_common.hpp"
+#include "socket_can_id.hpp"
+#include "visibility_control.hpp"
+
+namespace tita
+{
+namespace socket_can
+{
+class SOCKETCAN_PUBLIC SocketCanSender
+{
+public:
+  explicit SocketCanSender(
+    const std::string & interface = "can0", bool canfd_on = false,
+    const CanId & default_id = CanId{})
+  : m_default_id{default_id}
+  {
+    if (!bind_can_socket(fd_, interface, canfd_on)) {
+      printf("bind_can_socket failed\r\n");
+      return;
+    }
+  }
+  ~SocketCanSender() noexcept
+  {
+    (void)close(fd_);
+    // I'm destructing--there's not much else I can do on an error
+    // seem not good
+  }
+
+  void send(
+    const void * const data, const std::size_t Length,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    send(data, Length, m_default_id, timeout);
+  }
+
+  void send(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    if (length > MAX_DATA_LENGTH) {
+      throw std::domain_error{"Size is too large to send via CAN"};
+    }
+    send_impl(data, length, id, timeout);
+  }
+
+  template <typename T, typename = std::enable_if_t<!std::is_pointer<T>::value>>
+  void send(
+    const T & data, const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    send(data, m_default_id, timeout);
+  }
+
+  template <typename T, typename = std::enable_if<!std::is_pointer<T>::value>>
+  void send(
+    const T & data, const CanId id,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    static_assert(sizeof(data) <= MAX_DATA_LENGTH, "Data type too large for CAN");
+    send_impl(reinterpret_cast<const char *>(&data), sizeof(data), id, timeout);
+  }
+
+  void send_fd(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    if (length > MAX_DATA_LENGTH) {
+      throw std::domain_error{"Size is too large to send via CAN"};
+    }
+    send_fd_impl(data, length, id, timeout);
+  }
+
+  CanId default_id() const noexcept { return m_default_id; }
+
+private:
+  void send_impl(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout) const
+  {
+    // (void)data;
+    // (void)length;
+    // (void)id;
+    (void)timeout;
+
+    struct can_frame data_frame;
+    data_frame.can_id = id.get();
+
+    data_frame.can_dlc = static_cast<decltype(data_frame.can_dlc)>(length);
+
+    (void)std::memcpy(static_cast<void *>(&data_frame.data[0U]), data, length);
+
+    if (write(fd_, &data_frame, static_cast<int>(CAN_MTU)) != static_cast<int>(CAN_MTU)) {
+      throw std::runtime_error{strerror(errno)};
+    }
+  }
+
+  void send_fd_impl(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout) const
+  {
+    // (void)data;
+    // (void)length;
+    // (void)id;
+    (void)timeout;
+
+    struct canfd_frame data_frame;
+    memset(&data_frame, 0, sizeof(data_frame));
+    data_frame.can_id = id.get();
+    data_frame.flags = CANFD_FDF | CANFD_BRS;
+    data_frame.len = static_cast<decltype(data_frame.len)>(length);
+    std::memcpy(static_cast<void *>(&data_frame.data[0U]), data, length);
+    if (write(fd_, &data_frame, CANFD_MTU) != CANFD_MTU) {
+      throw std::runtime_error{strerror(errno)};
+    }
+  }
+
+  SOCKETCAN_LOCAL void wait(const std::chrono::nanoseconds timeout) const
+  {
+    if (decltype(timeout)::zero() < timeout) {
+      auto c_timeout = to_timeval(timeout);
+      auto write_set = single_set(fd_);
+
+      // wait
+      if (0 == select(fd_ + 1, NULL, &write_set, NULL, &c_timeout)) {
+        throw SocketCanTimeout{"$CAN Send Timeout [1]"};
+      }
+
+      if (!FD_ISSET(fd_, &write_set)) {
+        throw SocketCanTimeout{"$CAN Send Timeout [2]"};
+      }
+    } else {
+      // do nothing
+      // auto write_set = single_set(fd_);
+    }
+  }
+
+  int32_t fd_;
+  CanId m_default_id;
+};
+}  // namespace socket_can
+}  // namespace tita
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_SENDER_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/protocol/socket_can_sender.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/protocol/socket_can_sender.hpp
@@ -28,7 +28,7 @@
 #include "socket_can_id.hpp"
 #include "visibility_control.hpp"
 
-namespace tita
+namespace can_device
 {
 namespace socket_can
 {
@@ -163,6 +163,6 @@ private:
   CanId m_default_id;
 };
 }  // namespace socket_can
-}  // namespace tita
+}  // namespace can_device
 
 #endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_SENDER_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/protocol/visibility_control.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/protocol/visibility_control.hpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__VISIBILITY_CONTROL_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__VISIBILITY_CONTROL_HPP_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+#ifdef __GNUC__
+#define SOCKETCAN_EXPORT __attribute__((dllexport))
+#define SOCKETCAN_IMPORT __attribute__((dllimport))
+#else
+#define SOCKETCAN_EXPORT __declspec(dllexport)
+#define SOCKETCAN_IMPORT __declspec(dllimport)
+#endif
+#ifdef SOCKETCAN_BUILDING_LIBRARY
+#define SOCKETCAN_PUBLIC SOCKETCAN_EXPORT
+#else
+#define SOCKETCAN_PUBLIC SOCKETCAN_IMPORT
+#endif
+#define SOCKETCAN_PUBLIC_TYPE SOCKETCAN_PUBLIC
+#define SOCKETCAN_LOCAL
+#else
+#define SOCKETCAN_EXPORT __attribute__((visibility("default")))
+#define SOCKETCAN_IMPORT
+#if __GNUC__ >= 4
+#define SOCKETCAN_PUBLIC __attribute__((visibility("default")))
+#define SOCKETCAN_LOCAL __attribute__((visibility("hidden")))
+#else
+#define SOCKETCAN_PUBLIC
+#define SOCKETCAN_LOCAL
+#endif
+#define SOCKETCAN_PUBLIC_TYPE
+#endif
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__VISIBILITY_CONTROL_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/router/include/titati_canfd_router/canfd_router_can_receive_api.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/router/include/titati_canfd_router/canfd_router_can_receive_api.hpp
@@ -1,0 +1,101 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CANFD_ROUTER_CAN_API_HPP_
+#define CANFD_ROUTER_CAN_API_HPP_
+
+#include <algorithm>
+#include <atomic>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <sys/time.h>
+#include <vector>
+
+#include "protocol/can_utils.hpp"
+
+namespace can_device
+{
+#define CAN_ID_CANFD_ROUTER (0x09FU)
+
+class CanfdRouterCanReceiveApi
+{
+public:
+  explicit CanfdRouterCanReceiveApi(
+    const std::string & can_interface = "can0", const std::string & rpc_interface = "")
+  : canfd_router_can_interface(can_interface),
+    set_forcedirect_can_interface(rpc_interface.empty() ? can_interface : rpc_interface)
+  {
+    canfd_router_can_receive_api = std::make_shared<tita::socket_can::CanDev>(
+      canfd_router_can_interface, canfd_router_can_name, canfd_router_can_extended_frame,
+      canfd_router_can_receive_callback, canfd_router_can_rx_is_block, canfd_router_timeout_us,
+      canfd_router_can_id_offset);
+
+    set_forcedirect_can_send_api = std::make_shared<tita::socket_can::CanDev>(
+      set_forcedirect_can_interface, set_forcedirect_can_name, set_forcedirect_can_extended_frame,
+      set_forcedirect_can_fd_mode, set_forcedirect_timeout_us, set_forcedirect_can_id_offset);
+
+    register_canfd_router_device_can_filter();
+  }
+  ~CanfdRouterCanReceiveApi() = default;
+
+  void set_forcedirect_mode(bool init_flag) { init_flag_ = init_flag; }
+
+private:
+#define MIN_TIME_OUT_US 1'000L      // 1ms
+#define MAX_TIME_OUT_US 3'000'000L  // 3s
+#define CAN_ID_AS_CANFD_ROUTER_INFO (0x09FU)
+#define CAN_MASK_AS_CANFD_ROUTER_INFO (0x0FFU)
+  std::string canfd_router_can_interface = "can0";
+  std::string canfd_router_can_name = "canfd_can";
+  bool canfd_router_can_extended_frame = false;
+  bool canfd_router_can_rx_is_block = false;
+  int64_t canfd_router_timeout_us = MAX_TIME_OUT_US;
+  uint8_t canfd_router_can_id_offset = 0x00U;
+
+  void register_canfd_router_device_can_filter();
+  tita::socket_can::can_fd_callback canfd_router_can_receive_callback =
+    std::bind(&CanfdRouterCanReceiveApi::get_board_can_data, this, std::placeholders::_1);
+  std::shared_ptr<tita::socket_can::CanDev> canfd_router_can_receive_api;
+
+  void get_board_can_data(std::shared_ptr<struct canfd_frame> recv_frame);
+
+  uint32_t timestamp_;
+  uint32_t mode_;
+  uint32_t heart_cnt_;
+
+  std::string set_forcedirect_can_interface = "can0";
+  std::string set_forcedirect_can_name = "set_forcedirect_can";
+  int64_t set_forcedirect_timeout_us = MAX_TIME_OUT_US;
+  uint8_t set_forcedirect_can_id_offset = 0x00U;
+  bool set_forcedirect_can_extended_frame = false;
+  bool set_forcedirect_can_fd_mode = true;
+  std::shared_ptr<tita::socket_can::CanDev> set_forcedirect_can_send_api;
+  inline uint32_t get_current_time()
+  {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return std::move(tv.tv_sec * 1000000 + tv.tv_usec);
+  }
+
+  bool init_flag_ = false;
+ 
+};
+
+}
+
+#endif  // CANFD_ROUTER_CAN_API_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/router/protocol/can_utils.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/router/protocol/can_utils.hpp
@@ -1,0 +1,468 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__CAN_UTILS_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__CAN_UTILS_HPP_
+
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "linux/can.h"
+#include "linux/can/error.h"
+#include "linux/can/raw.h"
+#include "socket_can_receiver.hpp"
+#include "socket_can_sender.hpp"
+
+#define C_END "\033[m"
+// #define C_RED "\033[0;32;31m"
+#define C_RED "\033[0;31m"
+#define C_YELLOW "\033[1;33m"
+
+#ifdef GCC_OPTIMIZE_03
+#pragma GCC optimize("O3")
+#else
+#pragma GCC optimize("O0")
+#endif
+namespace tita
+{
+namespace socket_can
+{
+using can_std_callback = std::function<void(std::shared_ptr<struct can_frame> recv_frame)>;
+using can_fd_callback = std::function<void(std::shared_ptr<struct canfd_frame> recv_frame)>;
+class CanRxDev
+{
+public:
+  explicit CanRxDev(
+    const std::string & interface, const std::string & name, can_std_callback recv_callback,
+    bool is_block, int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    init(interface, name, false, recv_callback, nullptr, is_block, nano_timeout);
+  }
+  explicit CanRxDev(
+    const std::string & interface, const std::string & name, can_fd_callback recv_callback,
+    bool is_block, int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    init(interface, name, true, nullptr, recv_callback, is_block, nano_timeout);
+  }
+
+  ~CanRxDev()
+  {
+    ready_ = false;
+    isthreadrunning_ = false;
+    if (main_T_ != nullptr) {
+      main_T_->join();
+    }
+    main_T_ = nullptr;
+    receiver_ = nullptr;
+  }
+
+  bool is_ready() { return ready_; }
+  bool is_timeout() { return is_timeout_; }
+  void set_filter(const struct can_filter filter[], size_t s)
+  {
+    if (receiver_ != nullptr) {
+      receiver_->set_filter(filter, s);
+    }
+  }
+
+  std::shared_ptr<canfd_frame> wait_for_can_data_block()
+  {
+    tita::socket_can::CanId receive_id{};
+    std::string can_type;
+    if (canfd_) {
+      can_type = "FD";
+      rx_fd_frame_ = std::make_shared<struct canfd_frame>();
+    } else {
+      can_type = "STD";
+      rx_std_frame_ = std::make_shared<struct can_frame>();
+    }
+    if (receiver_ != nullptr) {
+      try {
+        bool result =
+          canfd_ ? receiver_->receive(rx_fd_frame_, std::chrono::nanoseconds(nano_timeout_))
+                 : receiver_->receive(rx_std_frame_, std::chrono::nanoseconds(nano_timeout_));
+        if (result) {
+          is_timeout_ = false;
+          return rx_fd_frame_;
+        } else {
+          return nullptr;
+        }
+      } catch (const std::exception & ex) {
+        if (ex.what()[0] == '$') {
+          is_timeout_ = true;
+          return nullptr;
+        }
+      }
+    } else {
+      isthreadrunning_ = false;
+      printf(
+        C_RED
+        "[CAN_RX %s][ERROR][%s] Error receiving CAN %s message: %s, "
+        "no receiver init\r\n" C_END,
+        can_type.c_str(), name_.c_str(), can_type.c_str(), interface_.c_str());
+    }
+    return nullptr;
+  }
+
+#ifdef COMMON_PROTOCOL_TEST
+  bool testing_setcandata(can_frame frame)
+  {
+    if (can_std_callback_ != nullptr) {
+      can_std_callback_(std::make_shared<struct can_frame>(frame));
+      return true;
+    }
+    return false;
+  }
+  bool testing_setcandata(canfd_frame frame)
+  {
+    if (can_fd_callback_ != nullptr) {
+      can_fd_callback_(std::make_shared<struct canfd_frame>(frame));
+      return true;
+    }
+    return false;
+  }
+#endif  // COMMON_PROTOCOL_TEST
+
+private:
+  bool ready_;
+  bool canfd_;
+  bool is_timeout_;
+  bool extended_frame_;
+  bool isthreadrunning_;
+  int64_t nano_timeout_;
+  std::string name_;
+  std::string interface_;
+  can_std_callback can_std_callback_;
+  can_fd_callback can_fd_callback_;
+  std::unique_ptr<std::thread> main_T_;
+  std::shared_ptr<struct can_frame> rx_std_frame_;
+  std::shared_ptr<struct canfd_frame> rx_fd_frame_;
+  std::unique_ptr<tita::socket_can::SocketCanReceiver> receiver_;
+  uint8_t can_id_offset_ = 0;
+  void init(
+    const std::string & interface, const std::string & name, bool canfd_on,
+    can_std_callback std_callback, can_fd_callback fd_callback, bool is_block, int64_t nano_timeout)
+  {
+    name_ = name;
+    interface_ = interface;
+    canfd_ = canfd_on;
+    nano_timeout_ = nano_timeout;
+    is_timeout_ = false;
+    interface_ = interface;
+    can_std_callback_ = std_callback;
+    can_fd_callback_ = fd_callback;
+    try {
+      receiver_ = std::make_unique<tita::socket_can::SocketCanReceiver>(interface_, canfd_);
+      if (!is_block) {
+        isthreadrunning_ = true;
+        ready_ = true;
+        main_T_ = std::make_unique<std::thread>(std::bind(&CanRxDev::main_recv_func, this));
+      }
+    } catch (const std::exception & ex) {
+      printf(
+        C_RED "[CAN_RX][ERROR][%s] %s receiver creat error! %s\r\n" C_END, name_.c_str(),
+        interface_.c_str(), ex.what());
+      return;
+    }
+  }
+
+  bool wait_for_can_data()
+  {
+    tita::socket_can::CanId receive_id{};
+    std::string can_type;
+    if (canfd_) {
+      can_type = "FD";
+      rx_fd_frame_ = std::make_shared<struct canfd_frame>();
+    } else {
+      can_type = "STD";
+      rx_std_frame_ = std::make_shared<struct can_frame>();
+    }
+
+    if (receiver_ != nullptr) {
+      try {
+        bool result =
+          canfd_ ? receiver_->receive(rx_fd_frame_, std::chrono::nanoseconds(nano_timeout_))
+                 : receiver_->receive(rx_std_frame_, std::chrono::nanoseconds(nano_timeout_));
+        if (result) {
+          is_timeout_ = false;
+        }
+        return result;
+      } catch (const std::exception & ex) {
+        if (ex.what()[0] == '$') {
+          is_timeout_ = true;
+          return false;
+        }
+        printf(
+          C_RED "[CAN_RX %s][ERROR][%s] Error receiving CAN %s message: %s - %s\n" C_END,
+          can_type.c_str(), name_.c_str(), can_type.c_str(), interface_.c_str(), ex.what());
+      }
+    } else {
+      isthreadrunning_ = false;
+      printf(
+        C_RED
+        "[CAN_RX %s][ERROR][%s] Error receiving CAN %s message: %s, "
+        "no receiver init\r\n" C_END,
+        can_type.c_str(), name_.c_str(), can_type.c_str(), interface_.c_str());
+    }
+    return false;
+  }
+
+  void main_recv_func()
+  {
+#ifdef DEBUG_LOG
+    printf("[CAN_RX][INFO][%s] Start recv thread: %s\r\n", interface_.c_str(), name_.c_str());
+#endif  // DEBUG_LOG
+    while (isthreadrunning_ && ready_) {
+      if (wait_for_can_data()) {
+        if (!canfd_ && can_std_callback_ != nullptr) {
+          can_std_callback_(rx_std_frame_);
+        } else if (canfd_ && can_fd_callback_ != nullptr) {
+          can_fd_callback_(rx_fd_frame_);
+        }
+      }
+    }
+#ifdef DEBUG_LOG
+    printf("[CAN_RX][INFO][%s] Exit recv thread: %s\r\n", interface_.c_str(), name_.c_str());
+#endif  // DEBUG_LOG
+  }
+};
+
+class CanTxDev
+{
+public:
+  explicit CanTxDev(
+    const std::string & interface, const std::string & name, bool extended_frame, bool canfd_on,
+    int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    can_id_offset_ = can_id_offset;
+    ready_ = false;
+    name_ = name;
+    nano_timeout_ = nano_timeout;
+    is_timeout_ = false;
+    canfd_on_ = canfd_on;
+    interface_ = interface;
+    extended_frame_ = extended_frame;
+    try {
+      sender_ = std::make_unique<tita::socket_can::SocketCanSender>(interface_, canfd_on_);
+    } catch (const std::exception & ex) {
+      printf(
+        C_RED "[CAN_TX][ERROR][%s] %s sender creat error! %s\r\n" C_END, name_.c_str(),
+        interface_.c_str(), ex.what());
+      return;
+    }
+    ready_ = true;
+  }
+
+  ~CanTxDev()
+  {
+    ready_ = false;
+    sender_ = nullptr;
+  }
+
+  bool send_can_message(struct can_frame & tx_frame)
+  {
+    return send_can_message(&tx_frame, nullptr);
+  }
+  bool send_can_message(struct canfd_frame & tx_frame)
+  {
+    return send_can_message(nullptr, &tx_frame);
+  }
+
+  bool is_ready() { return ready_; }
+  bool is_timeout() { return is_timeout_; }
+
+private:
+  bool ready_;
+  bool canfd_on_;
+  bool is_timeout_;
+  bool extended_frame_;
+  int64_t nano_timeout_;
+  std::string name_;
+  std::string interface_;
+  std::unique_ptr<tita::socket_can::SocketCanSender> sender_;
+  uint8_t can_id_offset_;
+
+  bool send_can_message(struct can_frame * std_frame, struct canfd_frame * fd_frame)
+  {
+    bool self_fd = (fd_frame != nullptr);
+    std::string can_type = self_fd ? "FD" : "STD";
+    if (canfd_on_ != self_fd) {
+      printf(
+        C_RED
+        "[CAN_TX %s][ERROR][%s] Error sending CAN message: %s - "
+        "Not support can/canfd frame mixed\r\n" C_END,
+        can_type.c_str(), name_.c_str(), interface_.c_str());
+      return false;
+    }
+    canid_t * canid = self_fd ? &fd_frame->can_id : &std_frame->can_id;
+
+    bool result = true;
+    tita::socket_can::CanId send_id =
+      extended_frame_
+        ? tita::socket_can::CanId(
+            *canid, tita::socket_can::FrameType::DATA, tita::socket_can::ExtendedFrame)
+        : tita::socket_can::CanId(
+            *canid, tita::socket_can::FrameType::DATA, tita::socket_can::StandardFrame);
+    if (sender_ != nullptr) {
+      try {
+        if (self_fd) {
+          sender_->send_fd(
+            fd_frame->data, (fd_frame->len == 0) ? 64 : fd_frame->len, send_id,
+            std::chrono::nanoseconds(nano_timeout_));
+          is_timeout_ = false;
+        } else {
+          sender_->send(
+            std_frame->data, (std_frame->can_dlc == 0) ? 8 : std_frame->can_dlc, send_id,
+            std::chrono::nanoseconds(nano_timeout_));
+          is_timeout_ = false;
+        }
+      } catch (const std::exception & ex) {
+        if (ex.what()[0] == '$') {
+          is_timeout_ = true;
+          return false;
+        }
+        result = false;
+        printf(
+          C_RED "[CAN_TX %s][ERROR][%s] Error sending CAN message: %s - %s\r\n" C_END,
+          can_type.c_str(), name_.c_str(), interface_.c_str(), ex.what());
+      }
+    } else {
+      result = false;
+      printf(
+        C_RED "[CAN_TX %s][ERROR][%s] Error sending CAN message: %s - No device\r\n" C_END,
+        can_type.c_str(), name_.c_str(), interface_.c_str());
+    }
+    return result;
+  }
+};
+
+class CanDev
+{
+public:
+  explicit CanDev(
+    const std::string & interface, const std::string & name, bool extended_frame,
+    can_std_callback recv_callback, bool is_block, int64_t nano_timeout = -1,
+    uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    name_ = name;
+    send_only_ = false;
+    tx_op_ = std::make_unique<CanTxDev>(
+      interface, name_, extended_frame, false, nano_timeout, can_id_offset_);
+    rx_op_ = std::make_unique<CanRxDev>(
+      interface, name_, recv_callback, is_block, nano_timeout, can_id_offset_);
+  }
+  explicit CanDev(
+    const std::string & interface, const std::string & name, bool extended_frame,
+    can_fd_callback recv_callback, bool is_block, int64_t nano_timeout = -1,
+    uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    name_ = name;
+    send_only_ = false;
+    tx_op_ = std::make_unique<CanTxDev>(
+      interface, name_, extended_frame, true, nano_timeout, can_id_offset_);
+    rx_op_ = std::make_unique<CanRxDev>(
+      interface, name_, recv_callback, is_block, nano_timeout, can_id_offset_);
+  }
+  explicit CanDev(
+    const std::string & interface, const std::string & name, bool extended_frame, bool canfd_on,
+    int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    name_ = name;
+    send_only_ = true;
+    tx_op_ = std::make_unique<CanTxDev>(
+      interface, name_, extended_frame, canfd_on, nano_timeout, can_id_offset_);
+  }
+
+  ~CanDev()
+  {
+    rx_op_ = nullptr;
+    tx_op_ = nullptr;
+  }
+
+  std::shared_ptr<canfd_frame> receive_can_message_block()
+  {
+    return rx_op_->wait_for_can_data_block();
+  }
+
+  bool send_can_message(struct can_frame & tx_frame)
+  {
+#ifdef COMMON_PROTOCOL_TEST
+    if (rx_op_ != nullptr) {
+      return rx_op_->testing_setcandata(tx_frame);
+    }
+    return false;
+#else
+    if (tx_op_ != nullptr) {
+      return tx_op_->send_can_message(tx_frame);
+    }
+    return false;
+#endif  // COMMON_PROTOCOL_TEST
+  }
+
+  bool send_can_message(struct canfd_frame & tx_frame)
+  {
+#ifdef COMMON_PROTOCOL_TEST
+    if (rx_op_ != nullptr) {
+      return rx_op_->testing_setcandata(tx_frame);
+    }
+    return false;
+#else
+    if (tx_op_ != nullptr) {
+      return tx_op_->send_can_message(tx_frame);
+    }
+    return false;
+#endif  // COMMON_PROTOCOL_TEST
+  }
+
+  void set_filter(const struct can_filter filter[], size_t s)
+  {
+    if (rx_op_ != nullptr) {
+      rx_op_->set_filter(filter, s);
+    }
+  }
+  bool is_send_only() { return send_only_; }
+  bool is_ready()
+  {
+    bool result = (tx_op_ == nullptr) ? false : tx_op_->is_ready();
+    if (send_only_) {
+      return result;
+    } else {
+      return result && ((rx_op_ == nullptr) ? false : rx_op_->is_ready());
+    }
+  }
+  bool is_rx_timeout() { return rx_op_->is_timeout(); }
+  bool is_tx_timeout() { return tx_op_->is_timeout(); }
+
+private:
+  bool send_only_;
+  std::string name_;
+  std::unique_ptr<CanRxDev> rx_op_;
+  std::unique_ptr<CanTxDev> tx_op_;
+  uint8_t can_id_offset_ = 0;
+};
+
+}  // namespace socket_can
+}  // namespace tita
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__CAN_UTILS_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/router/protocol/socket_can_common.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/router/protocol/socket_can_common.hpp
@@ -1,0 +1,122 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_COMMON_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_COMMON_HPP_
+
+#include <linux/can.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <sys/time.h>
+
+#include <chrono>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+
+#define GCC_OPTIMIZE_03
+
+#ifdef GCC_OPTIMIZE_03
+#pragma GCC optimize("O3")
+#else
+#pragma GCC optimize("O0")
+#endif
+
+namespace tita
+{
+namespace socket_can
+{
+inline bool bind_can_socket(int & fd, const std::string & interface, const bool canfd_on = false)
+{
+  if (interface.length() >= static_cast<std::string::size_type>(IFNAMSIZ)) {
+    throw std::domain_error{"CAN interface name too long"};
+    return false;
+  }
+
+  fd = socket(PF_CAN, static_cast<int32_t>(SOCK_RAW), CAN_RAW);
+  if (0 > fd) {
+    throw std::runtime_error{"Failed to open CAN socket"};
+    return false;
+  }
+
+  // Make it non-blocking so we can use timeouts
+
+  struct ifreq ifr;
+  (void)strncpy(&ifr.ifr_name[0U], interface.c_str(), IFNAMSIZ - 1);
+  ifr.ifr_name[IFNAMSIZ - 1] = '\0';
+  ifr.ifr_ifindex = if_nametoindex(ifr.ifr_name);
+  if (!ifr.ifr_ifindex) {
+    perror("if_nametoindex");
+    return false;
+  }
+
+  struct sockaddr_can addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.can_family = AF_CAN;
+  addr.can_ifindex = ifr.ifr_ifindex;
+
+  if (canfd_on) {
+    if (ioctl(fd, SIOCGIFMTU, &ifr) < 0) {
+      throw std::runtime_error{"Failed to set CAN FD socket name via ioctl()"};
+      return false;
+    }
+    if (ifr.ifr_mtu != CANFD_MTU) {
+      throw std::runtime_error{"Interface does not support CAN FD"};
+      return false;
+    }
+    int _canfd_on = canfd_on ? 1 : 0;
+    auto ret = setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FD_FRAMES, &_canfd_on, sizeof(_canfd_on));
+    if (ret) {
+      throw std::runtime_error{"error whem enable canfd"};
+      return false;
+    }
+  }
+
+  /* disable default receive filter on this RAW socket */
+  /* This is obsolete as we do not read from the socket at all, but for */
+  /* this reason we can remove the receive list in the Kernel to save a */
+  /* little (really a very little!) CPU usage.                          */
+  setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FILTER, NULL, 0);
+
+  if (0 > bind(fd, (struct sockaddr *)&addr, sizeof(addr))) {
+    throw std::runtime_error{"Failed to bind CAN socket"};
+    return false;
+  }
+
+  return true;
+}
+
+inline struct timeval to_timeval(const std::chrono::nanoseconds timeout) noexcept
+{
+  const auto count = timeout.count();
+  constexpr auto BILLION = 1'000'000'000LL;
+  struct timeval c_timeout;
+  c_timeout.tv_sec = static_cast<decltype(c_timeout.tv_sec)>(count / BILLION);
+  c_timeout.tv_usec = static_cast<decltype(c_timeout.tv_usec)>((count % BILLION) * (0.001));
+
+  return c_timeout;
+}
+
+inline fd_set single_set(int32_t file_descriptor) noexcept
+{
+  fd_set descriptor_set;
+  FD_ZERO(&descriptor_set);
+  FD_SET(file_descriptor, &descriptor_set);
+
+  return descriptor_set;
+}
+}  // namespace socket_can
+}  // namespace tita
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_COMMON_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/router/protocol/socket_can_id.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/router/protocol/socket_can_id.hpp
@@ -1,0 +1,188 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_ID_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_ID_HPP_
+
+#include <linux/can.h>
+
+#include <stdexcept>
+#include <utility>
+
+#include "visibility_control.hpp"
+
+namespace tita
+{
+namespace socket_can
+{
+using IdT = uint32_t;
+using LengthT = uint32_t;
+
+constexpr std::size_t MAX_DATA_LENGTH = 64U;
+
+static_assert(
+  MAX_DATA_LENGTH == sizeof(std::declval<struct canfd_frame>().data),
+  "Unexpected CAN frame data size");
+static_assert(std::is_same<IdT, canid_t>::value, "Underlying type of CanId is incorrect");
+constexpr IdT EXTENDED_MASK = CAN_EFF_FLAG;
+constexpr IdT REMOTE_MASK = CAN_RTR_FLAG;
+constexpr IdT ERROR_MASK = CAN_ERR_FLAG;
+constexpr IdT EXTENDED_ID_MASK = CAN_EFF_MASK;
+constexpr IdT STANDARD_ID_MASK = CAN_SFF_MASK;
+
+class SOCKETCAN_PUBLIC SocketCanTimeout : public std::runtime_error
+{
+public:
+  explicit SocketCanTimeout(const char * const what) : runtime_error{what} {};
+};  // class SocketCanTimeout
+
+enum class FrameType : uint32_t { DATA, ERROR, REMOTE };
+
+struct StandardFrame_
+{
+};
+
+constexpr StandardFrame_ StandardFrame;
+
+struct ExtendedFrame_
+{
+};
+
+constexpr ExtendedFrame_ ExtendedFrame;
+
+class SOCKETCAN_PUBLIC CanId
+{
+public:
+  CanId() = default;
+  explicit CanId(const IdT raw_id, const LengthT data_length = 0U)
+  : m_id{raw_id}, m_data_length{data_length}
+  {
+    (void)frame_type();
+  }
+
+  CanId(const IdT id, FrameType type, StandardFrame_) : CanId{id, type, false} {}
+  CanId(const IdT id, FrameType type, ExtendedFrame_) : CanId{id, type, true} {}
+
+  CanId & standard() noexcept
+  {
+    m_id = m_id & (~EXTENDED_MASK);
+    return *this;
+  }
+
+  CanId & extended() noexcept
+  {
+    m_id = m_id | EXTENDED_MASK;
+    return *this;
+  }
+
+  CanId & error_frame() noexcept
+  {
+    m_id = m_id & (~REMOTE_MASK);
+    m_id = m_id | ERROR_MASK;
+    return *this;
+  }
+
+  CanId & remote_frame() noexcept
+  {
+    m_id = m_id & (~ERROR_MASK);
+    m_id = m_id | REMOTE_MASK;
+    return *this;
+  }
+
+  CanId & data_frame() noexcept
+  {
+    m_id = m_id & (~ERROR_MASK);
+    m_id = m_id & (~REMOTE_MASK);
+    return *this;
+  }
+
+  CanId & frame_type(const FrameType type)
+  {
+    switch (type) {
+      case FrameType::DATA:
+        (void)data_frame();
+        break;
+      case FrameType::ERROR:
+        (void)error_frame();
+        break;
+      case FrameType::REMOTE:
+        (void)remote_frame();
+        break;
+      default:
+        throw std::logic_error{"CanId: No such type"};
+    }
+    return *this;
+  }
+
+  CanId & identifier(const IdT id)
+  {
+    constexpr auto MAX_EXTENDED = 0x1FBF'FFFFU;
+    constexpr auto MAX_STANDARD = 0x7FFU;
+
+    static_assert(MAX_EXTENDED <= EXTENDED_ID_MASK, "Max extended id value is wrong");
+    static_assert(MAX_STANDARD <= STANDARD_ID_MASK, "Max standed id value is wrong");
+    const auto max_id = is_extended() ? MAX_EXTENDED : MAX_STANDARD;
+    if (max_id < id) {
+      throw std::domain_error{"CanId would be truncated!"};
+    }
+    m_id = m_id & (~EXTENDED_ID_MASK);
+    m_id = m_id | id;
+    return *this;
+  }
+
+  IdT identifier() const noexcept
+  {
+    const auto mask = is_extended() ? EXTENDED_ID_MASK : STANDARD_ID_MASK;
+    return m_id & mask;
+  }
+
+  IdT get() const noexcept { return m_id; }
+
+  bool is_extended() const noexcept { return (m_id & EXTENDED_MASK) == EXTENDED_MASK; }
+
+  FrameType frame_type() const
+  {
+    const auto is_error = (m_id & ERROR_MASK) == ERROR_MASK;
+    const auto is_remote = (m_id & REMOTE_MASK) == REMOTE_MASK;
+    if (is_error && is_remote) {
+      throw std::domain_error{"CanId has both bit 29 and 30 set! Inconsistent"};
+    }
+    if (is_error) {
+      return FrameType::ERROR;
+    }
+    if (is_remote) {
+      return FrameType::REMOTE;
+    }
+    return FrameType::DATA;
+  }
+
+  LengthT length() const noexcept { return m_data_length; }
+  IdT m_id{};
+
+private:
+  SOCKETCAN_LOCAL CanId(const IdT id, FrameType type, bool is_extended)
+  {
+    if (is_extended) {
+      (void)extended();
+    }
+    (void)frame_type(type);
+    (void)identifier(id);
+  }
+
+  LengthT m_data_length{};
+};  // class CanId
+}  // namespace socket_can
+}  // namespace tita
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_ID_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/router/protocol/socket_can_receiver.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/router/protocol/socket_can_receiver.hpp
@@ -1,0 +1,147 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_RECEIVER_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_RECEIVER_HPP_
+#include <linux/can.h>
+#include <linux/can/raw.h>
+#include <sys/socket.h>
+#include <unistd.h>  // for close()
+
+#include <chrono>
+#include <cstring>
+#include <memory>
+#include <string>
+
+#include "socket_can_common.hpp"
+#include "socket_can_id.hpp"
+#include "visibility_control.hpp"
+
+#define TARGET_CAN_DEVICE "vcan0"
+
+namespace tita
+{
+namespace socket_can
+{
+// using target_can_device = static_cast<std::string>(TARGET_CAN_DEVICE);
+
+class SOCKETCAN_PUBLIC SocketCanReceiver
+{
+public:
+  explicit SocketCanReceiver(
+    const std::string & interface = TARGET_CAN_DEVICE, bool canfd_on = false)
+  {
+    if (!bind_can_socket(fd_, interface, canfd_on)) {
+      printf("bind_can_socket failed!\r\n");
+      return;
+    }
+  }
+
+  ~SocketCanReceiver() noexcept { (void)close(fd_); }
+
+  bool receive(
+    std::shared_ptr<struct can_frame> rx_frame,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero())
+  {
+    wait(timeout);
+
+    struct canfd_frame frame;
+    memset(&frame, 0, sizeof(frame));
+    const auto nbytes = read(fd_, &frame, sizeof(frame));
+
+    if (nbytes < 0) {
+      throw std::runtime_error{strerror(errno)};
+    }
+    if (static_cast<std::size_t>(nbytes) < CAN_MTU) {
+      throw std::logic_error{"read: incomplete CAN frame"};
+    }
+    if (static_cast<std::size_t>(nbytes) != CAN_MTU) {
+      throw std::logic_error{"Message was wrong size"};
+    }
+
+    auto receive_id = CanId{frame.can_id, frame.len};
+    if (receive_id.frame_type() == tita::socket_can::FrameType::DATA) {
+      rx_frame->can_id = receive_id.standard().get();
+      rx_frame->can_id = receive_id.length();
+      std::memcpy(rx_frame->data, frame.data, sizeof(rx_frame->data));
+      return true;
+    }
+    return false;
+  }
+
+  bool receive(
+    std::shared_ptr<struct canfd_frame> rx_frame,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero())
+  {
+    wait(timeout);
+
+    struct canfd_frame frame;
+    const auto nbytes = read(fd_, &frame, sizeof(frame));
+
+    uint8_t except_len = CAN_MTU - 8 + frame.len;
+    if (nbytes < 0) {
+      throw std::runtime_error{strerror(errno)};
+    }
+    if (static_cast<std::size_t>(nbytes) < except_len) {
+      throw std::runtime_error{"read: incomplete CAN frame"};
+    }
+
+    auto receive_id = CanId{frame.can_id, frame.len};
+    if (receive_id.frame_type() == tita::socket_can::FrameType::DATA) {
+      rx_frame->can_id = receive_id.standard().get();
+      rx_frame->len = receive_id.length();
+      std::memcpy(rx_frame->data, frame.data, sizeof(rx_frame->data));
+      return true;
+    }
+    return false;
+  }
+
+  void set_filter(const struct can_filter filter[], size_t s)
+  {
+    setsockopt(fd_, SOL_CAN_RAW, CAN_RAW_FILTER, filter, s);
+  }
+
+private:
+  SOCKETCAN_LOCAL void wait(const std::chrono::nanoseconds timeout) const
+  {
+    if (decltype(timeout)::zero() < timeout) {
+      auto c_timeout = to_timeval(timeout);
+      auto read_set = single_set(fd_);
+
+      if (0 == select(fd_ + 1, &read_set, NULL, NULL, &c_timeout)) {
+        throw SocketCanTimeout{"$CAN Receive Timeout 1"};
+      }
+
+      if (!FD_ISSET(fd_, &read_set)) {
+        throw SocketCanTimeout{"$CAN Receive Timeout 2"};
+      }
+    } else {
+      auto read_set = single_set(fd_);
+
+      if (0 == select(fd_ + 1, &read_set, NULL, NULL, NULL)) {
+        throw SocketCanTimeout{"$CAN Receive Timeout 1"};
+      }
+
+      if (!FD_ISSET(fd_, &read_set)) {
+        throw SocketCanTimeout{"CAN Receive Timeout 2"};
+      }
+    }
+  }
+
+  int32_t fd_;
+};  // class SocketCanReceiver
+}  // namespace socket_can
+}  // namespace tita
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_RECEIVER_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/router/protocol/socket_can_sender.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/router/protocol/socket_can_sender.hpp
@@ -1,0 +1,168 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_SENDER_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_SENDER_HPP_
+
+#include <linux/can.h>
+#include <linux/can/raw.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <stdexcept>
+#include <string>
+
+#include "socket_can_common.hpp"
+#include "socket_can_id.hpp"
+#include "visibility_control.hpp"
+
+namespace tita
+{
+namespace socket_can
+{
+class SOCKETCAN_PUBLIC SocketCanSender
+{
+public:
+  explicit SocketCanSender(
+    const std::string & interface = "can0", bool canfd_on = false,
+    const CanId & default_id = CanId{})
+  : m_default_id{default_id}
+  {
+    if (!bind_can_socket(fd_, interface, canfd_on)) {
+      printf("bind_can_socket failed\r\n");
+      return;
+    }
+  }
+  ~SocketCanSender() noexcept
+  {
+    (void)close(fd_);
+    // I'm destructing--there's not much else I can do on an error
+    // seem not good
+  }
+
+  void send(
+    const void * const data, const std::size_t Length,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    send(data, Length, m_default_id, timeout);
+  }
+
+  void send(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    if (length > MAX_DATA_LENGTH) {
+      throw std::domain_error{"Size is too large to send via CAN"};
+    }
+    send_impl(data, length, id, timeout);
+  }
+
+  template <typename T, typename = std::enable_if_t<!std::is_pointer<T>::value>>
+  void send(
+    const T & data, const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    send(data, m_default_id, timeout);
+  }
+
+  template <typename T, typename = std::enable_if<!std::is_pointer<T>::value>>
+  void send(
+    const T & data, const CanId id,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    static_assert(sizeof(data) <= MAX_DATA_LENGTH, "Data type too large for CAN");
+    send_impl(reinterpret_cast<const char *>(&data), sizeof(data), id, timeout);
+  }
+
+  void send_fd(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    if (length > MAX_DATA_LENGTH) {
+      throw std::domain_error{"Size is too large to send via CAN"};
+    }
+    send_fd_impl(data, length, id, timeout);
+  }
+
+  CanId default_id() const noexcept { return m_default_id; }
+
+private:
+  void send_impl(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout) const
+  {
+    // (void)data;
+    // (void)length;
+    // (void)id;
+    (void)timeout;
+
+    struct can_frame data_frame;
+    data_frame.can_id = id.get();
+
+    data_frame.can_dlc = static_cast<decltype(data_frame.can_dlc)>(length);
+
+    (void)std::memcpy(static_cast<void *>(&data_frame.data[0U]), data, length);
+
+    if (write(fd_, &data_frame, static_cast<int>(CAN_MTU)) != static_cast<int>(CAN_MTU)) {
+      throw std::runtime_error{strerror(errno)};
+    }
+  }
+
+  void send_fd_impl(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout) const
+  {
+    // (void)data;
+    // (void)length;
+    // (void)id;
+    (void)timeout;
+
+    struct canfd_frame data_frame;
+    memset(&data_frame, 0, sizeof(data_frame));
+    data_frame.can_id = id.get();
+    data_frame.flags = CANFD_FDF | CANFD_BRS;
+    data_frame.len = static_cast<decltype(data_frame.len)>(length);
+    std::memcpy(static_cast<void *>(&data_frame.data[0U]), data, length);
+    if (write(fd_, &data_frame, CANFD_MTU) != CANFD_MTU) {
+      throw std::runtime_error{strerror(errno)};
+    }
+  }
+
+  SOCKETCAN_LOCAL void wait(const std::chrono::nanoseconds timeout) const
+  {
+    if (decltype(timeout)::zero() < timeout) {
+      auto c_timeout = to_timeval(timeout);
+      auto write_set = single_set(fd_);
+
+      // wait
+      if (0 == select(fd_ + 1, NULL, &write_set, NULL, &c_timeout)) {
+        throw SocketCanTimeout{"$CAN Send Timeout [1]"};
+      }
+
+      if (!FD_ISSET(fd_, &write_set)) {
+        throw SocketCanTimeout{"$CAN Send Timeout [2]"};
+      }
+    } else {
+      // do nothing
+      // auto write_set = single_set(fd_);
+    }
+  }
+
+  int32_t fd_;
+  CanId m_default_id;
+};
+}  // namespace socket_can
+}  // namespace tita
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_SENDER_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/router/protocol/visibility_control.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/router/protocol/visibility_control.hpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__VISIBILITY_CONTROL_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__VISIBILITY_CONTROL_HPP_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+#ifdef __GNUC__
+#define SOCKETCAN_EXPORT __attribute__((dllexport))
+#define SOCKETCAN_IMPORT __attribute__((dllimport))
+#else
+#define SOCKETCAN_EXPORT __declspec(dllexport)
+#define SOCKETCAN_IMPORT __declspec(dllimport)
+#endif
+#ifdef SOCKETCAN_BUILDING_LIBRARY
+#define SOCKETCAN_PUBLIC SOCKETCAN_EXPORT
+#else
+#define SOCKETCAN_PUBLIC SOCKETCAN_IMPORT
+#endif
+#define SOCKETCAN_PUBLIC_TYPE SOCKETCAN_PUBLIC
+#define SOCKETCAN_LOCAL
+#else
+#define SOCKETCAN_EXPORT __attribute__((visibility("default")))
+#define SOCKETCAN_IMPORT
+#if __GNUC__ >= 4
+#define SOCKETCAN_PUBLIC __attribute__((visibility("default")))
+#define SOCKETCAN_LOCAL __attribute__((visibility("hidden")))
+#else
+#define SOCKETCAN_PUBLIC
+#define SOCKETCAN_LOCAL
+#endif
+#define SOCKETCAN_PUBLIC_TYPE
+#endif
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__VISIBILITY_CONTROL_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/router/src/canfd_router_can_receive_api.cpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/router/src/canfd_router_can_receive_api.cpp
@@ -1,0 +1,97 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "titati_canfd_router/canfd_router_can_receive_api.hpp"
+
+#include <cstring>
+#include <iostream>
+
+namespace can_device
+{
+
+void CanfdRouterCanReceiveApi::register_canfd_router_device_can_filter()
+{
+
+  struct can_filter canfd_router_device_rx_filter;
+  canfd_router_device_rx_filter.can_id = CAN_ID_AS_CANFD_ROUTER_INFO;
+  canfd_router_device_rx_filter.can_mask = CAN_MASK_AS_CANFD_ROUTER_INFO;
+  this->canfd_router_can_receive_api->set_filter(&canfd_router_device_rx_filter, sizeof(struct can_filter));
+
+  // struct canfd_frame frame;
+  // frame.can_id = 0x170U;
+  // frame.len = 10U;
+  // memset(frame.data, 0x00U, sizeof(frame.data));
+
+  // uint32_t timestamp = get_current_time();
+  // uint16_t key = 0x200;
+  // uint32_t value = 0x00U;
+
+  // std::memcpy(frame.data, &timestamp, sizeof(timestamp));
+  // std::memcpy(frame.data + 4, &key, sizeof(key));
+  // std::memcpy(frame.data + 6, &value, sizeof(value));
+
+  // set_forcedirect_can_send_api->send_can_message(frame);
+
+  // timestamp = get_current_time();
+  // key = 0x200;
+  // value = 0x03U;
+
+  // std::memcpy(frame.data, &timestamp, sizeof(timestamp));
+  // std::memcpy(frame.data + 4, &key, sizeof(key));
+  // std::memcpy(frame.data + 6, &value, sizeof(value));
+
+  // set_forcedirect_can_send_api->send_can_message(frame);
+}
+
+void CanfdRouterCanReceiveApi::get_board_can_data(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+    if (recv_frame->can_id == CAN_ID_CANFD_ROUTER) {
+        std::memcpy(&mode_, recv_frame->data + 4, sizeof(mode_));
+        std::memcpy(&heart_cnt_, recv_frame->data + 8, sizeof(heart_cnt_));
+        std::cout << "[titati_can_router] Heartbeat received (mode=" << mode_ << ", count=" << heart_cnt_ << ")"
+                  << std::endl;
+        if(init_flag_ && (mode_ == 2 || mode_ == 1)) {
+          struct canfd_frame frame;
+          frame.can_id = 0x170U;
+          frame.len = 10U;
+          memset(frame.data, 0x00U, sizeof(frame.data));
+
+          uint32_t timestamp = get_current_time();
+          uint16_t key = 0x200;
+          uint32_t value = 0x00U;
+
+          std::memcpy(frame.data, &timestamp, sizeof(timestamp));
+          std::memcpy(frame.data + 4, &key, sizeof(key));
+          std::memcpy(frame.data + 6, &value, sizeof(value));
+
+          set_forcedirect_can_send_api->send_can_message(frame);
+
+          std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+          timestamp = get_current_time();
+          key = 0x200;
+          value = 0x03U;
+
+          std::memcpy(frame.data, &timestamp, sizeof(timestamp));
+          std::memcpy(frame.data + 4, &key, sizeof(key));
+          std::memcpy(frame.data + 6, &value, sizeof(value));
+
+          set_forcedirect_can_send_api->send_can_message(frame);
+          init_flag_ = false;
+          std::cout << "[titati_can_router] FORCE_DIRECT request sent." << std::endl;
+      }
+    }
+}
+
+}

--- a/rl_sar/src/rl_sar/library/hardware/titati/tita_robot/include/tita_robot/can_receiver.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/tita_robot/include/tita_robot/can_receiver.hpp
@@ -1,0 +1,116 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MOTORS_CAN__MOTORS_CAN_API_HPP_
+#define MOTORS_CAN__MOTORS_CAN_API_HPP_
+
+#include <algorithm>
+#include <atomic>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "protocol/can_utils.hpp"
+namespace can_device
+{
+#define PACKED __attribute__((__packed__))
+#define GRAVITY 9.81f
+#define CAN_ID_MOTOR_IN 0x108
+#define CAN_ID_IMU1 0x118
+#define CAN_ID_STATE 0x102
+
+  struct api_motor_in_t
+  {
+    uint32_t timestamp;
+    float position;
+    float velocity;
+    float torque;
+  } PACKED;
+  /* 44 bytes */
+  struct api_imu_data_t
+  {
+    uint32_t timestamp;
+    float accl[3];
+    float gyro[3];
+    float quaternion[4]; // x y z w
+    float temperature;
+  } PACKED;
+  
+  struct api_motor_status_t
+  {
+    uint32_t timestamp;
+    uint16_t key;
+    uint8_t value[8];
+  } PACKED;
+
+  class MotorsImuCanReceiveApi
+  {
+  public:
+    MotorsImuCanReceiveApi(size_t size)
+    {
+      if(size % 8 == 0) leg_dof_ = 4;
+      else if(size % 6 == 0) leg_dof_ = 3;
+      leg_num_ = size / leg_dof_;
+      register_motors_device_can_filter();
+      api_motor_in_t default_motor_in;
+      std::memset(&default_motor_in, 0x00U, sizeof(api_motor_in_t));
+      motors_in_.resize(size, default_motor_in);
+      std::memset(&imu_data_, 0x00U, sizeof(api_imu_data_t));
+    }
+    ~MotorsImuCanReceiveApi() {}
+    const std::vector<api_motor_in_t> *get_motors_in() const { return &motors_in_; }
+    const api_imu_data_t *get_imu_data() const { return &imu_data_; }
+    const api_motor_status_t *get_motors_status() const { return &motors_status_; }
+
+  private:
+#define MIN_TIME_OUT_US 1'000L     // 1ms
+#define MAX_TIME_OUT_US 3'000'000L // 3s
+#define CAN_MASK_AS_MOTORS_INFO (0x7E0U)
+    std::string motors_can_interface = "can0";
+    std::string motors_can_name = "motors_can";
+    bool motors_can_extended_frame = false;
+    bool motors_can_rx_is_block = false;
+    int64_t motors_timeout_us = MAX_TIME_OUT_US;
+    uint8_t motors_can_id_offset = 0x00U;
+
+    void register_motors_device_can_filter();
+    can_device::socket_can::can_fd_callback motors_can_receive_callback =
+        std::bind(&MotorsImuCanReceiveApi::board_can_data_callback, this, std::placeholders::_1);
+
+    std::shared_ptr<can_device::socket_can::CanDev> motors_can_receive_api =
+        std::make_shared<can_device::socket_can::CanDev>(
+            motors_can_interface, motors_can_name, motors_can_extended_frame, motors_can_receive_callback,
+            motors_can_rx_is_block, motors_timeout_us, motors_can_id_offset);
+
+    void board_can_data_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+    void motors_data_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+    void imu_data_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+    void motors_status_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+
+    std::vector<api_motor_in_t> motors_in_;
+    api_imu_data_t imu_data_;
+    api_motor_status_t motors_status_;
+
+    mutable std::shared_mutex motors_in_mutex_, imu_mutex_;
+    size_t leg_dof_{4}, leg_num_{2};
+  };
+} // namespace can_device
+
+#endif // MOTORS_CAN__MOTORS_CAN_API_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/tita_robot/include/tita_robot/can_sender.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/tita_robot/include/tita_robot/can_sender.hpp
@@ -1,0 +1,120 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MOTORS_CAN__MOTORS_CAN_SEND_API_HPP_
+#define MOTORS_CAN__MOTORS_CAN_SEND_API_HPP_
+
+#include <algorithm>
+#include <atomic>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "protocol/can_utils.hpp"
+
+namespace can_device
+{
+
+#define CAN_ID_SEND_MOTORS (0x120U)
+#define CAN_ID_CHANNEL_INPUT (0x12DU)
+#define CAN_ID_RPC_REQUEST (0x170U)
+
+  enum ApiRpcKey
+  {
+    RPC_UNDEFINED = 0x000,
+    GET_MODEL_INFO = 0x100,
+    GET_SERIAL_NUMBER = 0x101,
+    SET_READY_NEXT = 0x200,
+    SET_BOARDCAST = 0x201,
+    SET_INPUT_MODE = 0x221,
+    SET_STAND_MODE = 0x222,
+    SET_HEAD_MODE = 0x223,
+    SET_JUMP = 0x231,
+    SET_MOTOR_ZERO = 0x280,
+  };
+  struct ChannelInput
+  {
+    uint32_t timestamp;
+    float forward;
+    float yaw;
+    float pitch;
+    float roll;
+    float height;
+    float split;
+    float tilt;
+    float forward_accel;
+    float yaw_accel;
+  };
+  struct RpcRequest
+  {
+    uint32_t timestamp;
+    uint16_t key;
+    uint32_t value;
+  };
+  struct motor_out
+  {
+    uint32_t timestamp;
+    float position;
+    float kp;
+    float velocity;
+    float kd;
+    float torque;
+  };
+
+  class MotorsCanSendApi
+  {
+  public:
+    MotorsCanSendApi(size_t size)
+    {
+      if (size % 8 == 0)
+        leg_dof_ = 4;
+      else if (size % 6 == 0)
+        leg_dof_ = 3;
+      leg_num_ = size / leg_dof_;
+    }
+    ~MotorsCanSendApi() = default;
+    bool send_motors_can(std::vector<motor_out> motors);
+    bool send_command_can_channel_input(ChannelInput data);
+    bool send_command_can_rpc_request(RpcRequest data);
+
+  private:
+#define MIN_TIME_OUT_US 1'000L     // 1ms
+#define MAX_TIME_OUT_US 3'000'000L // 3s
+    std::string can_interface = "can0";
+    std::string can_name = "motors_can_send";
+    int64_t timeout_us = MAX_TIME_OUT_US;
+    uint8_t can_id_offset = 0x00U;
+    bool can_extended_frame = false;
+    bool can_fd_mode = true;
+
+    std::shared_ptr<can_device::socket_can::CanDev> can_send_api_ =
+        std::make_shared<can_device::socket_can::CanDev>(
+            can_interface, can_name, can_extended_frame, can_fd_mode, timeout_us, can_id_offset);
+
+    inline uint32_t get_current_time()
+    {
+      struct timeval tv;
+      gettimeofday(&tv, NULL);
+      return std::move(tv.tv_sec * 1000000 + tv.tv_usec);
+    }
+    size_t leg_dof_{4}, leg_num_{2};
+  };
+} // namespace can_device
+
+#endif // MOTORS_CAN__MOTORS_CAN_SEND_API_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/tita_robot/include/tita_robot/tita_robot.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/tita_robot/include/tita_robot/tita_robot.hpp
@@ -1,0 +1,154 @@
+#include "can_receiver.hpp"
+#include "can_sender.hpp"
+
+class tita_robot
+{
+public:
+    enum ReadyNext
+    {
+        READY_WAITING = 0x00U,
+        AUTO_LOCOMOTION = 0x01U,
+        FORCE_LOCOMOTION = 0x02U,
+        FORCE_DIRECT = 0x03U,
+        MOTOR_ZERO_CAL = 0x04U,
+        BOOT_RECOVERY_MODE = 0x05U,
+        ESTOP_MODE = 0x06U,
+    };
+    struct ChannelInput
+    {
+        uint32_t timestamp;
+        float forward;
+        float yaw;
+        float pitch;
+        float roll;
+        float height;
+        float split;
+        float tilt;
+        float forward_accel;
+        float yaw_accel;
+    };
+    tita_robot(size_t num_motors)
+    {
+        // Initialize the CAN receiver
+        can_receiver_ = std::make_unique<can_device::MotorsImuCanReceiveApi>(num_motors);
+        can_sender_ = std::make_unique<can_device::MotorsCanSendApi>(num_motors);
+        motor_num_ = num_motors;
+    }
+
+    /**
+     * @brief Get the current joint positions in joint space.
+     * @return std::vector<double>: current joint positions in radians.
+     */
+    std::vector<double> get_joint_q() const;
+
+    /**
+     * @brief Get the current joint velocities in joint space.
+     * @return std::vector<double>: current joint velocities in radians per second.
+     */
+    std::vector<double> get_joint_v() const;
+
+    /**
+     * @brief Get the current joint torques in joint space.
+     * @return std::vector<double>: current joint torques in Newton meters.
+     */
+    std::vector<double> get_joint_t() const;
+
+    /**
+     * @brief Get the current joint status.
+     * @note Joints status now is in bool value, true means the joint is online(TODO).
+     * @return std::vector<uint8_t>: current joint status.
+     */
+    std::vector<uint8_t> get_joint_status() const;
+
+    /**
+     * @brief Get the current imu quaternion of mcu.
+     * @note Quaternion sequence is x y z w.
+     * @return std::array<double, 4>: current quaternion.
+     */
+    std::array<double, 4> get_imu_quaternion() const; // x y z w
+
+    /**
+     * @brief Get the current imu acceleration of mcu.
+     * @return std::array<double, 3>: current acceleration.
+     */
+    std::array<double, 3> get_imu_acceleration() const;
+
+    /**
+     * @brief Get the current imu angular velocity of mcu.
+     * @return std::array<double, 3>: current angular velocity.
+     */
+    std::array<double, 3> get_imu_angular_velocity() const;
+
+    /**
+     * @brief Set the target joint feed-forward torques.
+     * @param t the target joint feed-forward torques.
+     * @return return true if the target is set successfully.
+     */
+    bool set_target_joint_t(const std::vector<double> &t);
+
+    /**
+     * @brief MIT control method. Set the target joint positions, velocities, kp, kd and feed-forward torques of the
+     motors.
+     * @param q the target joint positions in radians.
+     * @param v the target joint velocities in radians per second.
+     * @param kp the target joint proportional gains.
+     * @param kd the target joint derivative gains.
+     * @param t the target joint feed-forward torques.
+     *
+     * @return return true if the target is set successfully
+     */
+    bool set_target_joint_mit(const std::vector<double> &q, const std::vector<double> &v, const std::vector<double> &kp, const std::vector<double> &kd, const std::vector<double> &t);
+
+    // /**
+    //  * @brief Set mcu board control mode, maybe remove in the future.
+    //  * @param mode the target mcu mode, option: READY_WAITING AUTO_LOCOMOTION FORCE_DIRECT.
+    //  *
+    //  * @return return true if the target is set successfully
+    //  */
+    // bool set_board_mode(ReadyNext mode);
+    /**
+     * @brief Set mcu board can direct drive motors, default is auto_locomotion(use mcu control).
+     * @param if_sdk true means use control motors sdk, false means use mcu control.
+     *
+     * @return return true if the target is set successfully
+     */
+    bool set_motors_sdk(bool if_sdk);
+    /**
+     * @brief Set rc input to mcu. Only used in board mode is AUTO_LOCOMOTION.
+     * @param forward the target forward.
+     * @param yaw the target yaw.
+     * @param pitch the target pitch.
+     * @param roll the target roll.
+     * @param height the target height.
+     * @param split the target split.
+     * @param tilt the target tilt.
+     * @param forward_accel the target forward acceleration.
+     * @param yaw_accel the target yaw acceleration.
+     * @return return true if the target is set successfully
+     */
+    bool set_rc_input(ChannelInput input);    
+    /**
+     * @brief Set rc input to mcu. Only used in board mode is AUTO_LOCOMOTION.
+     * @param stand true if stand.
+     * @return return true if the target is set successfully
+     */
+    bool set_robot_stand(bool stand);
+
+    /**
+     * @brief Set rc input to mcu. Only used in board mode is AUTO_LOCOMOTION.
+     * @param jump true to start robot charge, then false change to start jump.
+     * @return return true if the target is set successfully
+     */
+    bool set_robot_jump(bool jump);
+    /**
+     * @brief Set rc input to mcu. Only used in board mode is AUTO_LOCOMOTION.
+     * @return return true if the target is set successfully
+     */
+    bool set_robot_stop();
+private:
+    std::unique_ptr<can_device::MotorsImuCanReceiveApi> can_receiver_;
+    std::unique_ptr<can_device::MotorsCanSendApi> can_sender_;
+    size_t motor_num_;
+};
+
+// class tita_robot

--- a/rl_sar/src/rl_sar/library/hardware/titati/tita_robot/src/can_receiver.cpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/tita_robot/src/can_receiver.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tita_robot/can_receiver.hpp"
+
+namespace can_device
+{
+
+void MotorsImuCanReceiveApi::register_motors_device_can_filter()
+{
+  // if (!this->is_running.load()) {
+  //   throw std::runtime_error("MotorsImuCanReceiveApi is not running");
+  // }
+  struct can_filter motors_device_rx_filter;
+  motors_device_rx_filter.can_id = CAN_ID_MOTOR_IN;
+  motors_device_rx_filter.can_mask = CAN_MASK_AS_MOTORS_INFO;
+  this->motors_can_receive_api->set_filter(&motors_device_rx_filter, sizeof(struct can_filter));
+}
+
+void MotorsImuCanReceiveApi::board_can_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  if (recv_frame->can_id >= CAN_ID_MOTOR_IN && recv_frame->can_id < CAN_ID_MOTOR_IN + leg_num_) {
+    motors_data_callback(recv_frame);
+  } else if (recv_frame->can_id == CAN_ID_IMU1) {
+    imu_data_callback(recv_frame);
+  } else {
+    return;
+  }
+}
+void MotorsImuCanReceiveApi::motors_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  std::unique_lock<std::shared_mutex> lock(motors_in_mutex_);
+  for (size_t i = 0; i < leg_dof_; i++) {
+    api_motor_in_t motor;
+    std::memcpy(&motor, recv_frame->data + 16 * i, sizeof(api_motor_in_t));
+    auto it = recv_frame->can_id - CAN_ID_MOTOR_IN;
+    motors_in_[i + leg_dof_ * it] = motor;
+  }
+}
+void MotorsImuCanReceiveApi::imu_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  std::unique_lock<std::shared_mutex> lock(imu_mutex_);
+  std::memcpy(&imu_data_, recv_frame->data, sizeof(api_imu_data_t));
+  for (size_t i(0); i < 3; ++i) {
+    imu_data_.accl[i] *= GRAVITY;
+  }
+  return;
+}
+void MotorsImuCanReceiveApi::motors_status_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  std::memcpy(&motors_status_, recv_frame->data, sizeof(api_motor_status_t));
+}
+
+}  // namespace can_device

--- a/rl_sar/src/rl_sar/library/hardware/titati/tita_robot/src/can_sender.cpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/tita_robot/src/can_sender.cpp
@@ -1,0 +1,90 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tita_robot/can_sender.hpp"
+
+namespace can_device
+{
+bool MotorsCanSendApi::send_command_can_channel_input(ChannelInput data)
+{
+  data.timestamp = get_current_time();
+  struct canfd_frame frame;
+  frame.can_id = CAN_ID_CHANNEL_INPUT;
+  frame.len = 40u;
+  memset(frame.data, 0x00U, sizeof(frame.data));
+  
+  std::memcpy(frame.data, &data, sizeof(data));
+
+  return can_send_api_->send_can_message(frame);
+}
+
+bool MotorsCanSendApi::send_command_can_rpc_request(RpcRequest data){
+  data.timestamp = get_current_time();
+
+  struct canfd_frame frame;
+  frame.can_id = CAN_ID_RPC_REQUEST;
+  frame.len = 10U;
+
+  memset(frame.data, 0x00U, sizeof(frame.data));
+
+  std::memcpy(frame.data, &data.timestamp, sizeof(data.timestamp));
+  std::memcpy(frame.data + 4, &data.key, sizeof(data.key));
+  std::memcpy(frame.data + 6, &data.value, sizeof(data.value));
+
+  return can_send_api_->send_can_message(frame);
+}
+
+bool MotorsCanSendApi::send_motors_can(std::vector<motor_out> motors)
+{
+  if (motors.size() != leg_dof_ * leg_num_) {
+    std::cerr << "[MOTORS_CAN_SEND] motors size not equal to robot dof" << std::endl;
+    return false;
+  }
+  if(leg_dof_ == 3){
+    motor_out motor = {};
+    auto it = motors.begin() + 3;
+    motors.insert(it, motor);
+    motors.push_back(motor);
+  }
+  bool send_success = true;
+  struct canfd_frame frame;
+  frame.len = 48U;
+  auto now = get_current_time();
+  for (size_t id(0); id < motors.size()/2; id++) {
+    frame.can_id = CAN_ID_SEND_MOTORS + id;
+    memset(frame.data, 0x00U, sizeof(frame.data));
+    auto motor = motors[2 * id];
+    motor.timestamp = now;
+    std::memcpy(frame.data, &motor.timestamp, sizeof(motor.timestamp));
+    std::memcpy(frame.data + 4, &motor.position, sizeof(motor.position));
+    std::memcpy(frame.data + 8, &motor.kp, sizeof(motor.kp));
+    std::memcpy(frame.data + 12, &motor.velocity, sizeof(motor.velocity));
+    std::memcpy(frame.data + 16, &motor.kd, sizeof(motor.kd));
+    std::memcpy(frame.data + 20, &motor.torque, sizeof(motor.torque));
+
+    motor = motors[2 * id + 1];
+    motor.timestamp = now;
+    std::memcpy(frame.data + 24, &motor.timestamp, sizeof(motor.timestamp));
+    std::memcpy(frame.data + 28, &motor.position, sizeof(motor.position));
+    std::memcpy(frame.data + 32, &motor.kp, sizeof(motor.kp));
+    std::memcpy(frame.data + 36, &motor.velocity, sizeof(motor.velocity));
+    std::memcpy(frame.data + 40, &motor.kd, sizeof(motor.kd));
+    std::memcpy(frame.data + 44, &motor.torque, sizeof(motor.torque));
+    send_success &= can_send_api_->send_can_message(frame);
+    std::this_thread::sleep_for(std::chrono::microseconds(150)); // 等待 100 微秒
+  }
+  return send_success;
+}
+
+}  // namespace can_device

--- a/rl_sar/src/rl_sar/library/hardware/titati/tita_robot/src/tita_robot.cpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/tita_robot/src/tita_robot.cpp
@@ -1,0 +1,171 @@
+#include "tita_robot/tita_robot.hpp"
+
+std::vector<double> tita_robot::get_joint_q() const
+{
+  auto infos = can_receiver_->get_motors_in();
+  std::vector<double> joint;
+  for (const auto & info : *infos) {
+    joint.push_back(info.position);
+  }
+  return joint;
+}
+
+std::vector<double> tita_robot::get_joint_v() const
+{
+  auto infos = can_receiver_->get_motors_in();
+  std::vector<double> joint;
+  for (const auto & info : *infos) {
+    joint.push_back(info.velocity);
+  }
+  return joint;
+}
+
+std::vector<double> tita_robot::get_joint_t() const
+{
+  auto infos = can_receiver_->get_motors_in();
+  std::vector<double> joint;
+  for (const auto & info : *infos) {
+    joint.push_back(info.torque);
+  }
+  return joint;
+}
+
+std::vector<uint8_t> tita_robot::get_joint_status() const  // TODO: why 8
+{
+  auto infos = can_receiver_->get_motors_status();
+  std::vector<uint8_t> joint;
+  for (size_t id = 0; id < 8; id++) {
+    joint.push_back(infos->value[id]);
+  }
+  return joint;
+}
+
+std::array<double, 4> tita_robot::get_imu_quaternion() const
+{
+  auto infos = can_receiver_->get_imu_data();
+  std::array<double, 4> data;
+  for (size_t i = 0; i < 4; i++) {
+    data[i] = infos->quaternion[i];
+  }
+  return data;
+}
+
+std::array<double, 3> tita_robot::get_imu_acceleration() const
+{
+  auto infos = can_receiver_->get_imu_data();
+  std::array<double, 3> data;
+  for (size_t i = 0; i < 3; i++) {
+    data[i] = infos->accl[i];
+  }
+  return data;
+}
+
+std::array<double, 3> tita_robot::get_imu_angular_velocity() const
+{
+  auto infos = can_receiver_->get_imu_data();
+  std::array<double, 3> data;
+  for (size_t i = 0; i < 3; i++) {
+    data[i] = infos->gyro[i];
+  }
+  return data;
+}
+
+bool tita_robot::set_target_joint_t(const std::vector<double> & t)
+{
+  std::vector<can_device::motor_out> motors;
+  for (size_t id = 0; id < motor_num_; id++) {
+    can_device::motor_out motor;
+    motor.torque = t[id];
+    motor.kp = 0.0f;
+    motor.kd = 0.0f;
+    motor.velocity = 0.0f;
+    motor.position = 0.0f;
+    motors.push_back(motor);
+  }
+  return can_sender_->send_motors_can(motors);
+}
+
+bool tita_robot::set_target_joint_mit(
+  const std::vector<double> & q, const std::vector<double> & v, const std::vector<double> & kp,
+  const std::vector<double> & kd, const std::vector<double> & t)
+{
+  std::vector<can_device::motor_out> motors;
+  for (size_t id = 0; id < motor_num_; id++) {
+    can_device::motor_out motor;
+    motor.torque = t[id];
+    motor.kp = kp[id];
+    motor.kd = kd[id];
+    motor.velocity = v[id];
+    motor.position = q[id];
+    motors.push_back(motor);
+  }
+  return can_sender_->send_motors_can(motors);
+}
+
+// bool tita_robot::set_board_mode(ReadyNext mode)
+// {
+//   can_device::RpcRequest rpc_request;
+//   rpc_request.key = can_device::SET_READY_NEXT;
+//   rpc_request.value = mode;
+//   return can_sender_->send_command_can_rpc_request(rpc_request);
+// }
+
+bool tita_robot::set_motors_sdk(bool if_sdk)
+{
+  can_device::RpcRequest rpc_request;
+  rpc_request.key = can_device::SET_READY_NEXT;
+  rpc_request.value = READY_WAITING;
+  bool return_ok = can_sender_->send_command_can_rpc_request(rpc_request);
+  std::this_thread::sleep_for(std::chrono::microseconds(100));
+  if (if_sdk) {
+    rpc_request.value = FORCE_DIRECT;
+  } else {
+    rpc_request.value = AUTO_LOCOMOTION;
+  }
+  return_ok &= can_sender_->send_command_can_rpc_request(rpc_request);
+  return return_ok;
+}
+
+bool tita_robot::set_rc_input(ChannelInput input)
+{
+  can_device::ChannelInput can_input;
+  can_input.forward = input.forward;
+  can_input.yaw = input.yaw;
+  can_input.pitch = input.pitch;
+  can_input.roll = input.roll;
+  can_input.height = input.height;
+  can_input.split = input.split;
+  can_input.tilt = input.tilt;
+  can_input.forward_accel = input.forward_accel;
+  can_input.yaw_accel = input.yaw_accel;
+  return can_sender_->send_command_can_channel_input(can_input);
+}
+
+bool tita_robot::set_robot_stand(bool stand)
+{
+  can_device::RpcRequest rpc_request;
+  rpc_request.key = can_device::SET_STAND_MODE;
+  rpc_request.value = !stand ? 0x01U : 0x02U;
+  return can_sender_->send_command_can_rpc_request(rpc_request);
+}
+
+bool tita_robot::set_robot_jump(bool jump)
+{
+  can_device::RpcRequest rpc_request;
+  rpc_request.key = can_device::SET_JUMP;
+  rpc_request.value = !jump ? 0x01U : 0x02U;
+  return can_sender_->send_command_can_rpc_request(rpc_request);
+}
+
+bool tita_robot::set_robot_stop()
+{
+  can_device::RpcRequest rpc_request;
+  rpc_request.value = 0x01U;
+  rpc_request.key = can_device::SET_STAND_MODE;
+  bool return_ok = can_sender_->send_command_can_rpc_request(rpc_request);
+  std::this_thread::sleep_for(std::chrono::microseconds(200));
+  rpc_request.value = 0x02U;
+  rpc_request.key = can_device::SET_JUMP;
+  return_ok &= can_sender_->send_command_can_rpc_request(rpc_request);
+  return true;
+}

--- a/rl_sar/src/rl_sar/src/rl_real_titati.cpp
+++ b/rl_sar/src/rl_sar/src/rl_real_titati.cpp
@@ -1,0 +1,371 @@
+/*
+ * Copyright (c) 2024-2025 Ziqi Fan
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "rl_real_titati.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <thread>
+
+RL_Real::RL_Real()
+#if defined(USE_ROS2) && defined(USE_ROS)
+    : rclcpp::Node("rl_real_node")
+#endif
+{
+#if defined(USE_ROS1) && defined(USE_ROS)
+    ros::NodeHandle nh;
+    this->cmd_vel_subscriber = nh.subscribe<geometry_msgs::Twist>("/cmd_vel", 10, &RL_Real::CmdvelCallback, this);
+#elif defined(USE_ROS2) && defined(USE_ROS)
+    this->cmd_vel_subscriber = this->create_subscription<geometry_msgs::msg::Twist>(
+        "/cmd_vel", rclcpp::SystemDefaultsQoS(),
+        [this] (const geometry_msgs::msg::Twist::SharedPtr msg) {this->CmdvelCallback(msg);} );
+#endif
+
+    // read params from yaml
+    this->ang_vel_type = "ang_vel_body";
+    this->robot_name = "titati";
+    this->ReadYamlBase(this->robot_name);
+
+    // auto load FSM by robot_name
+    if (FSMManager::GetInstance().IsTypeSupported(this->robot_name))
+    {
+        auto fsm_ptr = FSMManager::GetInstance().CreateFSM(this->robot_name, this);
+        if (fsm_ptr)
+        {
+            this->fsm = *fsm_ptr;
+        }
+    }
+    else
+    {
+        std::cout << LOGGER::ERROR << "No FSM registered for robot: " << this->robot_name << std::endl;
+    }
+
+    // init torch
+    torch::autograd::GradMode::set_enabled(false);
+    torch::set_num_threads(4);
+
+    // init hardware
+    this->tita_hw = std::make_unique<tita_robot>(this->params.num_of_dofs);
+    this->hardware_dofs = this->params.num_of_dofs;
+    if (this->tita_hw)
+    {
+        this->tita_hw->set_motors_sdk(true);
+    }
+
+    this->InitOutputs();
+    this->InitControl();
+
+    this->mapped_joint_positions.resize(this->params.num_of_dofs, 0.0);
+    this->mapped_joint_velocities.resize(this->params.num_of_dofs, 0.0);
+
+    // loop
+    this->loop_keyboard = std::make_shared<LoopFunc>("loop_keyboard", 0.05, std::bind(&RL_Real::KeyboardInterface, this));
+    this->loop_control = std::make_shared<LoopFunc>("loop_control", this->params.dt, std::bind(&RL_Real::RobotControl, this));
+    this->loop_rl = std::make_shared<LoopFunc>("loop_rl", this->params.dt * this->params.decimation, std::bind(&RL_Real::RunModel, this));
+    this->loop_keyboard->start();
+    this->loop_control->start();
+    this->loop_rl->start();
+
+#ifdef PLOT
+    this->plot_t = std::vector<int>(this->plot_size, 0);
+    this->plot_real_joint_pos.resize(this->params.num_of_dofs);
+    this->plot_target_joint_pos.resize(this->params.num_of_dofs);
+    for (auto &vector : this->plot_real_joint_pos) { vector = std::vector<double>(this->plot_size, 0); }
+    for (auto &vector : this->plot_target_joint_pos) { vector = std::vector<double>(this->plot_size, 0); }
+    this->loop_plot = std::make_shared<LoopFunc>("loop_plot", 0.002, std::bind(&RL_Real::Plot, this));
+    this->loop_plot->start();
+#endif
+#ifdef CSV_LOGGER
+    this->CSVInit(this->robot_name);
+#endif
+}
+
+RL_Real::~RL_Real()
+{
+    if (this->loop_keyboard) this->loop_keyboard->shutdown();
+    if (this->loop_control) this->loop_control->shutdown();
+    if (this->loop_rl) this->loop_rl->shutdown();
+#ifdef PLOT
+    if (this->loop_plot) this->loop_plot->shutdown();
+#endif
+    if (this->tita_hw && this->hardware_dofs > 0)
+    {
+        std::vector<double> zero_tau(this->hardware_dofs, 0.0);
+        this->tita_hw->set_target_joint_t(zero_tau);
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    std::cout << LOGGER::INFO << "RL_Real exit" << std::endl;
+}
+
+void RL_Real::GetState(RobotState<double> *state)
+{
+    if (!this->tita_hw)
+    {
+        return;
+    }
+
+    auto q = this->tita_hw->get_joint_q();
+    auto dq = this->tita_hw->get_joint_v();
+    auto tau = this->tita_hw->get_joint_t();
+    auto quat_xyzw = this->tita_hw->get_imu_quaternion();
+    auto gyro = this->tita_hw->get_imu_angular_velocity();
+    auto accl = this->tita_hw->get_imu_acceleration();
+
+    this->hardware_dofs = q.size();
+
+    // imu data conversion (xyzw -> wxyz)
+    state->imu.quaternion[0] = quat_xyzw[3];
+    state->imu.quaternion[1] = quat_xyzw[0];
+    state->imu.quaternion[2] = quat_xyzw[1];
+    state->imu.quaternion[3] = quat_xyzw[2];
+
+    for (int i = 0; i < 3; ++i)
+    {
+        state->imu.gyroscope[i] = gyro[i];
+        state->imu.accelerometer[i] = accl[i];
+    }
+
+    for (int i = 0; i < this->params.num_of_dofs; ++i)
+    {
+        int idx = this->params.joint_mapping[i];
+        if (idx < static_cast<int>(q.size()))
+        {
+            state->motor_state.q[i] = q[idx];
+        }
+        if (idx < static_cast<int>(dq.size()))
+        {
+            state->motor_state.dq[i] = dq[idx];
+        }
+        if (idx < static_cast<int>(tau.size()))
+        {
+            state->motor_state.tau_est[i] = tau[idx];
+        }
+    }
+}
+
+void RL_Real::SetCommand(const RobotCommand<double> *command)
+{
+    if (!this->tita_hw || this->hardware_dofs == 0)
+    {
+        return;
+    }
+
+    std::vector<double> q_cmd(this->hardware_dofs, 0.0);
+    std::vector<double> dq_cmd(this->hardware_dofs, 0.0);
+    std::vector<double> kp_cmd(this->hardware_dofs, 0.0);
+    std::vector<double> kd_cmd(this->hardware_dofs, 0.0);
+    std::vector<double> tau_cmd(this->hardware_dofs, 0.0);
+
+    for (int i = 0; i < this->params.num_of_dofs; ++i)
+    {
+        int idx = this->params.joint_mapping[i];
+        if (idx < static_cast<int>(this->hardware_dofs))
+        {
+            q_cmd[idx] = command->motor_command.q[i];
+            dq_cmd[idx] = command->motor_command.dq[i];
+            kp_cmd[idx] = command->motor_command.kp[i];
+            kd_cmd[idx] = command->motor_command.kd[i];
+            tau_cmd[idx] = command->motor_command.tau[i];
+        }
+    }
+
+    this->tita_hw->set_target_joint_mit(q_cmd, dq_cmd, kp_cmd, kd_cmd, tau_cmd);
+}
+
+void RL_Real::RobotControl()
+{
+    this->motiontime++;
+
+    if (this->control.current_keyboard == Input::Keyboard::W)
+    {
+        this->control.x += 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::S)
+    {
+        this->control.x -= 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::A)
+    {
+        this->control.y += 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::D)
+    {
+        this->control.y -= 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::Q)
+    {
+        this->control.yaw += 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::E)
+    {
+        this->control.yaw -= 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::Space)
+    {
+        this->control.x = 0;
+        this->control.y = 0;
+        this->control.yaw = 0;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::N || this->control.current_gamepad == Input::Gamepad::X)
+    {
+        this->control.navigation_mode = !this->control.navigation_mode;
+        std::cout << std::endl << LOGGER::INFO << "Navigation mode: " << (this->control.navigation_mode ? "ON" : "OFF") << std::endl;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+
+    this->GetState(&this->robot_state);
+    this->StateController(&this->robot_state, &this->robot_command);
+    this->SetCommand(&this->robot_command);
+}
+
+void RL_Real::RunModel()
+{
+    if (this->rl_init_done)
+    {
+        this->episode_length_buf += 1;
+        this->obs.ang_vel = torch::tensor(this->robot_state.imu.gyroscope).unsqueeze(0);
+        if (this->control.navigation_mode)
+        {
+#if !defined(USE_CMAKE) && defined(USE_ROS)
+            this->obs.commands = torch::tensor({{this->cmd_vel.linear.x, this->cmd_vel.linear.y, this->cmd_vel.angular.z}});
+#endif
+        }
+        else
+        {
+            this->obs.commands = torch::tensor({{this->control.x, this->control.y, this->control.yaw}});
+        }
+        this->obs.base_quat = torch::tensor(this->robot_state.imu.quaternion).unsqueeze(0);
+        this->obs.dof_pos = torch::tensor(this->robot_state.motor_state.q).narrow(0, 0, this->params.num_of_dofs).unsqueeze(0);
+        this->obs.dof_vel = torch::tensor(this->robot_state.motor_state.dq).narrow(0, 0, this->params.num_of_dofs).unsqueeze(0);
+
+        this->obs.actions = this->Forward();
+        this->ComputeOutput(this->obs.actions, this->output_dof_pos, this->output_dof_vel, this->output_dof_tau);
+
+        if (this->output_dof_pos.defined() && this->output_dof_pos.numel() > 0)
+        {
+            output_dof_pos_queue.push(this->output_dof_pos);
+        }
+        if (this->output_dof_vel.defined() && this->output_dof_vel.numel() > 0)
+        {
+            output_dof_vel_queue.push(this->output_dof_vel);
+        }
+        if (this->output_dof_tau.defined() && this->output_dof_tau.numel() > 0)
+        {
+            output_dof_tau_queue.push(this->output_dof_tau);
+        }
+
+        this->TorqueProtect(this->output_dof_tau);
+        // this->AttitudeProtect(this->robot_state.imu.quaternion, 75.0f, 75.0f);
+
+#ifdef CSV_LOGGER
+        torch::Tensor tau_est = torch::tensor(this->robot_state.motor_state.tau_est).unsqueeze(0);
+        this->CSVLogger(this->output_dof_tau, tau_est, this->obs.dof_pos, this->output_dof_pos, this->obs.dof_vel);
+#endif
+    }
+}
+
+torch::Tensor RL_Real::Forward()
+{
+    torch::autograd::GradMode::set_enabled(false);
+
+    torch::Tensor clamped_obs = this->ComputeObservation();
+
+    torch::Tensor actions;
+    if (!this->params.observations_history.empty())
+    {
+        this->history_obs_buf.insert(clamped_obs);
+        this->history_obs = this->history_obs_buf.get_obs_vec(this->params.observations_history);
+        if (this->fsm.current_state_->GetStateName() != "RLFSMStateRL_LocomotionLab")
+        {
+            torch::Tensor myTensor = history_obs.view({1,10,57});
+            actions = this->model.forward({clamped_obs, myTensor}).toTensor();
+        }
+        else
+        {
+            actions = this->model.forward({this->history_obs}).toTensor();
+        }
+
+    }
+    else
+    {
+        actions = this->model.forward({clamped_obs}).toTensor();
+    }
+
+    if (this->params.clip_actions_upper.numel() != 0 && this->params.clip_actions_lower.numel() != 0)
+    {
+        return torch::clamp(actions, this->params.clip_actions_lower, this->params.clip_actions_upper);
+    }
+    else
+    {
+        return actions;
+    }
+}
+
+void RL_Real::Plot()
+{
+    this->plot_t.erase(this->plot_t.begin());
+    this->plot_t.push_back(this->motiontime);
+    plt::cla();
+    plt::clf();
+    for (int i = 0; i < this->params.num_of_dofs; ++i)
+    {
+        this->plot_real_joint_pos[i].erase(this->plot_real_joint_pos[i].begin());
+        this->plot_target_joint_pos[i].erase(this->plot_target_joint_pos[i].begin());
+        this->plot_real_joint_pos[i].push_back(this->robot_state.motor_state.q[i]);
+        this->plot_target_joint_pos[i].push_back(this->robot_command.motor_command.q[i]);
+        plt::subplot(this->params.num_of_dofs, 1, i + 1);
+        plt::named_plot("_real_joint_pos", this->plot_t, this->plot_real_joint_pos[i], "r");
+        plt::named_plot("_target_joint_pos", this->plot_t, this->plot_target_joint_pos[i], "b");
+        plt::xlim(this->plot_t.front(), this->plot_t.back());
+    }
+    // plt::legend();
+    plt::pause(0.0001);
+}
+
+#if !defined(USE_CMAKE) && defined(USE_ROS)
+void RL_Real::CmdvelCallback(
+#if defined(USE_ROS1) && defined(USE_ROS)
+    const geometry_msgs::Twist::ConstPtr &msg
+#elif defined(USE_ROS2) && defined(USE_ROS)
+    const geometry_msgs::msg::Twist::SharedPtr msg
+#endif
+)
+{
+    this->cmd_vel = *msg;
+}
+#endif
+
+#if defined(USE_ROS1) && defined(USE_ROS)
+void signalHandler(int signum)
+{
+    ros::shutdown();
+    exit(0);
+}
+#endif
+
+int main(int argc, char **argv)
+{
+#if defined(USE_ROS1) && defined(USE_ROS)
+    signal(SIGINT, signalHandler);
+    ros::init(argc, argv, "rl_sar");
+    RL_Real rl_sar;
+    ros::spin();
+#elif defined(USE_ROS2) && defined(USE_ROS)
+    rclcpp::init(argc, argv);
+    rclcpp::spin(std::make_shared<RL_Real>());
+    rclcpp::shutdown();
+#elif defined(USE_CMAKE) || !defined(USE_ROS)
+    RL_Real rl_sar;
+    while (1) { sleep(10); }
+#endif
+    return 0;
+}

--- a/rl_sar/src/rl_sar/src/titati_can_router.cpp
+++ b/rl_sar/src/rl_sar/src/titati_can_router.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2024-2025 Ziqi Fan
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "titati_canfd_router/canfd_router_can_receive_api.hpp"
+
+#include <atomic>
+#include <csignal>
+#include <chrono>
+#include <iostream>
+#include <string>
+#include <thread>
+
+namespace
+{
+std::atomic<bool> g_running{true};
+
+void SignalHandler(int)
+{
+    g_running.store(false);
+}
+
+void PrintUsage(const char *binary)
+{
+    std::cout << "Usage: " << binary << " [--interface <can_if>] [--rpc-interface <can_if>] [--no-force]" << std::endl;
+    std::cout << "\n";
+    std::cout << "Options:" << std::endl;
+    std::cout << "  --interface <can_if>        CAN interface used to receive router status (default: can0)" << std::endl;
+    std::cout << "  --rpc-interface <can_if>    CAN interface used to send RPC commands (default: same as --interface)" << std::endl;
+    std::cout << "  --no-force                  Do not automatically request FORCE_DIRECT mode" << std::endl;
+    std::cout << "  -h, --help                  Show this help message" << std::endl;
+}
+} // namespace
+
+int main(int argc, char **argv)
+{
+    std::string receive_interface = "can0";
+    std::string rpc_interface;
+    bool force_direct = true;
+
+    for (int i = 1; i < argc; ++i)
+    {
+        const std::string arg = argv[i];
+        if (arg == "--interface" && i + 1 < argc)
+        {
+            receive_interface = argv[++i];
+        }
+        else if (arg == "--rpc-interface" && i + 1 < argc)
+        {
+            rpc_interface = argv[++i];
+        }
+        else if (arg == "--no-force")
+        {
+            force_direct = false;
+        }
+        else if (arg == "-h" || arg == "--help")
+        {
+            PrintUsage(argv[0]);
+            return 0;
+        }
+        else
+        {
+            std::cerr << "Unknown argument: " << arg << std::endl;
+            PrintUsage(argv[0]);
+            return 1;
+        }
+    }
+
+    std::signal(SIGINT, SignalHandler);
+    std::signal(SIGTERM, SignalHandler);
+
+    try
+    {
+        can_device::CanfdRouterCanReceiveApi router(receive_interface, rpc_interface);
+        if (force_direct)
+        {
+            router.set_forcedirect_mode(true);
+            std::cout << "[titati_can_router] Waiting for Titati CAN router heartbeat on "
+                      << receive_interface << "..." << std::endl;
+        }
+        else
+        {
+            std::cout << "[titati_can_router] Monitoring Titati CAN router on " << receive_interface
+                      << " without sending FORCE_DIRECT request." << std::endl;
+        }
+
+        while (g_running.load())
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        }
+    }
+    catch (const std::exception &ex)
+    {
+        std::cerr << "[titati_can_router] Failed to initialise CAN router: " << ex.what() << std::endl;
+        return 1;
+    }
+
+    std::cout << "[titati_can_router] Shutdown requested." << std::endl;
+    return 0;
+}

--- a/rl_sar/src/rl_sar/src/titati_motor_test.cpp
+++ b/rl_sar/src/rl_sar/src/titati_motor_test.cpp
@@ -1,0 +1,614 @@
+/*
+ * Copyright (c) 2024-2025 Ziqi Fan
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "tita_robot/tita_robot.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <cctype>
+#include <cstdlib>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+
+enum class CommandMode
+{
+    Torque = 0,
+    MIT = 1,
+};
+
+std::atomic<bool> *g_running_flag = nullptr;
+
+void SignalHandler(int)
+{
+    if (g_running_flag)
+    {
+        g_running_flag->store(false);
+    }
+}
+
+std::string ToLower(std::string value)
+{
+    std::transform(value.begin(), value.end(), value.begin(), [] (unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return value;
+}
+
+std::string ModeToString(CommandMode mode)
+{
+    return mode == CommandMode::Torque ? "torque" : "mit";
+}
+
+void PrintHelp(std::mutex &io_mutex)
+{
+    std::lock_guard<std::mutex> lock(io_mutex);
+    std::cout << "Available commands:\n"
+              << "  help                         Show this message\n"
+              << "  status [index]              Print the latest joint state (all motors or a single motor)\n"
+              << "  mode torque|mit             Switch the command mode and clear all pending targets\n"
+              << "  set <index> <values...>     Update the command for a motor (0-based index)\n"
+              << "       torque mode:           set <index> <torque_Nm>\n"
+              << "       mit mode:              set <index> <pos_rad> [vel_rad_s kp kd ff_torque] (missing terms default to 0)\n"
+              << "  zero [index|all]            Zero the command for one motor or every motor\n"
+              << "  monitor [period_ms|off]     Toggle periodic state printing (default 500 ms)\n"
+              << "  exit / quit                 Stop commanding torques and exit\n"
+              << std::flush;
+}
+
+struct CommandBuffers
+{
+    std::vector<double> position;
+    std::vector<double> velocity;
+    std::vector<double> kp;
+    std::vector<double> kd;
+    std::vector<double> torque;
+};
+
+void ResetCommands(CommandBuffers &buffers)
+{
+    std::fill(buffers.position.begin(), buffers.position.end(), 0.0);
+    std::fill(buffers.velocity.begin(), buffers.velocity.end(), 0.0);
+    std::fill(buffers.kp.begin(), buffers.kp.end(), 0.0);
+    std::fill(buffers.kd.begin(), buffers.kd.end(), 0.0);
+    std::fill(buffers.torque.begin(), buffers.torque.end(), 0.0);
+}
+
+void PrintMotorStates(
+    tita_robot &robot,
+    CommandMode mode,
+    const CommandBuffers &commands,
+    std::mutex &io_mutex,
+    int motor_index = -1)
+{
+    auto q = robot.get_joint_q();
+    auto dq = robot.get_joint_v();
+    auto tau = robot.get_joint_t();
+
+    const std::size_t motor_count = std::min({q.size(), dq.size(), tau.size(), commands.torque.size()});
+
+    std::lock_guard<std::mutex> lock(io_mutex);
+    std::cout << std::fixed << std::setprecision(4);
+
+    if (motor_index >= 0)
+    {
+        if (static_cast<std::size_t>(motor_index) >= motor_count)
+        {
+            std::cout << "Motor index " << motor_index << " is out of range (" << motor_count << " motors reported)." << std::endl;
+            return;
+        }
+
+        std::cout << "Motor " << motor_index << " state (mode: " << ModeToString(mode) << ")" << std::endl;
+        std::cout << "  q: " << q[motor_index] << " rad" << std::endl;
+        std::cout << "  dq: " << dq[motor_index] << " rad/s" << std::endl;
+        std::cout << "  tau_est: " << tau[motor_index] << " Nm" << std::endl;
+
+        if (mode == CommandMode::Torque)
+        {
+            std::cout << "  cmd_tau: " << commands.torque[motor_index] << " Nm" << std::endl;
+        }
+        else
+        {
+            std::cout << "  cmd_q: " << commands.position[motor_index] << " rad" << std::endl;
+            std::cout << "  cmd_dq: " << commands.velocity[motor_index] << " rad/s" << std::endl;
+            std::cout << "  cmd_kp: " << commands.kp[motor_index] << std::endl;
+            std::cout << "  cmd_kd: " << commands.kd[motor_index] << std::endl;
+            std::cout << "  cmd_tau: " << commands.torque[motor_index] << " Nm" << std::endl;
+        }
+        return;
+    }
+
+    std::cout << "Motor states (mode: " << ModeToString(mode) << ")" << std::endl;
+    std::cout << " idx |     q(rad) |  dq(rad/s) |  tau_est |   cmd_tau";
+    if (mode == CommandMode::MIT)
+    {
+        std::cout << " |    cmd_q |  cmd_dq |  cmd_kp |  cmd_kd";
+    }
+    std::cout << std::endl;
+    std::cout << "-------------------------------------------------------------";
+    if (mode == CommandMode::MIT)
+    {
+        std::cout << "-----------------------------";
+    }
+    std::cout << std::endl;
+
+    for (std::size_t i = 0; i < motor_count; ++i)
+    {
+        std::cout << std::setw(4) << i << " | " << std::setw(9) << q[i] << " | " << std::setw(10) << dq[i] << " | "
+                  << std::setw(8) << tau[i] << " | " << std::setw(8) << commands.torque[i];
+        if (mode == CommandMode::MIT)
+        {
+            std::cout << " | " << std::setw(8) << commands.position[i] << " | " << std::setw(7) << commands.velocity[i]
+                      << " | " << std::setw(7) << commands.kp[i] << " | " << std::setw(7) << commands.kd[i];
+        }
+        std::cout << std::endl;
+    }
+}
+
+} // namespace
+
+int main(int argc, char *argv[])
+{
+    std::size_t motor_count = 16U;
+    std::atomic<CommandMode> mode(CommandMode::Torque);
+    bool monitor_enabled = false;
+    int monitor_period_ms = 500;
+
+    for (int i = 1; i < argc; ++i)
+    {
+        const std::string arg = argv[i];
+        if (arg == "--motors" && i + 1 < argc)
+        {
+            try
+            {
+                motor_count = static_cast<std::size_t>(std::stoul(argv[++i]));
+            }
+            catch (const std::exception &)
+            {
+                std::cerr << "Invalid value for --motors: " << argv[i] << std::endl;
+                return EXIT_FAILURE;
+            }
+        }
+        else if (arg == "--mode" && i + 1 < argc)
+        {
+            const std::string value = ToLower(argv[++i]);
+            if (value == "torque")
+            {
+                mode = CommandMode::Torque;
+            }
+            else if (value == "mit")
+            {
+                mode = CommandMode::MIT;
+            }
+            else
+            {
+                std::cerr << "Unknown mode: " << value << std::endl;
+                return EXIT_FAILURE;
+            }
+        }
+        else if (arg == "--monitor")
+        {
+            monitor_enabled = true;
+            if (i + 1 < argc)
+            {
+                char *end_ptr = nullptr;
+                const long candidate = std::strtol(argv[i + 1], &end_ptr, 10);
+                if (end_ptr != nullptr && *end_ptr == '\0' && candidate > 0)
+                {
+                    monitor_period_ms = static_cast<int>(candidate);
+                    ++i;
+                }
+            }
+        }
+        else if (arg == "--help" || arg == "-h")
+        {
+            std::cout << "Usage: " << argv[0] << " [--motors N] [--mode torque|mit] [--monitor [period_ms]]" << std::endl;
+            return EXIT_SUCCESS;
+        }
+        else
+        {
+            std::cerr << "Unknown argument: " << arg << std::endl;
+            return EXIT_FAILURE;
+        }
+    }
+
+    if (motor_count == 0U)
+    {
+        std::cerr << "Motor count must be greater than zero." << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    tita_robot robot(motor_count);
+
+    if (!robot.set_motors_sdk(true))
+    {
+        std::cerr << "Failed to switch the Titati MCU into SDK (direct torque) mode." << std::endl;
+    }
+
+    CommandBuffers command_buffers;
+    command_buffers.position.resize(motor_count, 0.0);
+    command_buffers.velocity.resize(motor_count, 0.0);
+    command_buffers.kp.resize(motor_count, 0.0);
+    command_buffers.kd.resize(motor_count, 0.0);
+    command_buffers.torque.resize(motor_count, 0.0);
+
+    std::mutex command_mutex;
+    std::mutex io_mutex;
+
+    std::atomic<bool> running(true);
+    g_running_flag = &running;
+    std::signal(SIGINT, SignalHandler);
+
+    std::thread command_thread([&] () {
+        while (running.load())
+        {
+            CommandMode active_mode = mode.load();
+            CommandBuffers local_buffers;
+            {
+                std::lock_guard<std::mutex> lock(command_mutex);
+                local_buffers = command_buffers;
+            }
+
+            bool success = false;
+            try
+            {
+                if (active_mode == CommandMode::Torque)
+                {
+                    success = robot.set_target_joint_t(local_buffers.torque);
+                }
+                else
+                {
+                    success = robot.set_target_joint_mit(
+                        local_buffers.position, local_buffers.velocity, local_buffers.kp, local_buffers.kd, local_buffers.torque);
+                }
+            }
+            catch (const std::exception &ex)
+            {
+                std::lock_guard<std::mutex> lock(io_mutex);
+                std::cerr << "Exception while sending command: " << ex.what() << std::endl;
+            }
+
+            if (!success)
+            {
+                std::lock_guard<std::mutex> lock(io_mutex);
+                std::cerr << "Failed to send command over CAN." << std::endl;
+            }
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+
+        // Send a final zero command on exit
+        CommandBuffers zero_buffers;
+        zero_buffers.position.resize(motor_count, 0.0);
+        zero_buffers.velocity.resize(motor_count, 0.0);
+        zero_buffers.kp.resize(motor_count, 0.0);
+        zero_buffers.kd.resize(motor_count, 0.0);
+        zero_buffers.torque.resize(motor_count, 0.0);
+
+        try
+        {
+            if (mode.load() == CommandMode::Torque)
+            {
+                robot.set_target_joint_t(zero_buffers.torque);
+            }
+            else
+            {
+                robot.set_target_joint_mit(
+                    zero_buffers.position, zero_buffers.velocity, zero_buffers.kp, zero_buffers.kd, zero_buffers.torque);
+            }
+        }
+        catch (const std::exception &ex)
+        {
+            std::lock_guard<std::mutex> lock(io_mutex);
+            std::cerr << "Exception while clearing command: " << ex.what() << std::endl;
+        }
+    });
+
+    std::atomic<bool> monitor_toggle(monitor_enabled);
+    std::atomic<int> monitor_period(monitor_period_ms);
+
+    std::thread monitor_thread([&] () {
+        while (running.load())
+        {
+            if (monitor_toggle.load())
+            {
+                CommandMode active_mode = mode.load();
+                CommandBuffers local_buffers;
+                {
+                    std::lock_guard<std::mutex> lock(command_mutex);
+                    local_buffers = command_buffers;
+                }
+
+                PrintMotorStates(robot, active_mode, local_buffers, io_mutex);
+                std::this_thread::sleep_for(std::chrono::milliseconds(monitor_period.load()));
+            }
+            else
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            }
+        }
+    });
+
+    PrintHelp(io_mutex);
+
+    while (running.load())
+    {
+        {
+            std::lock_guard<std::mutex> lock(io_mutex);
+            std::cout << "> " << std::flush;
+        }
+
+        std::string line;
+        if (!std::getline(std::cin, line))
+        {
+            running.store(false);
+            break;
+        }
+
+        std::istringstream iss(line);
+        std::string command;
+        if (!(iss >> command))
+        {
+            continue;
+        }
+
+        command = ToLower(command);
+
+        if (command == "help" || command == "h")
+        {
+            PrintHelp(io_mutex);
+        }
+        else if (command == "exit" || command == "quit" || command == "q")
+        {
+            running.store(false);
+        }
+        else if (command == "status" || command == "s")
+        {
+            int requested_index = -1;
+            CommandBuffers snapshot;
+            {
+                std::lock_guard<std::mutex> lock(command_mutex);
+                snapshot = command_buffers;
+            }
+            if (iss >> requested_index)
+            {
+                PrintMotorStates(robot, mode.load(), snapshot, io_mutex, requested_index);
+            }
+            else
+            {
+                PrintMotorStates(robot, mode.load(), snapshot, io_mutex);
+            }
+        }
+        else if (command == "mode")
+        {
+            std::string value;
+            if (!(iss >> value))
+            {
+                std::lock_guard<std::mutex> lock(io_mutex);
+                std::cerr << "Usage: mode torque|mit" << std::endl;
+                continue;
+            }
+
+            value = ToLower(value);
+            if (value == "torque")
+            {
+                mode.store(CommandMode::Torque);
+            }
+            else if (value == "mit")
+            {
+                mode.store(CommandMode::MIT);
+            }
+            else
+            {
+                std::lock_guard<std::mutex> lock(io_mutex);
+                std::cerr << "Unknown mode: " << value << std::endl;
+                continue;
+            }
+
+            {
+                std::lock_guard<std::mutex> lock(command_mutex);
+                ResetCommands(command_buffers);
+            }
+
+            std::lock_guard<std::mutex> lock(io_mutex);
+            std::cout << "Switched to " << ModeToString(mode.load()) << " mode and cleared all commands." << std::endl;
+        }
+        else if (command == "set")
+        {
+            int index_input = -1;
+            if (!(iss >> index_input))
+            {
+                std::lock_guard<std::mutex> lock(io_mutex);
+                std::cerr << "Usage: set <index> <values...>" << std::endl;
+                continue;
+            }
+
+            if (index_input < 0 || static_cast<std::size_t>(index_input) >= motor_count)
+            {
+                std::lock_guard<std::mutex> lock(io_mutex);
+                std::cerr << "Motor index must be within [0, " << motor_count - 1 << "]." << std::endl;
+                continue;
+            }
+
+            std::vector<double> values;
+            double value = 0.0;
+            while (iss >> value)
+            {
+                values.push_back(value);
+            }
+
+            if (mode.load() == CommandMode::Torque)
+            {
+                if (values.empty())
+                {
+                    std::lock_guard<std::mutex> lock(io_mutex);
+                    std::cerr << "Torque mode requires one value: set <index> <torque_Nm>." << std::endl;
+                    continue;
+                }
+
+                {
+                    std::lock_guard<std::mutex> lock(command_mutex);
+                    command_buffers.torque[static_cast<std::size_t>(index_input)] = values[0];
+                }
+
+                std::lock_guard<std::mutex> lock(io_mutex);
+                std::cout << "Motor " << index_input << " torque command set to " << values[0] << " Nm." << std::endl;
+            }
+            else
+            {
+                const double q_target = values.size() > 0 ? values[0] : 0.0;
+                const double dq_target = values.size() > 1 ? values[1] : 0.0;
+                const double kp_target = values.size() > 2 ? values[2] : 0.0;
+                const double kd_target = values.size() > 3 ? values[3] : 0.0;
+                const double tau_target = values.size() > 4 ? values[4] : 0.0;
+
+                {
+                    std::lock_guard<std::mutex> lock(command_mutex);
+                    const std::size_t idx = static_cast<std::size_t>(index_input);
+                    command_buffers.position[idx] = q_target;
+                    command_buffers.velocity[idx] = dq_target;
+                    command_buffers.kp[idx] = kp_target;
+                    command_buffers.kd[idx] = kd_target;
+                    command_buffers.torque[idx] = tau_target;
+                }
+
+                std::lock_guard<std::mutex> lock(io_mutex);
+                std::cout << "Motor " << index_input << " MIT command set to (q=" << q_target << ", dq=" << dq_target
+                          << ", kp=" << kp_target << ", kd=" << kd_target << ", tau=" << tau_target << ")." << std::endl;
+            }
+        }
+        else if (command == "zero")
+        {
+            std::string target;
+            if (!(iss >> target))
+            {
+                std::lock_guard<std::mutex> lock(io_mutex);
+                std::cerr << "Usage: zero <index|all>" << std::endl;
+                continue;
+            }
+
+            if (target == "all")
+            {
+                {
+                    std::lock_guard<std::mutex> lock(command_mutex);
+                    ResetCommands(command_buffers);
+                }
+
+                std::lock_guard<std::mutex> io_lock(io_mutex);
+                std::cout << "Cleared commands for all motors." << std::endl;
+            }
+            else
+            {
+                int index = 0;
+                try
+                {
+                    index = std::stoi(target);
+                }
+                catch (const std::exception &)
+                {
+                    std::lock_guard<std::mutex> lock(io_mutex);
+                    std::cerr << "Motor index must be an integer or 'all'." << std::endl;
+                    continue;
+                }
+
+                if (index < 0 || static_cast<std::size_t>(index) >= motor_count)
+                {
+                    std::lock_guard<std::mutex> lock(io_mutex);
+                    std::cerr << "Motor index must be within [0, " << motor_count - 1 << "]." << std::endl;
+                    continue;
+                }
+
+                {
+                    std::lock_guard<std::mutex> lock(command_mutex);
+                    const std::size_t idx = static_cast<std::size_t>(index);
+                    command_buffers.position[idx] = 0.0;
+                    command_buffers.velocity[idx] = 0.0;
+                    command_buffers.kp[idx] = 0.0;
+                    command_buffers.kd[idx] = 0.0;
+                    command_buffers.torque[idx] = 0.0;
+                }
+
+                std::lock_guard<std::mutex> lock(io_mutex);
+                std::cout << "Cleared command for motor " << index << '.' << std::endl;
+            }
+        }
+        else if (command == "monitor")
+        {
+            std::string token;
+            if (!(iss >> token))
+            {
+                const bool new_state = !monitor_toggle.load();
+                monitor_toggle.store(new_state);
+                std::lock_guard<std::mutex> lock(io_mutex);
+                std::cout << (new_state ? "Enabled" : "Disabled") << " periodic state monitoring." << std::endl;
+                continue;
+            }
+
+            token = ToLower(token);
+            if (token == "off")
+            {
+                monitor_toggle.store(false);
+                std::lock_guard<std::mutex> lock(io_mutex);
+                std::cout << "Disabled periodic state monitoring." << std::endl;
+            }
+            else
+            {
+                int period = 0;
+                try
+                {
+                    period = std::stoi(token);
+                }
+                catch (const std::exception &)
+                {
+                    std::lock_guard<std::mutex> lock(io_mutex);
+                    std::cerr << "Usage: monitor [period_ms|off]" << std::endl;
+                    continue;
+                }
+
+                if (period <= 0)
+                {
+                    std::lock_guard<std::mutex> lock(io_mutex);
+                    std::cerr << "Monitor period must be positive." << std::endl;
+                    continue;
+                }
+
+                monitor_period.store(period);
+                monitor_toggle.store(true);
+                std::lock_guard<std::mutex> lock(io_mutex);
+                std::cout << "Enabled periodic monitoring every " << period << " ms." << std::endl;
+            }
+        }
+        else
+        {
+            std::lock_guard<std::mutex> lock(io_mutex);
+            std::cerr << "Unknown command: " << command << std::endl;
+        }
+    }
+
+    running.store(false);
+    if (monitor_thread.joinable())
+    {
+        monitor_thread.join();
+    }
+    if (command_thread.joinable())
+    {
+        command_thread.join();
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(io_mutex);
+        std::cout << "Titati motor tester exited." << std::endl;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/rl_sar/src/rl_sar/src/titati_motor_test.cpp
+++ b/rl_sar/src/rl_sar/src/titati_motor_test.cpp
@@ -235,6 +235,9 @@ int main(int argc, char *argv[])
         std::cerr << "Failed to switch the Titati MCU into SDK (direct torque) mode." << std::endl;
     }
 
+    std::cout << "[titati_motor_test] Tip: start `titati_can_router` on both Jetsons so all 16 actuators report telemetry."
+              << std::endl;
+
     CommandBuffers command_buffers;
     command_buffers.position.resize(motor_count, 0.0);
     command_buffers.velocity.resize(motor_count, 0.0);


### PR DESCRIPTION
## Summary
- vendor the Titati CAN-based hardware stack into rl_sar so the project can talk directly to the robot motors and IMU
- add a Titati-specific RL real controller that streams state from the new hardware interface and drives the RL policy
- register the Titati hardware library and executable in the CMake build so the new controller can be built with the rest of the project

## Testing
- `./build.sh -m rl_real_titati` *(fails: TorchConfig.cmake not found in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e7f923f483218ba1d07502568604