### PR TITLE
Handle variable motor counts per CAN-FD frame

### DIFF
--- a/rl_sar/src/rl_sar/include/tita_hardware/can_receiver.hpp
+++ b/rl_sar/src/rl_sar/include/tita_hardware/can_receiver.hpp
@@ -64,14 +64,12 @@ namespace can_device
   {
   public:
     MotorsImuCanReceiveApi(size_t size)
+        : total_motors_(size)
     {
-      if(size % 8 == 0) leg_dof_ = 4;
-      else if(size % 6 == 0) leg_dof_ = 3;
-      leg_num_ = size / leg_dof_;
       register_motors_device_can_filter();
       api_motor_in_t default_motor_in;
       std::memset(&default_motor_in, 0x00U, sizeof(api_motor_in_t));
-      motors_in_.resize(size, default_motor_in);
+      motors_in_.resize(total_motors_, default_motor_in);
       std::memset(&imu_data_, 0x00U, sizeof(api_imu_data_t));
     }
     ~MotorsImuCanReceiveApi() {}
@@ -109,7 +107,8 @@ namespace can_device
     api_motor_status_t motors_status_;
 
     mutable std::shared_mutex motors_in_mutex_, imu_mutex_;
-    size_t leg_dof_{4}, leg_num_{2};
+    size_t total_motors_{0};
+    size_t observed_frame_count_{0};
   };
 } // namespace can_device
 

--- a/rl_sar/src/rl_sar/src/hardware/can_receiver.cpp
+++ b/rl_sar/src/rl_sar/src/hardware/can_receiver.cpp
@@ -30,7 +30,8 @@ void MotorsImuCanReceiveApi::register_motors_device_can_filter()
 
 void MotorsImuCanReceiveApi::board_can_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)
 {
-  if (recv_frame->can_id >= CAN_ID_MOTOR_IN && recv_frame->can_id < CAN_ID_MOTOR_IN + leg_num_) {
+  if (recv_frame->can_id >= CAN_ID_MOTOR_IN &&
+      recv_frame->can_id < CAN_ID_MOTOR_IN + total_motors_) {
     motors_data_callback(recv_frame);
   } else if (recv_frame->can_id == CAN_ID_IMU1) {
     imu_data_callback(recv_frame);
@@ -40,12 +41,37 @@ void MotorsImuCanReceiveApi::board_can_data_callback(std::shared_ptr<struct canf
 }
 void MotorsImuCanReceiveApi::motors_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)
 {
+  constexpr size_t kBytesPerMotor = sizeof(api_motor_in_t);
+  if (recv_frame->len < kBytesPerMotor) {
+    return;
+  }
+
+  const size_t motors_in_frame = recv_frame->len / kBytesPerMotor;
+  if (motors_in_frame == 0) {
+    return;
+  }
+
+  const size_t frame_index = recv_frame->can_id - CAN_ID_MOTOR_IN;
+
   std::unique_lock<std::shared_mutex> lock(motors_in_mutex_);
-  for (size_t i = 0; i < leg_dof_; i++) {
+  observed_frame_count_ = std::max(observed_frame_count_, frame_index + 1);
+  size_t frames_in_cycle = observed_frame_count_ == 0 ? 1 : observed_frame_count_;
+  size_t motors_per_frame = (total_motors_ + frames_in_cycle - 1) / frames_in_cycle;
+  motors_per_frame = std::max<size_t>(1, std::min(motors_per_frame, motors_in_frame));
+
+  size_t motor_index_start = frame_index * motors_per_frame;
+  if (motor_index_start >= motors_in_.size()) {
+    return;
+  }
+
+  for (size_t i = 0; i < motors_in_frame; i++) {
     api_motor_in_t motor;
-    std::memcpy(&motor, recv_frame->data + 16 * i, sizeof(api_motor_in_t));
-    auto it = recv_frame->can_id - CAN_ID_MOTOR_IN;
-    motors_in_[i + leg_dof_ * it] = motor;
+    std::memcpy(&motor, recv_frame->data + kBytesPerMotor * i, sizeof(api_motor_in_t));
+    size_t motor_index = motor_index_start + i;
+    if (motor_index >= motors_in_.size()) {
+      break;
+    }
+    motors_in_[motor_index] = motor;
   }
 }
 void MotorsImuCanReceiveApi::imu_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)

--- a/titati_control/src/tita_hardware_ros2_control/tita_robot/include/tita_robot/can_receiver.hpp
+++ b/titati_control/src/tita_hardware_ros2_control/tita_robot/include/tita_robot/can_receiver.hpp
@@ -64,14 +64,12 @@ namespace can_device
   {
   public:
     MotorsImuCanReceiveApi(size_t size)
+        : total_motors_(size)
     {
-      if(size % 8 == 0) leg_dof_ = 4;
-      else if(size % 6 == 0) leg_dof_ = 3;
-      leg_num_ = size / leg_dof_;
       register_motors_device_can_filter();
       api_motor_in_t default_motor_in;
       std::memset(&default_motor_in, 0x00U, sizeof(api_motor_in_t));
-      motors_in_.resize(size, default_motor_in);
+      motors_in_.resize(total_motors_, default_motor_in);
       std::memset(&imu_data_, 0x00U, sizeof(api_imu_data_t));
     }
     ~MotorsImuCanReceiveApi() {}
@@ -109,7 +107,8 @@ namespace can_device
     api_motor_status_t motors_status_;
 
     mutable std::shared_mutex motors_in_mutex_, imu_mutex_;
-    size_t leg_dof_{4}, leg_num_{2};
+    size_t total_motors_{0};
+    size_t observed_frame_count_{0};
   };
 } // namespace can_device
 

--- a/titati_control/src/tita_hardware_ros2_control/tita_robot/src/can_receiver.cpp
+++ b/titati_control/src/tita_hardware_ros2_control/tita_robot/src/can_receiver.cpp
@@ -30,7 +30,8 @@ void MotorsImuCanReceiveApi::register_motors_device_can_filter()
 
 void MotorsImuCanReceiveApi::board_can_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)
 {
-  if (recv_frame->can_id >= CAN_ID_MOTOR_IN && recv_frame->can_id < CAN_ID_MOTOR_IN + leg_num_) {
+  if (recv_frame->can_id >= CAN_ID_MOTOR_IN &&
+      recv_frame->can_id < CAN_ID_MOTOR_IN + total_motors_) {
     motors_data_callback(recv_frame);
   } else if (recv_frame->can_id == CAN_ID_IMU1) {
     imu_data_callback(recv_frame);
@@ -40,12 +41,37 @@ void MotorsImuCanReceiveApi::board_can_data_callback(std::shared_ptr<struct canf
 }
 void MotorsImuCanReceiveApi::motors_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)
 {
+  constexpr size_t kBytesPerMotor = sizeof(api_motor_in_t);
+  if (recv_frame->len < kBytesPerMotor) {
+    return;
+  }
+
+  const size_t motors_in_frame = recv_frame->len / kBytesPerMotor;
+  if (motors_in_frame == 0) {
+    return;
+  }
+
+  const size_t frame_index = recv_frame->can_id - CAN_ID_MOTOR_IN;
+
   std::unique_lock<std::shared_mutex> lock(motors_in_mutex_);
-  for (size_t i = 0; i < leg_dof_; i++) {
+  observed_frame_count_ = std::max(observed_frame_count_, frame_index + 1);
+  size_t frames_in_cycle = observed_frame_count_ == 0 ? 1 : observed_frame_count_;
+  size_t motors_per_frame = (total_motors_ + frames_in_cycle - 1) / frames_in_cycle;
+  motors_per_frame = std::max<size_t>(1, std::min(motors_per_frame, motors_in_frame));
+
+  size_t motor_index_start = frame_index * motors_per_frame;
+  if (motor_index_start >= motors_in_.size()) {
+    return;
+  }
+
+  for (size_t i = 0; i < motors_in_frame; i++) {
     api_motor_in_t motor;
-    std::memcpy(&motor, recv_frame->data + 16 * i, sizeof(api_motor_in_t));
-    auto it = recv_frame->can_id - CAN_ID_MOTOR_IN;
-    motors_in_[i + leg_dof_ * it] = motor;
+    std::memcpy(&motor, recv_frame->data + kBytesPerMotor * i, sizeof(api_motor_in_t));
+    size_t motor_index = motor_index_start + i;
+    if (motor_index >= motors_in_.size()) {
+      break;
+    }
+    motors_in_[motor_index] = motor;
   }
 }
 void MotorsImuCanReceiveApi::imu_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)


### PR DESCRIPTION
## Summary
- allow the CAN receiver to size its motor buffers off the configured motor count and drop the baked-in leg layout
- infer the number of motors carried by each CAN-FD frame from the payload length and map them into the motor array using the observed frame IDs in both rl_sar and titati_control

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4db96b13483218398ceb655068370