### PR TITLE
Add detailed Titati RL migration README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,99 @@
-# test
+# Titati 四轮足使用 rl_sar 的迁移说明
+
+本仓库同时保留了原始的 `titati_control` 项目以及已经移植完成的 `rl_sar` 强化学习控制栈，方便在两套方案之间切换、对照调试。本文档梳理 Titati 机器人（两台 Tita 通过连线拼接成的四轮足）在 `rl_sar` 上线需要注意的软硬件准备、构建流程以及运行方法。
+
+## 仓库结构速览
+
+- `titati_control/`：原始 ROS2 控制器、CANFD 路由以及 bringup 脚本，可用于参考 URDF、参数或继续使用传统控制器。
+- `rl_sar/`：强化学习仿真与真机部署框架，本次移植已经加入 Titati 的硬件接口（`tita_robot_sdk`）、状态机（`policy/titati`）以及真机入口程序 `rl_real_titati`。
+
+建议把 `titati_control` 当作参考资料和紧急兜底方案，实际在线运行强化学习策略时全部工作都在 `rl_sar` 目录完成。
+
+## 硬件与系统先决条件
+
+1. **Jetson Orin NX (16G)**：确保已经刷入 Ubuntu 20.04/22.04，并根据需要安装 ROS Noetic 或 ROS2 Foxy/Humble。
+2. **实时总线**：`tita_robot_sdk` 默认通过 `can0` 接口以 CAN FD 模式访问 16 个电机与 IMU，波特率 1 Mbps / 数据速率 8 Mbps。可以直接复用 `titati_control` 中的脚本初始化 CAN：
+   ```bash
+   sudo ip link set can0 down
+   sudo ip link set can0 up type can bitrate 1000000 sample-point 0.80 \
+       dbitrate 8000000 dsample-point 0.80 fd on restart-ms 100
+   sudo ifconfig can0 txqueuelen 1000
+   ```
+   或执行 `titati_control/src/can_setup_8m_master.sh` 以一键设置并停止旧的 bringup 服务。
+3. **第三方依赖**：
+   - [libtorch 2.0.1 cxx11 ABI](https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.0.1%2Bcpu.zip)，并通过 `export Torch_DIR=<PATH>/libtorch` 指向其根目录。
+   - `yaml-cpp` 与 `lcm`：`sudo apt install libyaml-cpp-dev liblcm-dev`。
+   - 可选：若需要 ROS 键盘/遥控输入，请安装 `teleop-twist-keyboard`、`ros_control` 等依赖，具体列表见 `rl_sar/README.md`。
+
+在启动 `rl_real_titati` 前务必确认 `can0` 已经 up，且旧的 `titati_controller` 节点不会同时抢占电机。
+
+## 构建 rl_sar（含 Titati 支持）
+
+> 建议在机器人本机或开发主机上完成以下步骤，默认从仓库根目录执行。
+
+1. **配置 Torch 路径**（仅首次）
+   ```bash
+   echo 'export Torch_DIR=/opt/libtorch' >> ~/.bashrc
+   source ~/.bashrc
+   ```
+2. **进入 rl_sar 并执行硬件构建**：
+   ```bash
+   cd rl_sar
+   ./build.sh --cmake rl_sar
+   ```
+   该命令会以纯 CMake 方式生成 `cmake_build/`，包含 `tita_robot_sdk` 与 `rl_real_titati` 可执行文件。
+3. **ROS 工作区构建（可选）**：若需要通过 `ros2 run rl_sar rl_real_titati` 启动，可执行 `./build.sh --ros rl_sar`，脚本会自动创建符号链接并调用 `colcon`/`catkin` 构建。
+
+构建成功后，`cmake_build/bin/rl_real_titati` 即可直接运行，无需 ROS 环境。
+
+## 策略、模型与参数配置
+
+Titati 的策略配置集中在 `rl_sar/src/rl_sar/policy/titati/`：
+
+- `base.yaml`：对齐物理硬件的默认关节姿态、力矩上限、轮子索引以及 `joint_mapping`。如硬件布线顺序发生变化，请同步修改 `joint_mapping`，否则状态和命令会错位。
+- `robot_lab/config.yaml`：描述策略输入输出维度、观测项以及增益。可将训练得到的 TorchScript 模型命名为 `policy.pt`（或在 `model_name` 字段中填写自定义文件名），并放置到 `rl_sar/src/rl_sar/policy/titati/robot_lab/` 目录下。
+- `fsm.hpp`：定义 Titati 的有限状态机，包括被动、起身、下蹲与 RL Locomotion 等状态，通常无须修改，但若需要自定义前置动作可在此扩展。
+
+当 `rl_real_titati` 启动后会读取上述 YAML 并自动加载模型、初始化观测缓冲与控制参数。
+
+## 运行 rl_real_titati
+
+### 纯 CMake 可执行文件
+
+```bash
+cd rl_sar
+./cmake_build/bin/rl_real_titati
+```
+
+程序启动后会自动尝试将电机切换至 SDK 直驱模式；退出（或 `Ctrl+C`）时会回落到 MCU 控制，以避免无人值守状态下电机保持使能。
+
+### ROS2 启动（可选）
+
+```bash
+source install/setup.bash   # 或 source devel/setup.bash (ROS1)
+ros2 run rl_sar rl_real_titati
+```
+
+在定义了 `USE_ROS` 的编译配置下，节点会订阅 `/cmd_vel` 并根据导航模式决定使用 ROS 命令或键盘命令。
+
+### 键盘 / 手柄指令速查
+
+- `W/S`：前后速度增减；`A/D`：侧向速度增减；`Q/E`：航向角速度增减；`Space`：清空所有速度命令。
+- `M`：强制切换到 SDK 直驱，使能电机；`K`：切回 MCU 控制，关闭电机；`N`：切换导航模式（键盘 VS `/cmd_vel`）。
+- 当接入 Retroid 手柄时，`LB+RB` 会触发 `set_robot_stop()` 急停，`LB+A/B/X` 与键盘热键一致。
+
+策略推理线程会将 IMU、关节位置/速度/力矩写入 `RobotState`，经过状态机输出 MIT 力矩命令，并通过 `tita_robot_sdk` 下发到各电机。
+
+## 与 titati_control 共存的注意事项
+
+- 两套系统都会占用 `can0` 与电机 SDK 通道，请确保同一时间只启动其中一个，否则会互相抢占导致力矩指令异常。
+- 如需回退到原控制器，可先退出 `rl_real_titati`，执行 `titati_control/src/can_setup_8m_master.sh` 重新拉起原 ROS2 launch。
+- 通过 `tita_robot::set_motors_sdk(false)` 可以在不退出程序的情况下让 MCU 接管，以便切换到 `titati_control` 的节点。
+
+## 调试与排错建议
+
+- 若 `rl_real_titati` 启动报错 `TORCH` 未找到，请检查 `Torch_DIR` 环境变量是否指向正确目录。
+- 若 CAN 报错 `Interface does not support CAN FD`，请确认网卡驱动支持 CAN FD，并按脚本重新设置。
+- 可通过定义 `PLOT` 或 `CSV_LOGGER`（`rl_real_titati.hpp` 顶部）开启实时曲线或数据记录，便于排查策略输出与硬件反馈的差异。
+
+按照以上流程完成准备后，即可使用 `rl_sar` 中的强化学习策略对 Titati 四轮足进行实时控制，实现从 `titati_control` 向 RL 框架的平滑迁移。

--- a/README.md
+++ b/README.md
@@ -1,130 +1,168 @@
-# Titati 四轮足使用 rl_sar 的迁移说明
+# Titati 四轮足：从 `titati_control` 迁移到 `rl_sar`
 
-本仓库同时保留了原始的 `titati_control` 项目以及已经移植完成的 `rl_sar` 强化学习控制栈，方便在两套方案之间切换、对照调试。本文档梳理 Titati 机器人（两台 Tita 通过连线拼接成的四轮足）在 `rl_sar` 上线需要注意的软硬件准备、构建流程以及运行方法。
+本文记录如何在无需 ROS 的前提下，将由两台 Tita 拼接的四轮足机器人切换到 `rl_sar` 强化学习控制栈。请在动手前完整阅读“主从运行顺序”小节，
+确保两台 Jetson（主控、从控）和 16 个电机能够在同一条 CAN-FD 总线上协同工作。
 
-## 仓库结构速览
+---
 
-- `titati_control/`：原始 ROS2 控制器、CANFD 路由以及 bringup 脚本，可用于参考 URDF、参数或继续使用传统控制器。
-- `rl_sar/`：强化学习仿真与真机部署框架，本次移植已经加入 Titati 的硬件接口（`tita_robot_sdk`）、状态机（`policy/titati`）以及真机入口程序 `rl_real_titati`。
+## 1. 系统概览
 
-建议把 `titati_control` 当作参考资料和紧急兜底方案，实际在线运行强化学习策略时全部工作都在 `rl_sar` 目录完成。
+- **机器人拓扑**：四轮足由两台 Tita 通过连接盒串接，整体共有 16 个电机、2 组 IMU，各自由一台 Jetson Orin NX 16G 控制。
+- **主控 Jetson**：运行 `rl_real_titati`，直接与 16 个电机通信并执行强化学习策略。
+- **从控 Jetson**：保持 CAN-FD 路由心跳，使连接盒持续处于直通模式。`rl_sar` 提供了 `rl_titati_router` 守护程序完成此任务。
+- **仓库结构**：
+  - `titati_control/`：旧 ROS2 控制栈、URDF、CAN 初始化脚本，仅作为参考或回退方案。
+  - `rl_sar/`：强化学习主仓库，本次迁移已经集成 Titati 的硬件驱动（`tita_robot_sdk`）、策略配置与真机程序。
 
-## 硬件与系统先决条件
+在 `rl_sar` 下调试/运行时，无需再启动 `titati_control` 的节点，但仍可复用其中的工具脚本（如 CAN 设置）。
 
-1. **Jetson Orin NX (16G)**：确保已经刷入 Ubuntu 20.04/22.04。若完全在 `rl_sar` 内运行并通过键盘/手柄控制，可跳过 ROS 的安装。
-2. **实时总线**：`tita_robot_sdk` 默认通过 `can0` 接口以 CAN FD 模式访问 16 个电机与 IMU，波特率 1 Mbps / 数据速率 8 Mbps。只需完成接口设置即可；可直接复用 `titati_control` 中的脚本初始化 CAN：
-   ```bash
-   sudo ip link set can0 down
-   sudo ip link set can0 up type can bitrate 1000000 sample-point 0.80 \
-       dbitrate 8000000 dsample-point 0.80 fd on restart-ms 100
-   sudo ifconfig can0 txqueuelen 1000
-   ```
-   或执行 `titati_control/src/can_setup_8m_master.sh` 一键设置（脚本仅负责网络参数，`rl_sar` 不再依赖其它 `titati_control` 组件）。
-   对于运行 `rl_real_titati` 的主控 Jetson，`tita_robot_sdk` 内置的 CAN-FD 路由桥会在切换到 SDK 模式时自动监听路由心跳并下发
-   `READY_WAITING/ FORCE_DIRECT` 序列，保证主控端直接接管全部 16 个电机。
-   串联结构仍需要从机 Jetson 保持与路由器的握手，此时可使用新的守护程序 `rl_titati_router` 取代原来的 ROS 节点：
+---
 
-   ```bash
-   cd rl_sar
-   ./cmake_build/bin/rl_titati_router --interface can0
-   ```
+## 2. 先决条件
 
-   该工具会自动在检测到主从模式变化或路由复位时重发握手指令，确保主从机之间的 CAN 通道持续打通。
-3. **第三方依赖**：
-   - [libtorch 2.0.1 cxx11 ABI](https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.0.1%2Bcpu.zip)，并通过 `export Torch_DIR=<PATH>/libtorch` 指向其根目录。
-   - `yaml-cpp` 与 `lcm`：`sudo apt install libyaml-cpp-dev liblcm-dev`。
-   - 可选：若需要 ROS 键盘/遥控输入，请安装 `teleop-twist-keyboard`、`ros_control` 等依赖，具体列表见 `rl_sar/README.md`。
+### 2.1 操作系统与工具链
 
-在启动 `rl_real_titati` 前务必确认 `can0` 已经 up，且旧的 `titati_controller` 节点不会同时抢占电机。
+| 组件 | 要求 |
+| --- | --- |
+| 系统 | Ubuntu 20.04 或 22.04（Jetson 官方系统即可） |
+| 编译工具 | CMake ≥ 3.18、gcc ≥ 9（Jetson 默认满足） |
+| Python | 3.8–3.10，用于 TorchScript 运行时 |
 
-## 构建 rl_sar（含 Titati 支持）
+### 2.2 第三方依赖
 
-> 建议在机器人本机或开发主机上完成以下步骤，默认从仓库根目录执行。
+在**两台 Jetson**上均需要准备：
 
-1. **配置 Torch 路径**（仅首次）
+1. **libtorch**：建议使用 `libtorch 2.0.1 cxx11 ABI`，下载后设置环境变量：
    ```bash
    echo 'export Torch_DIR=/opt/libtorch' >> ~/.bashrc
    source ~/.bashrc
    ```
-2. **进入 rl_sar 并执行硬件构建**：
+2. **系统库**：
+   ```bash
+   sudo apt install libyaml-cpp-dev liblcm-dev
+   ```
+3. **可选 ROS 依赖**：若需要在 ROS2 中启动，可再安装 `ros-<distro>-teleop-twist-keyboard` 等工具。
+
+### 2.3 CAN-FD 总线配置
+
+`tita_robot_sdk` 默认使用 `can0`，速率 1 Mbps / 8 Mbps。可执行旧项目里的脚本完成设置：
+
+```bash
+sudo bash titati_control/src/can_setup_8m_master.sh
+```
+
+或手动运行：
+
+```bash
+sudo ip link set can0 down
+sudo ip link set can0 up type can bitrate 1000000 sample-point 0.80 \
+    dbitrate 8000000 dsample-point 0.80 fd on restart-ms 100
+sudo ifconfig can0 txqueuelen 1000
+```
+
+确保命令在**主控与从控**两侧都执行一次，使两条 CAN 链路都处于 CAN-FD 直通状态。
+
+---
+
+## 3. 构建 `rl_sar`
+
+以下步骤默认在仓库根目录执行。
+
+1. **进入子仓库**：
    ```bash
    cd rl_sar
+   ```
+2. **硬件部署构建（推荐）**：
+   ```bash
    ./build.sh --cmake rl_sar
    ```
-   该命令会以纯 CMake 方式生成 `cmake_build/`，包含 `tita_robot_sdk` 与 `rl_real_titati` 可执行文件。
-3. **ROS 工作区构建（可选）**：若需要通过 `ros2 run rl_sar rl_real_titati` 启动，可执行 `./build.sh --ros rl_sar`，脚本会自动创建符号链接并调用 `colcon`/`catkin` 构建。
+   生成的 `cmake_build/` 将包含 `rl_real_titati`、`rl_titati_router`、`rl_titati_motor_test` 等可执行文件。
+3. **ROS 工作区（可选）**：如需 `ros2 run rl_sar rl_real_titati`，执行：
+   ```bash
+   ./build.sh --ros rl_sar
+   ```
+   脚本会自动调用 `colcon`/`catkin` 进行额外构建。
 
-构建成功后，`cmake_build/bin/rl_real_titati` 即可直接运行，无需 ROS 环境。
+> 提示：首次构建可能因 Torch 没有找到而失败，请确认 `Torch_DIR` 已正确导出。
 
-## 策略、模型与参数配置
+---
 
-Titati 的策略配置集中在 `rl_sar/src/rl_sar/policy/titati/`：
+## 4. 策略与配置文件
 
-- `base.yaml`：对齐物理硬件的默认关节姿态、力矩上限、轮子索引以及 `joint_mapping`。如硬件布线顺序发生变化，请同步修改 `joint_mapping`，否则状态和命令会错位。
-- `base.yaml` 同时包含 `can_interface` 与 `use_canfd_router` 两个开关：前者指定使用的 Linux CAN 口，后者控制是否监听 CAN-FD 路由器心跳并自动打通主从机通讯（默认对串联的四轮足开启）。
-- `robot_lab/config.yaml`：描述策略输入输出维度、观测项以及增益。可将训练得到的 TorchScript 模型命名为 `policy.pt`（或在 `model_name` 字段中填写自定义文件名），并放置到 `rl_sar/src/rl_sar/policy/titati/robot_lab/` 目录下。
-- `fsm.hpp`：定义 Titati 的有限状态机，包括被动、起身、下蹲与 RL Locomotion 等状态，通常无须修改，但若需要自定义前置动作可在此扩展。
+相关配置位于 `rl_sar/src/rl_sar/policy/titati/`：
 
-当 `rl_real_titati` 启动后会读取上述 YAML 并自动加载模型、初始化观测缓冲与控制参数。
+- **`base.yaml`**：硬件相关参数，包括 `joint_mapping`、关节限幅、`can_interface` 以及 `use_canfd_router`。若布线顺序有变，务必同步 `joint_mapping`。
+- **`robot_lab/config.yaml`**：策略输入输出维度、观测项定义与默认模型名。训练好的 TorchScript 模型（如 `policy.pt`）需置于同目录。
+- **`fsm.hpp`**：Titati 的有限状态机定义，一般只在自定义起步/收脚动作时修改。
 
-## 运行 rl_real_titati
+`rl_real_titati` 启动时会读取以上配置，初始化观测缓存并加载策略模型。
 
-### 纯 CMake 可执行文件
+---
+
+## 5. 主从运行顺序
+
+为了保证 CAN-FD 路由始终保持直通，请严格遵循以下流程：
+
+1. **从控 Jetson**：
+   ```bash
+   cd rl_sar
+   ./cmake_build/bin/rl_titati_router --interface can0
+   ```
+   - 该守护程序会持续监听路由心跳，一旦检测到模式回落会立即重发 `READY_WAITING/ FORCE_DIRECT` 序列。
+   - 程序输出会记录当前路由模式及是否成功切换到 FORCE_DIRECT，方便排查链路状态。
+
+2. **主控 Jetson**（确保从控已在运行）：
+   ```bash
+   cd rl_sar
+   ./cmake_build/bin/rl_real_titati
+   ```
+   - 启动阶段会自动发送零力矩并将 MCU 切换到 SDK 直驱模式。
+   - 一旦退出（`Ctrl+C`），程序会重新下发 `AUTO_LOCOMOTION`，确保 MCU 重新接管。
+
+3. **再次启动**：直接重复第 2 步即可，程序会检测到路由仍在直通并重发握手以确认主控拥有全部 16 个电机的控制权。
+
+> 若需要回退到 `titati_control`：先退出 `rl_real_titati`，待终端打印“MCU control restored”后，再启动原 ROS2 launch。
+
+---
+
+## 6. 操作接口
+
+- **键盘**：`W/S` 控制前后速度，`A/D` 控制横移，`Q/E` 控制偏航；`Space` 清零命令。
+- **模式切换**：`M` 进入 SDK 直驱、`K` 回落 MCU；`N` 切换键盘/ROS 输入源。
+- **遥控手柄**：`LB+RB` 急停，`LB+A/B/X` 功能等同于键盘热键。
+
+`rl_real_titati` 会循环读取关节位置/速度/力矩与 IMU 数据，经过 FSM 与策略后通过 MIT 控制下发到电机。
+
+---
+
+## 7. 电机连通性与安全测试
+
+在加载强化学习策略前，建议先通过下列测试确认 16 个电机均能响应：
 
 ```bash
 cd rl_sar
-./cmake_build/bin/rl_real_titati
+
+# MIT：对每个关节施加小幅度位置扰动，验证编码器读取与 MIT 参数映射
+./cmake_build/bin/rl_titati_motor_test --mode mit --amplitude 0.05 --hold 0.5
+
+# 力矩：对每个关节输出短脉冲，检查是否存在饱和或正反向接线问题
+./cmake_build/bin/rl_titati_motor_test --mode torque --amplitude 2.0 --hold 0.3
 ```
 
-程序启动后会自动尝试将电机切换至 SDK 直驱模式；退出（或 `Ctrl+C`）时会回落到 MCU 控制，以避免无人值守状态下电机保持使能。
-再次启动 `rl_real_titati` 时会自动重发 `READY_WAITING/ FORCE_DIRECT` 握手，并在握手成功后发送当前位置保持指令，确保每次运行都能顺利接管 16 个电机。
+程序会按 `joint_mapping` 顺序依次测试每个电机，并打印实时的位置、速度、力矩与电机状态。当检测不到 CAN-FD 路由时会提示警告；退出或测试完成后自动切回 MCU 控制。
 
-### ROS2 启动（可选）
+---
 
-```bash
-source install/setup.bash   # 或 source devel/setup.bash (ROS1)
-ros2 run rl_sar rl_real_titati
-```
+## 8. 常见问题
 
-在定义了 `USE_ROS` 的编译配置下，节点会订阅 `/cmd_vel` 并根据导航模式决定使用 ROS 命令或键盘命令。
+| 现象 | 排查步骤 |
+| --- | --- |
+| `Torch package not found` | 检查 `Torch_DIR` 是否指向 libtorch 根目录，或确认 `./build.sh --cmake rl_sar` 的日志中已找到 Torch。 |
+| `Interface does not support CAN FD` | 核对内核与驱动是否支持 CAN-FD，重新执行 CAN 配置脚本，确认 `ip -details link show can0` 中 `fd` 字段为 `on`。 |
+| 主控无法接管全部电机 | 确认从控上的 `rl_titati_router` 正在运行，查看其日志是否持续打印 `FORCE_DIRECT`; 同时检查 `rl_real_titati` 是否成功调用 `set_motors_sdk(true)`。 |
+| 需要回退到旧栈 | 在主控执行 `K` 或直接退出 `rl_real_titati`，待提示“MCU 接管”后，再启动 `titati_control` 的 launch。 |
 
-### 电机连通性测试（MIT / 力矩）
+---
 
-在接入真实机器人之前，可以先使用新的 `rl_titati_motor_test` 工具确认 16 个电机都能正常读取反馈并响应指令：
+完成以上步骤后，便可在主控 Jetson 上运行 `rl_real_titati`，加载强化学习策略并控制四轮足机器人，实现从 `titati_control` 到 `rl_sar` 的平滑迁移。
 
-```bash
-cd rl_sar
-# MIT 模式：依次对每个关节施加 0.05rad 的小幅度 MIT 位移
-./cmake_build/bin/rl_titati_motor_test --mode mit --amplitude 0.05
-
-# 力矩模式：依次对每个关节输出 2Nm 力矩脉冲
-./cmake_build/bin/rl_titati_motor_test --mode torque --amplitude 2.0
-```
-
-该程序会按照 `policy/titati/base.yaml` 中的关节映射顺序逐个测试电机，持续打印当前位置、速度与力矩反馈，便于快速定位通讯或布线问题。测试结束或按下 `Ctrl+C` 后，程序会自动发送零力矩并切回 MCU 控制，避免电机长时间保持在 SDK 模式。
-
-### 键盘 / 手柄指令速查
-
-- `W/S`：前后速度增减；`A/D`：侧向速度增减；`Q/E`：航向角速度增减；`Space`：清空所有速度命令。
-- `M`：强制切换到 SDK 直驱，使能电机；`K`：切回 MCU 控制，关闭电机；`N`：切换导航模式（键盘 VS `/cmd_vel`）。
-- 当接入 Retroid 手柄时，`LB+RB` 会触发 `set_robot_stop()` 急停，`LB+A/B/X` 与键盘热键一致。
-
-策略推理线程会将 IMU、关节位置/速度/力矩写入 `RobotState`，经过状态机输出 MIT 力矩命令，并通过 `tita_robot_sdk` 下发到各电机。
-
-## 与 titati_control 共存的注意事项
-
-> 若已完全迁移到 `rl_sar` 并不再运行旧栈，可忽略本节。
-
-- 两套系统都会占用 `can0` 与电机 SDK 通道，请确保同一时间只启动其中一个，否则会互相抢占导致力矩指令异常。
-- 如需回退到原控制器，可先退出 `rl_real_titati`，执行 `titati_control/src/can_setup_8m_master.sh` 重新拉起原 ROS2 launch。
-- 通过 `tita_robot::set_motors_sdk(false)` 可以在不退出程序的情况下让 MCU 接管，以便切换到 `titati_control` 的节点。
-
-## 调试与排错建议
-
-- 若 `rl_real_titati` 启动报错 `TORCH` 未找到，请检查 `Torch_DIR` 环境变量是否指向正确目录。
-- 若 CAN 报错 `Interface does not support CAN FD`，请确认网卡驱动支持 CAN FD，并按脚本重新设置。
-- 可通过定义 `PLOT` 或 `CSV_LOGGER`（`rl_real_titati.hpp` 顶部）开启实时曲线或数据记录，便于排查策略输出与硬件反馈的差异。
-- 若怀疑主从机握手异常，可观察主控上的 `rl_real_titati` 与从控上的 `rl_titati_router` 日志：程序会在检测到路由模式变化或重发
-  `FORCE_DIRECT` 时打印提示，便于确认 CAN-FD 路由是否保持连通。
-
-按照以上流程完成准备后，即可使用 `rl_sar` 中的强化学习策略对 Titati 四轮足进行实时控制，实现从 `titati_control` 向 RL 框架的平滑迁移。

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ sudo ifconfig can0 txqueuelen 1000
    ./build.sh --cmake rl_sar
    ```
    生成的 `cmake_build/` 将包含 `rl_real_titati`、`rl_titati_router`、`rl_titati_motor_test` 等可执行文件。
+   - CMake 会在未发现 Unitree/Lite3 依赖时自动启用 `BUILD_TITATI_ONLY=ON`，仅编译 Titati 所需目标。
+   - 若未来需要同时构建其它机器人的可执行文件，可手动传入 `-DBUILD_TITATI_ONLY=OFF` 并确保相关 SDK 就绪。
 3. **ROS 工作区（可选）**：如需 `ros2 run rl_sar rl_real_titati`，执行：
    ```bash
    ./build.sh --ros rl_sar

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ sudo ifconfig can0 txqueuelen 1000
    生成的 `cmake_build/` 将包含 `rl_real_titati`、`rl_titati_router`、`rl_titati_motor_test` 等可执行文件。
    - CMake 会在未发现 Unitree/Lite3 依赖时自动启用 `BUILD_TITATI_ONLY=ON`，仅编译 Titati 所需目标。
    - 若未来需要同时构建其它机器人的可执行文件，可手动传入 `-DBUILD_TITATI_ONLY=OFF` 并确保相关 SDK 就绪。
+   - 可执行文件会在运行时自动解析 `rl_sar/src/rl_sar/policy`，无需切换工作目录；如需自定义配置路径，可使用 `--config` 或设置 `RL_SAR_CONFIG_DIR`。
 3. **ROS 工作区（可选）**：如需 `ros2 run rl_sar rl_real_titati`，执行：
    ```bash
    ./build.sh --ros rl_sar
@@ -111,7 +112,7 @@ sudo ifconfig can0 txqueuelen 1000
    ./cmake_build/bin/rl_titati_router --interface can0
    ```
    - 该守护程序会持续监听路由心跳，一旦检测到模式回落会立即重发 `READY_WAITING/ FORCE_DIRECT` 序列。
-   - 程序输出会记录当前路由模式及是否成功切换到 FORCE_DIRECT，方便排查链路状态。
+   - 程序输出会记录当前路由模式及是否成功切换到 FORCE_DIRECT，稍后主控上线时应看到 `Router entered FORCE_DIRECT mode.` 的提示；若迟迟未出现，请核对 CAN 线束与速率设置。
 
 2. **主控 Jetson**（确保从控已在运行）：
    ```bash
@@ -151,7 +152,7 @@ cd rl_sar
 ./cmake_build/bin/rl_titati_motor_test --mode torque --amplitude 2.0 --hold 0.3
 ```
 
-程序会按 `joint_mapping` 顺序依次测试每个电机，并打印实时的位置、速度、力矩与电机状态。当检测不到 CAN-FD 路由时会提示警告；退出或测试完成后自动切回 MCU 控制。
+程序会按 `joint_mapping` 顺序依次测试每个电机，并打印实时的位置、速度、力矩与电机状态。当检测不到 CAN-FD 路由时会提示警告；退出或测试完成后自动切回 MCU 控制。默认配置会自动从源码目录读取 `policy/titati/base.yaml`，无需修改当前工作目录；如需调试其它参数，可显式传入 `--config` 或设置 `RL_SAR_CONFIG_DIR=/path/to/policy`。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ cd rl_sar
 ```
 
 程序启动后会自动尝试将电机切换至 SDK 直驱模式；退出（或 `Ctrl+C`）时会回落到 MCU 控制，以避免无人值守状态下电机保持使能。
+再次启动 `rl_real_titati` 时会自动重发 `READY_WAITING/ FORCE_DIRECT` 握手，并在握手成功后发送当前位置保持指令，确保每次运行都能顺利接管 16 个电机。
 
 ### ROS2 启动（可选）
 
@@ -86,6 +87,21 @@ ros2 run rl_sar rl_real_titati
 ```
 
 在定义了 `USE_ROS` 的编译配置下，节点会订阅 `/cmd_vel` 并根据导航模式决定使用 ROS 命令或键盘命令。
+
+### 电机连通性测试（MIT / 力矩）
+
+在接入真实机器人之前，可以先使用新的 `rl_titati_motor_test` 工具确认 16 个电机都能正常读取反馈并响应指令：
+
+```bash
+cd rl_sar
+# MIT 模式：依次对每个关节施加 0.05rad 的小幅度 MIT 位移
+./cmake_build/bin/rl_titati_motor_test --mode mit --amplitude 0.05
+
+# 力矩模式：依次对每个关节输出 2Nm 力矩脉冲
+./cmake_build/bin/rl_titati_motor_test --mode torque --amplitude 2.0
+```
+
+该程序会按照 `policy/titati/base.yaml` 中的关节映射顺序逐个测试电机，持续打印当前位置、速度与力矩反馈，便于快速定位通讯或布线问题。测试结束或按下 `Ctrl+C` 后，程序会自动发送零力矩并切回 MCU 控制，避免电机长时间保持在 SDK 模式。
 
 ### 键盘 / 手柄指令速查
 

--- a/README.md
+++ b/README.md
@@ -11,15 +11,16 @@
 
 ## 硬件与系统先决条件
 
-1. **Jetson Orin NX (16G)**：确保已经刷入 Ubuntu 20.04/22.04，并根据需要安装 ROS Noetic 或 ROS2 Foxy/Humble。
-2. **实时总线**：`tita_robot_sdk` 默认通过 `can0` 接口以 CAN FD 模式访问 16 个电机与 IMU，波特率 1 Mbps / 数据速率 8 Mbps。可以直接复用 `titati_control` 中的脚本初始化 CAN：
+1. **Jetson Orin NX (16G)**：确保已经刷入 Ubuntu 20.04/22.04。若完全在 `rl_sar` 内运行并通过键盘/手柄控制，可跳过 ROS 的安装。
+2. **实时总线**：`tita_robot_sdk` 默认通过 `can0` 接口以 CAN FD 模式访问 16 个电机与 IMU，波特率 1 Mbps / 数据速率 8 Mbps。只需完成接口设置即可；可直接复用 `titati_control` 中的脚本初始化 CAN：
    ```bash
    sudo ip link set can0 down
    sudo ip link set can0 up type can bitrate 1000000 sample-point 0.80 \
        dbitrate 8000000 dsample-point 0.80 fd on restart-ms 100
    sudo ifconfig can0 txqueuelen 1000
    ```
-   或执行 `titati_control/src/can_setup_8m_master.sh` 以一键设置并停止旧的 bringup 服务。
+   或执行 `titati_control/src/can_setup_8m_master.sh` 一键设置（脚本仅负责网络参数，`rl_sar` 不再依赖其它 `titati_control` 组件）。
+   `tita_robot_sdk` 内置的 CAN-FD 路由桥会在切换到 SDK 模式时自动向主从机下发 `FORCE_DIRECT`，无需再启动 ROS 节点维持主从通信。
 3. **第三方依赖**：
    - [libtorch 2.0.1 cxx11 ABI](https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.0.1%2Bcpu.zip)，并通过 `export Torch_DIR=<PATH>/libtorch` 指向其根目录。
    - `yaml-cpp` 与 `lcm`：`sudo apt install libyaml-cpp-dev liblcm-dev`。
@@ -51,6 +52,7 @@
 Titati 的策略配置集中在 `rl_sar/src/rl_sar/policy/titati/`：
 
 - `base.yaml`：对齐物理硬件的默认关节姿态、力矩上限、轮子索引以及 `joint_mapping`。如硬件布线顺序发生变化，请同步修改 `joint_mapping`，否则状态和命令会错位。
+- `base.yaml` 同时包含 `can_interface` 与 `use_canfd_router` 两个开关：前者指定使用的 Linux CAN 口，后者控制是否监听 CAN-FD 路由器心跳并自动打通主从机通讯（默认对串联的四轮足开启）。
 - `robot_lab/config.yaml`：描述策略输入输出维度、观测项以及增益。可将训练得到的 TorchScript 模型命名为 `policy.pt`（或在 `model_name` 字段中填写自定义文件名），并放置到 `rl_sar/src/rl_sar/policy/titati/robot_lab/` 目录下。
 - `fsm.hpp`：定义 Titati 的有限状态机，包括被动、起身、下蹲与 RL Locomotion 等状态，通常无须修改，但若需要自定义前置动作可在此扩展。
 
@@ -85,6 +87,8 @@ ros2 run rl_sar rl_real_titati
 策略推理线程会将 IMU、关节位置/速度/力矩写入 `RobotState`，经过状态机输出 MIT 力矩命令，并通过 `tita_robot_sdk` 下发到各电机。
 
 ## 与 titati_control 共存的注意事项
+
+> 若已完全迁移到 `rl_sar` 并不再运行旧栈，可忽略本节。
 
 - 两套系统都会占用 `can0` 与电机 SDK 通道，请确保同一时间只启动其中一个，否则会互相抢占导致力矩指令异常。
 - 如需回退到原控制器，可先退出 `rl_real_titati`，执行 `titati_control/src/can_setup_8m_master.sh` 重新拉起原 ROS2 launch。

--- a/README.md
+++ b/README.md
@@ -20,7 +20,16 @@
    sudo ifconfig can0 txqueuelen 1000
    ```
    或执行 `titati_control/src/can_setup_8m_master.sh` 一键设置（脚本仅负责网络参数，`rl_sar` 不再依赖其它 `titati_control` 组件）。
-   `tita_robot_sdk` 内置的 CAN-FD 路由桥会在切换到 SDK 模式时自动向主从机下发 `FORCE_DIRECT`，无需再启动 ROS 节点维持主从通信。
+   对于运行 `rl_real_titati` 的主控 Jetson，`tita_robot_sdk` 内置的 CAN-FD 路由桥会在切换到 SDK 模式时自动监听路由心跳并下发
+   `READY_WAITING/ FORCE_DIRECT` 序列，保证主控端直接接管全部 16 个电机。
+   串联结构仍需要从机 Jetson 保持与路由器的握手，此时可使用新的守护程序 `rl_titati_router` 取代原来的 ROS 节点：
+
+   ```bash
+   cd rl_sar
+   ./cmake_build/bin/rl_titati_router --interface can0
+   ```
+
+   该工具会自动在检测到主从模式变化或路由复位时重发握手指令，确保主从机之间的 CAN 通道持续打通。
 3. **第三方依赖**：
    - [libtorch 2.0.1 cxx11 ABI](https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.0.1%2Bcpu.zip)，并通过 `export Torch_DIR=<PATH>/libtorch` 指向其根目录。
    - `yaml-cpp` 与 `lcm`：`sudo apt install libyaml-cpp-dev liblcm-dev`。
@@ -99,5 +108,7 @@ ros2 run rl_sar rl_real_titati
 - 若 `rl_real_titati` 启动报错 `TORCH` 未找到，请检查 `Torch_DIR` 环境变量是否指向正确目录。
 - 若 CAN 报错 `Interface does not support CAN FD`，请确认网卡驱动支持 CAN FD，并按脚本重新设置。
 - 可通过定义 `PLOT` 或 `CSV_LOGGER`（`rl_real_titati.hpp` 顶部）开启实时曲线或数据记录，便于排查策略输出与硬件反馈的差异。
+- 若怀疑主从机握手异常，可观察主控上的 `rl_real_titati` 与从控上的 `rl_titati_router` 日志：程序会在检测到路由模式变化或重发
+  `FORCE_DIRECT` 时打印提示，便于确认 CAN-FD 路由是否保持连通。
 
 按照以上流程完成准备后，即可使用 `rl_sar` 中的强化学习策略对 Titati 四轮足进行实时控制，实现从 `titati_control` 向 RL 框架的平滑迁移。

--- a/rl_sar/src/rl_sar/CMakeLists.txt
+++ b/rl_sar/src/rl_sar/CMakeLists.txt
@@ -356,6 +356,16 @@ if(NOT USE_CMAKE)
     endif()
 endif()
 
+add_executable(rl_titati_router src/rl_titati_router.cpp)
+target_link_libraries(rl_titati_router
+    tita_robot_sdk
+)
+if(NOT USE_CMAKE)
+    if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+        install(TARGETS rl_titati_router DESTINATION lib/${PROJECT_NAME})
+    endif()
+endif()
+
 if(NOT USE_CMAKE)
     if($ENV{ROS_DISTRO} MATCHES "noetic")
         catkin_install_python(PROGRAMS

--- a/rl_sar/src/rl_sar/CMakeLists.txt
+++ b/rl_sar/src/rl_sar/CMakeLists.txt
@@ -134,6 +134,21 @@ if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
     )
 endif()
 
+# titati robot interface
+add_library(tita_robot_sdk
+    library/robot_interfaces/tita_robot/src/tita_robot.cpp
+    library/robot_interfaces/tita_robot/src/can_receiver.cpp
+    library/robot_interfaces/tita_robot/src/can_sender.cpp
+)
+target_include_directories(tita_robot_sdk PUBLIC
+    library/robot_interfaces/tita_robot/include
+)
+set_target_properties(tita_robot_sdk PROPERTIES
+    CXX_STANDARD 14
+    CXX_STANDARD_REQUIRED ON
+)
+target_link_libraries(tita_robot_sdk PUBLIC Threads::Threads)
+
 # Retroid Gamepad
 set(GAMEPAD_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/gamepad/src/gamepad.cpp
@@ -318,6 +333,25 @@ if(NOT USE_CMAKE)
             geometry_msgs
         )
         install(TARGETS rl_real_l4w4 DESTINATION lib/${PROJECT_NAME})
+    endif()
+endif()
+
+add_executable(rl_real_titati src/rl_real_titati.cpp)
+target_link_libraries(rl_real_titati
+    tita_robot_sdk
+    rl_sdk
+    observation_buffer
+    yaml-cpp
+)
+if(NOT USE_CMAKE)
+    if($ENV{ROS_DISTRO} MATCHES "noetic")
+        target_link_libraries(rl_real_titati ${catkin_LIBRARIES})
+    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+        ament_target_dependencies(rl_real_titati
+            rclcpp
+            geometry_msgs
+        )
+        install(TARGETS rl_real_titati DESTINATION lib/${PROJECT_NAME})
     endif()
 endif()
 

--- a/rl_sar/src/rl_sar/CMakeLists.txt
+++ b/rl_sar/src/rl_sar/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.5)
 project(rl_sar VERSION 3.0.0 LANGUAGES CXX)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 set(USE_CMAKE OFF CACHE BOOL "Use Cmake build system")
 message(STATUS "USE_CMAKE: ${USE_CMAKE}")
 if(USE_CMAKE)
@@ -145,7 +149,7 @@ target_include_directories(tita_robot_sdk PUBLIC
     library/robot_interfaces/tita_robot/include
 )
 set_target_properties(tita_robot_sdk PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED ON
 )
 target_link_libraries(tita_robot_sdk PUBLIC Threads::Threads)
@@ -175,7 +179,7 @@ include_directories(
 
 add_library(rl_sdk library/core/rl_sdk/rl_sdk.cpp)
 set_target_properties(rl_sdk PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED ON
 )
 target_link_libraries(rl_sdk PUBLIC
@@ -199,7 +203,7 @@ endif()
 add_library(observation_buffer library/core/observation_buffer/observation_buffer.cpp)
 target_link_libraries(observation_buffer PUBLIC "${TORCH_LIBRARIES}")
 set_target_properties(observation_buffer PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED ON
 )
 if(NOT USE_CMAKE)

--- a/rl_sar/src/rl_sar/CMakeLists.txt
+++ b/rl_sar/src/rl_sar/CMakeLists.txt
@@ -139,6 +139,7 @@ add_library(tita_robot_sdk
     library/robot_interfaces/tita_robot/src/tita_robot.cpp
     library/robot_interfaces/tita_robot/src/can_receiver.cpp
     library/robot_interfaces/tita_robot/src/can_sender.cpp
+    library/robot_interfaces/tita_robot/src/canfd_router_bridge.cpp
 )
 target_include_directories(tita_robot_sdk PUBLIC
     library/robot_interfaces/tita_robot/include

--- a/rl_sar/src/rl_sar/CMakeLists.txt
+++ b/rl_sar/src/rl_sar/CMakeLists.txt
@@ -366,6 +366,18 @@ if(NOT USE_CMAKE)
     endif()
 endif()
 
+add_executable(rl_titati_motor_test src/rl_titati_motor_test.cpp)
+target_link_libraries(rl_titati_motor_test
+    tita_robot_sdk
+    yaml-cpp
+    Threads::Threads
+)
+if(NOT USE_CMAKE)
+    if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+        install(TARGETS rl_titati_motor_test DESTINATION lib/${PROJECT_NAME})
+    endif()
+endif()
+
 if(NOT USE_CMAKE)
     if($ENV{ROS_DISTRO} MATCHES "noetic")
         catkin_install_python(PROGRAMS

--- a/rl_sar/src/rl_sar/CMakeLists.txt
+++ b/rl_sar/src/rl_sar/CMakeLists.txt
@@ -97,45 +97,99 @@ else()
     message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
 endif()
 
+set(UNITREE_SDK2_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/unitree_sdk2-2.0.0")
+set(UNITREE_SDK2_LOG_HEADER "${UNITREE_SDK2_ROOT}/include/unitree/common/log/log.hpp")
+set(_titati_only_default OFF)
+if(NOT EXISTS "${UNITREE_SDK2_LOG_HEADER}")
+    set(_titati_only_default ON)
+endif()
+option(BUILD_TITATI_ONLY "Skip non-Titati hardware targets when building rl_sar" ${_titati_only_default})
+if(BUILD_TITATI_ONLY)
+    message(STATUS "BUILD_TITATI_ONLY is ON: skipping non-Titati hardware targets")
+endif()
+
 # unitree_legged_sdk-3.2
-add_library(unitree_legged_sdk SHARED IMPORTED)
-set_target_properties(unitree_legged_sdk PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/unitree_legged_sdk-3.2/include"
-    IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/unitree_legged_sdk-3.2/lib/${UNITREE_LIB}.so"
-)
-set(UNITREE_A1_LIBS Threads::Threads unitree_legged_sdk lcm)
-if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-    file(GLOB GLOB_UNITREE_LEGGED_SDK "${CMAKE_CURRENT_SOURCE_DIR}/library/unitree_legged_sdk-3.2/lib/${UNITREE_LIB}.so")
-    install(FILES
-        ${GLOB_UNITREE_LEGGED_SDK}
-        DESTINATION lib/
-    )
+if(NOT BUILD_TITATI_ONLY)
+    set(UNITREE_LEGGED_INCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/unitree_legged_sdk-3.2/include")
+    set(UNITREE_LEGGED_LIBRARY "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/unitree_legged_sdk-3.2/lib/${UNITREE_LIB}.so")
+    if(EXISTS "${UNITREE_LEGGED_INCLUDE}/unitree_legged_sdk/unitree_legged_sdk.h" AND EXISTS "${UNITREE_LEGGED_LIBRARY}")
+        add_library(unitree_legged_sdk SHARED IMPORTED)
+        set_target_properties(unitree_legged_sdk PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${UNITREE_LEGGED_INCLUDE}"
+            IMPORTED_LOCATION "${UNITREE_LEGGED_LIBRARY}"
+        )
+        set(UNITREE_A1_LIBS Threads::Threads unitree_legged_sdk lcm)
+        if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            file(GLOB GLOB_UNITREE_LEGGED_SDK "${CMAKE_CURRENT_SOURCE_DIR}/library/unitree_legged_sdk-3.2/lib/${UNITREE_LIB}.so")
+            install(FILES
+                ${GLOB_UNITREE_LEGGED_SDK}
+                DESTINATION lib/
+            )
+        endif()
+        set(HAVE_UNITREE_LEGGED ON)
+    else()
+        message(WARNING "unitree_legged_sdk headers or library missing, skipping rl_real_a1")
+        set(HAVE_UNITREE_LEGGED OFF)
+    endif()
+else()
+    set(HAVE_UNITREE_LEGGED OFF)
 endif()
 
 # unitree_sdk2-2.0.0
-set(BUILD_EXAMPLES OFF CACHE BOOL "Disable examples build for unitree_sdk2" FORCE)
-add_subdirectory(library/thirdparty/unitree_sdk2-2.0.0)
+if(NOT BUILD_TITATI_ONLY AND EXISTS "${UNITREE_SDK2_LOG_HEADER}")
+    set(BUILD_EXAMPLES OFF CACHE BOOL "Disable examples build for unitree_sdk2" FORCE)
+    add_subdirectory(library/thirdparty/unitree_sdk2-2.0.0)
+    set(HAVE_UNITREE_SDK2 ON)
+elseif(NOT BUILD_TITATI_ONLY)
+    message(WARNING "unitree_sdk2 headers missing, skipping rl_real_go2 and rl_real_g1")
+    set(HAVE_UNITREE_SDK2 OFF)
+else()
+    set(HAVE_UNITREE_SDK2 OFF)
+endif()
 
 # l4w4_sdk
-add_library(l4w4_sdk INTERFACE)
-target_include_directories(l4w4_sdk INTERFACE
-    library/thirdparty/l4w4_sdk
-)
-target_link_libraries(l4w4_sdk INTERFACE Threads::Threads)
+if(NOT BUILD_TITATI_ONLY)
+    set(L4W4_SDK_INCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/l4w4_sdk")
+    if(EXISTS "${L4W4_SDK_INCLUDE}/l4w4_sdk.hpp")
+        add_library(l4w4_sdk INTERFACE)
+        target_include_directories(l4w4_sdk INTERFACE
+            library/thirdparty/l4w4_sdk
+        )
+        target_link_libraries(l4w4_sdk INTERFACE Threads::Threads)
+        set(HAVE_L4W4 ON)
+    else()
+        message(WARNING "l4w4 SDK headers missing, skipping rl_real_l4w4")
+        set(HAVE_L4W4 OFF)
+    endif()
+else()
+    set(HAVE_L4W4 OFF)
+endif()
 
 # Lite3_MotionSDK
-add_library(lite3_motionsdk SHARED IMPORTED)
-set_target_properties(lite3_motionsdk PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/include"
-    IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/lib/libdeeprobotics_legged_sdk_${ARCH_DIR}.so"
-)
-set(LITE3_REAL_LIBS Threads::Threads lite3_motionsdk)
-if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-    file(GLOB GLOB_LITE3_SDK_SO "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/lib/libdeeprobotics_legged_sdk_${ARCH_DIR}.so")
-    install(FILES
-        ${GLOB_LITE3_SDK_SO}
-        DESTINATION lib/
-    )
+if(NOT BUILD_TITATI_ONLY)
+    set(LITE3_SDK_INCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/include")
+    set(LITE3_SDK_LIBRARY "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/lib/libdeeprobotics_legged_sdk_${ARCH_DIR}.so")
+    if(EXISTS "${LITE3_SDK_INCLUDE}/Lite3SDK.h" AND EXISTS "${LITE3_SDK_LIBRARY}")
+        add_library(lite3_motionsdk SHARED IMPORTED)
+        set_target_properties(lite3_motionsdk PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${LITE3_SDK_INCLUDE}"
+            IMPORTED_LOCATION "${LITE3_SDK_LIBRARY}"
+        )
+        set(LITE3_REAL_LIBS Threads::Threads lite3_motionsdk)
+        if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            file(GLOB GLOB_LITE3_SDK_SO "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/lib/libdeeprobotics_legged_sdk_${ARCH_DIR}.so")
+            install(FILES
+                ${GLOB_LITE3_SDK_SO}
+                DESTINATION lib/
+            )
+        endif()
+        set(HAVE_LITE3 ON)
+    else()
+        message(WARNING "Lite3 MotionSDK missing, skipping rl_real_lite3")
+        set(HAVE_LITE3 OFF)
+    endif()
+else()
+    set(HAVE_LITE3 OFF)
 endif()
 
 # titati robot interface
@@ -240,104 +294,114 @@ if(NOT USE_CMAKE)
     endif()
 endif()
 
-add_executable(rl_real_a1 src/rl_real_a1.cpp)
-target_link_libraries(rl_real_a1
-    ${UNITREE_A1_LIBS}
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
-if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_a1 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_a1
-            rclcpp
-            geometry_msgs
-        )
-        install(TARGETS rl_real_a1 DESTINATION lib/${PROJECT_NAME})
+if(HAVE_UNITREE_LEGGED)
+    add_executable(rl_real_a1 src/rl_real_a1.cpp)
+    target_link_libraries(rl_real_a1
+        ${UNITREE_A1_LIBS}
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_a1 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_a1
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_a1 DESTINATION lib/${PROJECT_NAME})
+        endif()
     endif()
 endif()
 
-add_executable(rl_real_lite3
-    src/rl_real_lite3.cpp
-    ${GAMEPAD_SRC}
-)
-target_link_libraries(rl_real_lite3
-    ${LITE3_REAL_LIBS}
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
-target_include_directories(rl_real_lite3 PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/gamepad/include
-)
-if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_lite3 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_lite3
-            rclcpp
-            geometry_msgs
-        )
-        install(TARGETS rl_real_lite3 DESTINATION lib/${PROJECT_NAME})
+if(HAVE_LITE3)
+    add_executable(rl_real_lite3
+        src/rl_real_lite3.cpp
+        ${GAMEPAD_SRC}
+    )
+    target_link_libraries(rl_real_lite3
+        ${LITE3_REAL_LIBS}
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    target_include_directories(rl_real_lite3 PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/gamepad/include
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_lite3 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_lite3
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_lite3 DESTINATION lib/${PROJECT_NAME})
+        endif()
     endif()
 endif()
 
-add_executable(rl_real_go2 src/rl_real_go2.cpp)
-target_link_libraries(rl_real_go2
-    unitree_sdk2
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
-if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_go2 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_go2
-            rclcpp
-            geometry_msgs
-        )
-        install(TARGETS rl_real_go2 DESTINATION lib/${PROJECT_NAME})
+if(HAVE_UNITREE_SDK2)
+    add_executable(rl_real_go2 src/rl_real_go2.cpp)
+    target_link_libraries(rl_real_go2
+        unitree_sdk2
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_go2 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_go2
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_go2 DESTINATION lib/${PROJECT_NAME})
+        endif()
     endif()
 endif()
 
-add_executable(rl_real_g1 src/rl_real_g1.cpp)
-target_link_libraries(rl_real_g1
-    unitree_sdk2
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
-if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_g1 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_g1
-            rclcpp
-            geometry_msgs
-        )
-        install(TARGETS rl_real_g1 DESTINATION lib/${PROJECT_NAME})
+if(HAVE_UNITREE_SDK2)
+    add_executable(rl_real_g1 src/rl_real_g1.cpp)
+    target_link_libraries(rl_real_g1
+        unitree_sdk2
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_g1 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_g1
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_g1 DESTINATION lib/${PROJECT_NAME})
+        endif()
     endif()
 endif()
 
-add_executable(rl_real_l4w4 src/rl_real_l4w4.cpp)
-target_link_libraries(rl_real_l4w4
-    l4w4_sdk
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
-if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_l4w4 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_l4w4
-            rclcpp
-            geometry_msgs
-        )
-        install(TARGETS rl_real_l4w4 DESTINATION lib/${PROJECT_NAME})
+if(HAVE_L4W4)
+    add_executable(rl_real_l4w4 src/rl_real_l4w4.cpp)
+    target_link_libraries(rl_real_l4w4
+        l4w4_sdk
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_l4w4 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_l4w4
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_l4w4 DESTINATION lib/${PROJECT_NAME})
+        endif()
     endif()
 endif()
 

--- a/rl_sar/src/rl_sar/include/rl_real_titati.hpp
+++ b/rl_sar/src/rl_sar/include/rl_real_titati.hpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2024-2025 Ziqi Fan
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef RL_REAL_TITATI_HPP
+#define RL_REAL_TITATI_HPP
+
+// #define PLOT
+// #define CSV_LOGGER
+// #define USE_ROS
+
+#include "rl_sdk.hpp"
+#include "observation_buffer.hpp"
+#include "loop.hpp"
+#include "fsm.hpp"
+#include <memory>
+
+#include "tita_robot/tita_robot.hpp"
+#include <csignal>
+#include "matplotlibcpp.h"
+namespace plt = matplotlibcpp;
+
+#if defined(USE_ROS1) && defined(USE_ROS)
+#include <ros/ros.h>
+#include <geometry_msgs/Twist.h>
+#elif defined(USE_ROS2) && defined(USE_ROS)
+#include <rclcpp/rclcpp.hpp>
+#include <geometry_msgs/msg/twist.hpp>
+#endif
+
+class RL_Real : public RL
+#if defined(USE_ROS2) && defined(USE_ROS)
+    , public rclcpp::Node
+#endif
+{
+public:
+    RL_Real();
+    ~RL_Real();
+
+private:
+    // rl functions
+    torch::Tensor Forward() override;
+    void GetState(RobotState<double> *state) override;
+    void SetCommand(const RobotCommand<double> *command) override;
+    void RunModel();
+    void RobotControl();
+
+    // loop
+    std::shared_ptr<LoopFunc> loop_keyboard;
+    std::shared_ptr<LoopFunc> loop_control;
+    std::shared_ptr<LoopFunc> loop_rl;
+    std::shared_ptr<LoopFunc> loop_plot;
+
+    // plot
+    const int plot_size = 100;
+    std::vector<int> plot_t;
+    std::vector<std::vector<double>> plot_real_joint_pos, plot_target_joint_pos;
+    void Plot();
+
+    // titati interface
+    std::unique_ptr<tita_robot> titati_hw;
+
+    // others
+    int motiontime = 0;
+
+#if defined(USE_ROS1) && defined(USE_ROS)
+    geometry_msgs::Twist cmd_vel;
+    ros::Subscriber cmd_vel_subscriber;
+    void CmdvelCallback(const geometry_msgs::Twist::ConstPtr &msg);
+#elif defined(USE_ROS2) && defined(USE_ROS)
+    geometry_msgs::msg::Twist cmd_vel;
+    rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_subscriber;
+    void CmdvelCallback(const geometry_msgs::msg::Twist::SharedPtr msg);
+#endif
+};
+
+#endif // RL_REAL_TITATI_HPP

--- a/rl_sar/src/rl_sar/include/rl_real_titati.hpp
+++ b/rl_sar/src/rl_sar/include/rl_real_titati.hpp
@@ -52,6 +52,10 @@ private:
     std::shared_ptr<LoopFunc> loop_rl;
     std::shared_ptr<LoopFunc> loop_plot;
 
+    bool EnableSdkControl();
+    std::vector<double> TensorToHardwareVector(const torch::Tensor &tensor) const;
+    void SendHoldPositionCommand();
+
     // plot
     const int plot_size = 100;
     std::vector<int> plot_t;
@@ -60,6 +64,8 @@ private:
 
     // titati interface
     std::unique_ptr<tita_robot> titati_hw;
+    std::vector<double> hardware_fixed_kp_;
+    std::vector<double> hardware_fixed_kd_;
 
     // others
     int motiontime = 0;

--- a/rl_sar/src/rl_sar/library/core/rl_sdk/rl_sdk.cpp
+++ b/rl_sar/src/rl_sar/library/core/rl_sdk/rl_sdk.cpp
@@ -394,6 +394,16 @@ void RL::ReadYamlBase(std::string robot_path)
     this->params.joint_names = ReadVectorFromYaml<std::string>(config["joint_names"]);
     this->params.joint_controller_names = ReadVectorFromYaml<std::string>(config["joint_controller_names"]);
     this->params.joint_mapping = ReadVectorFromYaml<int>(config["joint_mapping"]);
+    if (config["can_interface"]) {
+        this->params.can_interface = config["can_interface"].as<std::string>();
+    } else {
+        this->params.can_interface = "can0";
+    }
+    if (config["use_canfd_router"]) {
+        this->params.use_canfd_router = config["use_canfd_router"].as<bool>();
+    } else {
+        this->params.use_canfd_router = this->params.num_of_dofs > 8;
+    }
 }
 
 void RL::ReadYamlRL(std::string robot_path)

--- a/rl_sar/src/rl_sar/library/core/rl_sdk/rl_sdk.hpp
+++ b/rl_sar/src/rl_sar/library/core/rl_sdk/rl_sdk.hpp
@@ -153,6 +153,8 @@ struct ModelParams
     std::vector<std::string> joint_controller_names;
     std::vector<std::string> joint_names;
     std::vector<int> joint_mapping;
+    std::string can_interface = "can0";
+    bool use_canfd_router = false;
 };
 
 struct Observations

--- a/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/protocol/can_utils.hpp
+++ b/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/protocol/can_utils.hpp
@@ -1,0 +1,468 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__CAN_UTILS_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__CAN_UTILS_HPP_
+
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "linux/can.h"
+#include "linux/can/error.h"
+#include "linux/can/raw.h"
+#include "socket_can_receiver.hpp"
+#include "socket_can_sender.hpp"
+
+#define C_END "\033[m"
+// #define C_RED "\033[0;32;31m"
+#define C_RED "\033[0;31m"
+#define C_YELLOW "\033[1;33m"
+
+#ifdef GCC_OPTIMIZE_03
+#pragma GCC optimize("O3")
+#else
+#pragma GCC optimize("O0")
+#endif
+namespace can_device
+{
+namespace socket_can
+{
+using can_std_callback = std::function<void(std::shared_ptr<struct can_frame> recv_frame)>;
+using can_fd_callback = std::function<void(std::shared_ptr<struct canfd_frame> recv_frame)>;
+class CanRxDev
+{
+public:
+  explicit CanRxDev(
+    const std::string & interface, const std::string & name, can_std_callback recv_callback,
+    bool is_block, int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    init(interface, name, false, recv_callback, nullptr, is_block, nano_timeout);
+  }
+  explicit CanRxDev(
+    const std::string & interface, const std::string & name, can_fd_callback recv_callback,
+    bool is_block, int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    init(interface, name, true, nullptr, recv_callback, is_block, nano_timeout);
+  }
+
+  ~CanRxDev()
+  {
+    ready_ = false;
+    isthreadrunning_ = false;
+    if (main_T_ != nullptr) {
+      main_T_->join();
+    }
+    main_T_ = nullptr;
+    receiver_ = nullptr;
+  }
+
+  bool is_ready() { return ready_; }
+  bool is_timeout() { return is_timeout_; }
+  void set_filter(const struct can_filter filter[], size_t s)
+  {
+    if (receiver_ != nullptr) {
+      receiver_->set_filter(filter, s);
+    }
+  }
+
+  std::shared_ptr<canfd_frame> wait_for_can_data_block()
+  {
+    can_device::socket_can::CanId receive_id{};
+    std::string can_type;
+    if (canfd_) {
+      can_type = "FD";
+      rx_fd_frame_ = std::make_shared<struct canfd_frame>();
+    } else {
+      can_type = "STD";
+      rx_std_frame_ = std::make_shared<struct can_frame>();
+    }
+    if (receiver_ != nullptr) {
+      try {
+        bool result =
+          canfd_ ? receiver_->receive(rx_fd_frame_, std::chrono::nanoseconds(nano_timeout_))
+                 : receiver_->receive(rx_std_frame_, std::chrono::nanoseconds(nano_timeout_));
+        if (result) {
+          is_timeout_ = false;
+          return rx_fd_frame_;
+        } else {
+          return nullptr;
+        }
+      } catch (const std::exception & ex) {
+        if (ex.what()[0] == '$') {
+          is_timeout_ = true;
+          return nullptr;
+        }
+      }
+    } else {
+      isthreadrunning_ = false;
+      printf(
+        C_RED
+        "[CAN_RX %s][ERROR][%s] Error receiving CAN %s message: %s, "
+        "no receiver init\r\n" C_END,
+        can_type.c_str(), name_.c_str(), can_type.c_str(), interface_.c_str());
+    }
+    return nullptr;
+  }
+
+#ifdef COMMON_PROTOCOL_TEST
+  bool testing_setcandata(can_frame frame)
+  {
+    if (can_std_callback_ != nullptr) {
+      can_std_callback_(std::make_shared<struct can_frame>(frame));
+      return true;
+    }
+    return false;
+  }
+  bool testing_setcandata(canfd_frame frame)
+  {
+    if (can_fd_callback_ != nullptr) {
+      can_fd_callback_(std::make_shared<struct canfd_frame>(frame));
+      return true;
+    }
+    return false;
+  }
+#endif  // COMMON_PROTOCOL_TEST
+
+private:
+  bool ready_;
+  bool canfd_;
+  bool is_timeout_;
+  bool extended_frame_;
+  bool isthreadrunning_;
+  int64_t nano_timeout_;
+  std::string name_;
+  std::string interface_;
+  can_std_callback can_std_callback_;
+  can_fd_callback can_fd_callback_;
+  std::unique_ptr<std::thread> main_T_;
+  std::shared_ptr<struct can_frame> rx_std_frame_;
+  std::shared_ptr<struct canfd_frame> rx_fd_frame_;
+  std::unique_ptr<can_device::socket_can::SocketCanReceiver> receiver_;
+  uint8_t can_id_offset_ = 0;
+  void init(
+    const std::string & interface, const std::string & name, bool canfd_on,
+    can_std_callback std_callback, can_fd_callback fd_callback, bool is_block, int64_t nano_timeout)
+  {
+    name_ = name;
+    interface_ = interface;
+    canfd_ = canfd_on;
+    nano_timeout_ = nano_timeout;
+    is_timeout_ = false;
+    interface_ = interface;
+    can_std_callback_ = std_callback;
+    can_fd_callback_ = fd_callback;
+    try {
+      receiver_ = std::make_unique<can_device::socket_can::SocketCanReceiver>(interface_, canfd_);
+      if (!is_block) {
+        isthreadrunning_ = true;
+        ready_ = true;
+        main_T_ = std::make_unique<std::thread>(std::bind(&CanRxDev::main_recv_func, this));
+      }
+    } catch (const std::exception & ex) {
+      printf(
+        C_RED "[CAN_RX][ERROR][%s] %s receiver creat error! %s\r\n" C_END, name_.c_str(),
+        interface_.c_str(), ex.what());
+      return;
+    }
+  }
+
+  bool wait_for_can_data()
+  {
+    can_device::socket_can::CanId receive_id{};
+    std::string can_type;
+    if (canfd_) {
+      can_type = "FD";
+      rx_fd_frame_ = std::make_shared<struct canfd_frame>();
+    } else {
+      can_type = "STD";
+      rx_std_frame_ = std::make_shared<struct can_frame>();
+    }
+
+    if (receiver_ != nullptr) {
+      try {
+        bool result =
+          canfd_ ? receiver_->receive(rx_fd_frame_, std::chrono::nanoseconds(nano_timeout_))
+                 : receiver_->receive(rx_std_frame_, std::chrono::nanoseconds(nano_timeout_));
+        if (result) {
+          is_timeout_ = false;
+        }
+        return result;
+      } catch (const std::exception & ex) {
+        if (ex.what()[0] == '$') {
+          is_timeout_ = true;
+          return false;
+        }
+        printf(
+          C_RED "[CAN_RX %s][ERROR][%s] Error receiving CAN %s message: %s - %s\n" C_END,
+          can_type.c_str(), name_.c_str(), can_type.c_str(), interface_.c_str(), ex.what());
+      }
+    } else {
+      isthreadrunning_ = false;
+      printf(
+        C_RED
+        "[CAN_RX %s][ERROR][%s] Error receiving CAN %s message: %s, "
+        "no receiver init\r\n" C_END,
+        can_type.c_str(), name_.c_str(), can_type.c_str(), interface_.c_str());
+    }
+    return false;
+  }
+
+  void main_recv_func()
+  {
+#ifdef DEBUG_LOG
+    printf("[CAN_RX][INFO][%s] Start recv thread: %s\r\n", interface_.c_str(), name_.c_str());
+#endif  // DEBUG_LOG
+    while (isthreadrunning_ && ready_) {
+      if (wait_for_can_data()) {
+        if (!canfd_ && can_std_callback_ != nullptr) {
+          can_std_callback_(rx_std_frame_);
+        } else if (canfd_ && can_fd_callback_ != nullptr) {
+          can_fd_callback_(rx_fd_frame_);
+        }
+      }
+    }
+#ifdef DEBUG_LOG
+    printf("[CAN_RX][INFO][%s] Exit recv thread: %s\r\n", interface_.c_str(), name_.c_str());
+#endif  // DEBUG_LOG
+  }
+};
+
+class CanTxDev
+{
+public:
+  explicit CanTxDev(
+    const std::string & interface, const std::string & name, bool extended_frame, bool canfd_on,
+    int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    can_id_offset_ = can_id_offset;
+    ready_ = false;
+    name_ = name;
+    nano_timeout_ = nano_timeout;
+    is_timeout_ = false;
+    canfd_on_ = canfd_on;
+    interface_ = interface;
+    extended_frame_ = extended_frame;
+    try {
+      sender_ = std::make_unique<can_device::socket_can::SocketCanSender>(interface_, canfd_on_);
+    } catch (const std::exception & ex) {
+      printf(
+        C_RED "[CAN_TX][ERROR][%s] %s sender creat error! %s\r\n" C_END, name_.c_str(),
+        interface_.c_str(), ex.what());
+      return;
+    }
+    ready_ = true;
+  }
+
+  ~CanTxDev()
+  {
+    ready_ = false;
+    sender_ = nullptr;
+  }
+
+  bool send_can_message(struct can_frame & tx_frame)
+  {
+    return send_can_message(&tx_frame, nullptr);
+  }
+  bool send_can_message(struct canfd_frame & tx_frame)
+  {
+    return send_can_message(nullptr, &tx_frame);
+  }
+
+  bool is_ready() { return ready_; }
+  bool is_timeout() { return is_timeout_; }
+
+private:
+  bool ready_;
+  bool canfd_on_;
+  bool is_timeout_;
+  bool extended_frame_;
+  int64_t nano_timeout_;
+  std::string name_;
+  std::string interface_;
+  std::unique_ptr<can_device::socket_can::SocketCanSender> sender_;
+  uint8_t can_id_offset_;
+
+  bool send_can_message(struct can_frame * std_frame, struct canfd_frame * fd_frame)
+  {
+    bool self_fd = (fd_frame != nullptr);
+    std::string can_type = self_fd ? "FD" : "STD";
+    if (canfd_on_ != self_fd) {
+      printf(
+        C_RED
+        "[CAN_TX %s][ERROR][%s] Error sending CAN message: %s - "
+        "Not support can/canfd frame mixed\r\n" C_END,
+        can_type.c_str(), name_.c_str(), interface_.c_str());
+      return false;
+    }
+    canid_t * canid = self_fd ? &fd_frame->can_id : &std_frame->can_id;
+
+    bool result = true;
+    can_device::socket_can::CanId send_id =
+      extended_frame_
+        ? can_device::socket_can::CanId(
+            *canid, can_device::socket_can::FrameType::DATA, can_device::socket_can::ExtendedFrame)
+        : can_device::socket_can::CanId(
+            *canid, can_device::socket_can::FrameType::DATA, can_device::socket_can::StandardFrame);
+    if (sender_ != nullptr) {
+      try {
+        if (self_fd) {
+          sender_->send_fd(
+            fd_frame->data, (fd_frame->len == 0) ? 64 : fd_frame->len, send_id,
+            std::chrono::nanoseconds(nano_timeout_));
+          is_timeout_ = false;
+        } else {
+          sender_->send(
+            std_frame->data, (std_frame->can_dlc == 0) ? 8 : std_frame->can_dlc, send_id,
+            std::chrono::nanoseconds(nano_timeout_));
+          is_timeout_ = false;
+        }
+      } catch (const std::exception & ex) {
+        if (ex.what()[0] == '$') {
+          is_timeout_ = true;
+          return false;
+        }
+        result = false;
+        printf(
+          C_RED "[CAN_TX %s][ERROR][%s] Error sending CAN message: %s - %s\r\n" C_END,
+          can_type.c_str(), name_.c_str(), interface_.c_str(), ex.what());
+      }
+    } else {
+      result = false;
+      printf(
+        C_RED "[CAN_TX %s][ERROR][%s] Error sending CAN message: %s - No device\r\n" C_END,
+        can_type.c_str(), name_.c_str(), interface_.c_str());
+    }
+    return result;
+  }
+};
+
+class CanDev
+{
+public:
+  explicit CanDev(
+    const std::string & interface, const std::string & name, bool extended_frame,
+    can_std_callback recv_callback, bool is_block, int64_t nano_timeout = -1,
+    uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    name_ = name;
+    send_only_ = false;
+    tx_op_ = std::make_unique<CanTxDev>(
+      interface, name_, extended_frame, false, nano_timeout, can_id_offset_);
+    rx_op_ = std::make_unique<CanRxDev>(
+      interface, name_, recv_callback, is_block, nano_timeout, can_id_offset_);
+  }
+  explicit CanDev(
+    const std::string & interface, const std::string & name, bool extended_frame,
+    can_fd_callback recv_callback, bool is_block, int64_t nano_timeout = -1,
+    uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    name_ = name;
+    send_only_ = false;
+    tx_op_ = std::make_unique<CanTxDev>(
+      interface, name_, extended_frame, true, nano_timeout, can_id_offset_);
+    rx_op_ = std::make_unique<CanRxDev>(
+      interface, name_, recv_callback, is_block, nano_timeout, can_id_offset_);
+  }
+  explicit CanDev(
+    const std::string & interface, const std::string & name, bool extended_frame, bool canfd_on,
+    int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    name_ = name;
+    send_only_ = true;
+    tx_op_ = std::make_unique<CanTxDev>(
+      interface, name_, extended_frame, canfd_on, nano_timeout, can_id_offset_);
+  }
+
+  ~CanDev()
+  {
+    rx_op_ = nullptr;
+    tx_op_ = nullptr;
+  }
+
+  std::shared_ptr<canfd_frame> receive_can_message_block()
+  {
+    return rx_op_->wait_for_can_data_block();
+  }
+
+  bool send_can_message(struct can_frame & tx_frame)
+  {
+#ifdef COMMON_PROTOCOL_TEST
+    if (rx_op_ != nullptr) {
+      return rx_op_->testing_setcandata(tx_frame);
+    }
+    return false;
+#else
+    if (tx_op_ != nullptr) {
+      return tx_op_->send_can_message(tx_frame);
+    }
+    return false;
+#endif  // COMMON_PROTOCOL_TEST
+  }
+
+  bool send_can_message(struct canfd_frame & tx_frame)
+  {
+#ifdef COMMON_PROTOCOL_TEST
+    if (rx_op_ != nullptr) {
+      return rx_op_->testing_setcandata(tx_frame);
+    }
+    return false;
+#else
+    if (tx_op_ != nullptr) {
+      return tx_op_->send_can_message(tx_frame);
+    }
+    return false;
+#endif  // COMMON_PROTOCOL_TEST
+  }
+
+  void set_filter(const struct can_filter filter[], size_t s)
+  {
+    if (rx_op_ != nullptr) {
+      rx_op_->set_filter(filter, s);
+    }
+  }
+  bool is_send_only() { return send_only_; }
+  bool is_ready()
+  {
+    bool result = (tx_op_ == nullptr) ? false : tx_op_->is_ready();
+    if (send_only_) {
+      return result;
+    } else {
+      return result && ((rx_op_ == nullptr) ? false : rx_op_->is_ready());
+    }
+  }
+  bool is_rx_timeout() { return rx_op_->is_timeout(); }
+  bool is_tx_timeout() { return tx_op_->is_timeout(); }
+
+private:
+  bool send_only_;
+  std::string name_;
+  std::unique_ptr<CanRxDev> rx_op_;
+  std::unique_ptr<CanTxDev> tx_op_;
+  uint8_t can_id_offset_ = 0;
+};
+
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__CAN_UTILS_HPP_

--- a/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/protocol/socket_can_common.hpp
+++ b/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/protocol/socket_can_common.hpp
@@ -1,0 +1,122 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_COMMON_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_COMMON_HPP_
+
+#include <linux/can.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <sys/time.h>
+
+#include <chrono>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+
+#define GCC_OPTIMIZE_03
+
+#ifdef GCC_OPTIMIZE_03
+#pragma GCC optimize("O3")
+#else
+#pragma GCC optimize("O0")
+#endif
+
+namespace can_device
+{
+namespace socket_can
+{
+inline bool bind_can_socket(int & fd, const std::string & interface, const bool canfd_on = false)
+{
+  if (interface.length() >= static_cast<std::string::size_type>(IFNAMSIZ)) {
+    throw std::domain_error{"CAN interface name too long"};
+    return false;
+  }
+
+  fd = socket(PF_CAN, static_cast<int32_t>(SOCK_RAW), CAN_RAW);
+  if (0 > fd) {
+    throw std::runtime_error{"Failed to open CAN socket"};
+    return false;
+  }
+
+  // Make it non-blocking so we can use timeouts
+
+  struct ifreq ifr;
+  (void)strncpy(&ifr.ifr_name[0U], interface.c_str(), IFNAMSIZ - 1);
+  ifr.ifr_name[IFNAMSIZ - 1] = '\0';
+  ifr.ifr_ifindex = if_nametoindex(ifr.ifr_name);
+  if (!ifr.ifr_ifindex) {
+    perror("if_nametoindex");
+    return false;
+  }
+
+  struct sockaddr_can addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.can_family = AF_CAN;
+  addr.can_ifindex = ifr.ifr_ifindex;
+
+  if (canfd_on) {
+    if (ioctl(fd, SIOCGIFMTU, &ifr) < 0) {
+      throw std::runtime_error{"Failed to set CAN FD socket name via ioctl()"};
+      return false;
+    }
+    if (ifr.ifr_mtu != CANFD_MTU) {
+      throw std::runtime_error{"Interface does not support CAN FD"};
+      return false;
+    }
+    int _canfd_on = canfd_on ? 1 : 0;
+    auto ret = setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FD_FRAMES, &_canfd_on, sizeof(_canfd_on));
+    if (ret) {
+      throw std::runtime_error{"error whem enable canfd"};
+      return false;
+    }
+  }
+
+  /* disable default receive filter on this RAW socket */
+  /* This is obsolete as we do not read from the socket at all, but for */
+  /* this reason we can remove the receive list in the Kernel to save a */
+  /* little (really a very little!) CPU usage.                          */
+  setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FILTER, NULL, 0);
+
+  if (0 > bind(fd, (struct sockaddr *)&addr, sizeof(addr))) {
+    throw std::runtime_error{"Failed to bind CAN socket"};
+    return false;
+  }
+
+  return true;
+}
+
+inline struct timeval to_timeval(const std::chrono::nanoseconds timeout) noexcept
+{
+  const auto count = timeout.count();
+  constexpr auto BILLION = 1'000'000'000LL;
+  struct timeval c_timeout;
+  c_timeout.tv_sec = static_cast<decltype(c_timeout.tv_sec)>(count / BILLION);
+  c_timeout.tv_usec = static_cast<decltype(c_timeout.tv_usec)>((count % BILLION) * (0.001));
+
+  return c_timeout;
+}
+
+inline fd_set single_set(int32_t file_descriptor) noexcept
+{
+  fd_set descriptor_set;
+  FD_ZERO(&descriptor_set);
+  FD_SET(file_descriptor, &descriptor_set);
+
+  return descriptor_set;
+}
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_COMMON_HPP_

--- a/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/protocol/socket_can_id.hpp
+++ b/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/protocol/socket_can_id.hpp
@@ -1,0 +1,188 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_ID_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_ID_HPP_
+
+#include <linux/can.h>
+
+#include <stdexcept>
+#include <utility>
+
+#include "visibility_control.hpp"
+
+namespace can_device
+{
+namespace socket_can
+{
+using IdT = uint32_t;
+using LengthT = uint32_t;
+
+constexpr std::size_t MAX_DATA_LENGTH = 64U;
+
+static_assert(
+  MAX_DATA_LENGTH == sizeof(std::declval<struct canfd_frame>().data),
+  "Unexpected CAN frame data size");
+static_assert(std::is_same<IdT, canid_t>::value, "Underlying type of CanId is incorrect");
+constexpr IdT EXTENDED_MASK = CAN_EFF_FLAG;
+constexpr IdT REMOTE_MASK = CAN_RTR_FLAG;
+constexpr IdT ERROR_MASK = CAN_ERR_FLAG;
+constexpr IdT EXTENDED_ID_MASK = CAN_EFF_MASK;
+constexpr IdT STANDARD_ID_MASK = CAN_SFF_MASK;
+
+class SOCKETCAN_PUBLIC SocketCanTimeout : public std::runtime_error
+{
+public:
+  explicit SocketCanTimeout(const char * const what) : runtime_error{what} {};
+};  // class SocketCanTimeout
+
+enum class FrameType : uint32_t { DATA, ERROR, REMOTE };
+
+struct StandardFrame_
+{
+};
+
+constexpr StandardFrame_ StandardFrame;
+
+struct ExtendedFrame_
+{
+};
+
+constexpr ExtendedFrame_ ExtendedFrame;
+
+class SOCKETCAN_PUBLIC CanId
+{
+public:
+  CanId() = default;
+  explicit CanId(const IdT raw_id, const LengthT data_length = 0U)
+  : m_id{raw_id}, m_data_length{data_length}
+  {
+    (void)frame_type();
+  }
+
+  CanId(const IdT id, FrameType type, StandardFrame_) : CanId{id, type, false} {}
+  CanId(const IdT id, FrameType type, ExtendedFrame_) : CanId{id, type, true} {}
+
+  CanId & standard() noexcept
+  {
+    m_id = m_id & (~EXTENDED_MASK);
+    return *this;
+  }
+
+  CanId & extended() noexcept
+  {
+    m_id = m_id | EXTENDED_MASK;
+    return *this;
+  }
+
+  CanId & error_frame() noexcept
+  {
+    m_id = m_id & (~REMOTE_MASK);
+    m_id = m_id | ERROR_MASK;
+    return *this;
+  }
+
+  CanId & remote_frame() noexcept
+  {
+    m_id = m_id & (~ERROR_MASK);
+    m_id = m_id | REMOTE_MASK;
+    return *this;
+  }
+
+  CanId & data_frame() noexcept
+  {
+    m_id = m_id & (~ERROR_MASK);
+    m_id = m_id & (~REMOTE_MASK);
+    return *this;
+  }
+
+  CanId & frame_type(const FrameType type)
+  {
+    switch (type) {
+      case FrameType::DATA:
+        (void)data_frame();
+        break;
+      case FrameType::ERROR:
+        (void)error_frame();
+        break;
+      case FrameType::REMOTE:
+        (void)remote_frame();
+        break;
+      default:
+        throw std::logic_error{"CanId: No such type"};
+    }
+    return *this;
+  }
+
+  CanId & identifier(const IdT id)
+  {
+    constexpr auto MAX_EXTENDED = 0x1FBF'FFFFU;
+    constexpr auto MAX_STANDARD = 0x7FFU;
+
+    static_assert(MAX_EXTENDED <= EXTENDED_ID_MASK, "Max extended id value is wrong");
+    static_assert(MAX_STANDARD <= STANDARD_ID_MASK, "Max standed id value is wrong");
+    const auto max_id = is_extended() ? MAX_EXTENDED : MAX_STANDARD;
+    if (max_id < id) {
+      throw std::domain_error{"CanId would be truncated!"};
+    }
+    m_id = m_id & (~EXTENDED_ID_MASK);
+    m_id = m_id | id;
+    return *this;
+  }
+
+  IdT identifier() const noexcept
+  {
+    const auto mask = is_extended() ? EXTENDED_ID_MASK : STANDARD_ID_MASK;
+    return m_id & mask;
+  }
+
+  IdT get() const noexcept { return m_id; }
+
+  bool is_extended() const noexcept { return (m_id & EXTENDED_MASK) == EXTENDED_MASK; }
+
+  FrameType frame_type() const
+  {
+    const auto is_error = (m_id & ERROR_MASK) == ERROR_MASK;
+    const auto is_remote = (m_id & REMOTE_MASK) == REMOTE_MASK;
+    if (is_error && is_remote) {
+      throw std::domain_error{"CanId has both bit 29 and 30 set! Inconsistent"};
+    }
+    if (is_error) {
+      return FrameType::ERROR;
+    }
+    if (is_remote) {
+      return FrameType::REMOTE;
+    }
+    return FrameType::DATA;
+  }
+
+  LengthT length() const noexcept { return m_data_length; }
+  IdT m_id{};
+
+private:
+  SOCKETCAN_LOCAL CanId(const IdT id, FrameType type, bool is_extended)
+  {
+    if (is_extended) {
+      (void)extended();
+    }
+    (void)frame_type(type);
+    (void)identifier(id);
+  }
+
+  LengthT m_data_length{};
+};  // class CanId
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_ID_HPP_

--- a/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/protocol/socket_can_receiver.hpp
+++ b/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/protocol/socket_can_receiver.hpp
@@ -1,0 +1,145 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_RECEIVER_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_RECEIVER_HPP_
+#include <linux/can.h>
+#include <linux/can/raw.h>
+#include <sys/socket.h>
+#include <unistd.h>  // for close()
+
+#include <chrono>
+#include <cstring>
+#include <memory>
+#include <string>
+
+#include "socket_can_common.hpp"
+#include "socket_can_id.hpp"
+#include "visibility_control.hpp"
+
+namespace can_device
+{
+namespace socket_can
+{
+// using target_can_device = static_cast<std::string>(TARGET_CAN_DEVICE);
+
+class SOCKETCAN_PUBLIC SocketCanReceiver
+{
+public:
+  explicit SocketCanReceiver(
+    const std::string & interface = "can0", bool canfd_on = false)
+  {
+    if (!bind_can_socket(fd_, interface, canfd_on)) {
+      printf("bind_can_socket failed!\r\n");
+      return;
+    }
+  }
+
+  ~SocketCanReceiver() noexcept { (void)close(fd_); }
+
+  bool receive(
+    std::shared_ptr<struct can_frame> rx_frame,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero())
+  {
+    wait(timeout);
+
+    struct canfd_frame frame;
+    memset(&frame, 0, sizeof(frame));
+    const auto nbytes = read(fd_, &frame, sizeof(frame));
+
+    if (nbytes < 0) {
+      throw std::runtime_error{strerror(errno)};
+    }
+    if (static_cast<std::size_t>(nbytes) < CAN_MTU) {
+      throw std::logic_error{"read: incomplete CAN frame"};
+    }
+    if (static_cast<std::size_t>(nbytes) != CAN_MTU) {
+      throw std::logic_error{"Message was wrong size"};
+    }
+
+    auto receive_id = CanId{frame.can_id, frame.len};
+    if (receive_id.frame_type() == can_device::socket_can::FrameType::DATA) {
+      rx_frame->can_id = receive_id.standard().get();
+      rx_frame->can_id = receive_id.length();
+      std::memcpy(rx_frame->data, frame.data, sizeof(rx_frame->data));
+      return true;
+    }
+    return false;
+  }
+
+  bool receive(
+    std::shared_ptr<struct canfd_frame> rx_frame,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero())
+  {
+    wait(timeout);
+
+    struct canfd_frame frame;
+    const auto nbytes = read(fd_, &frame, sizeof(frame));
+
+    uint8_t except_len = CAN_MTU - 8 + frame.len;
+    if (nbytes < 0) {
+      throw std::runtime_error{strerror(errno)};
+    }
+    if (static_cast<std::size_t>(nbytes) < except_len) {
+      throw std::runtime_error{"read: incomplete CAN frame"};
+    }
+
+    auto receive_id = CanId{frame.can_id, frame.len};
+    if (receive_id.frame_type() == can_device::socket_can::FrameType::DATA) {
+      rx_frame->can_id = receive_id.standard().get();
+      rx_frame->len = receive_id.length();
+      std::memcpy(rx_frame->data, frame.data, sizeof(rx_frame->data));
+      return true;
+    }
+    return false;
+  }
+
+  void set_filter(const struct can_filter filter[], size_t s)
+  {
+    setsockopt(fd_, SOL_CAN_RAW, CAN_RAW_FILTER, filter, s);
+  }
+
+private:
+  SOCKETCAN_LOCAL void wait(const std::chrono::nanoseconds timeout) const
+  {
+    if (decltype(timeout)::zero() < timeout) {
+      auto c_timeout = to_timeval(timeout);
+      auto read_set = single_set(fd_);
+
+      if (0 == select(fd_ + 1, &read_set, NULL, NULL, &c_timeout)) {
+        throw SocketCanTimeout{"$CAN Receive Timeout 1"};
+      }
+
+      if (!FD_ISSET(fd_, &read_set)) {
+        throw SocketCanTimeout{"$CAN Receive Timeout 2"};
+      }
+    } else {
+      auto read_set = single_set(fd_);
+
+      if (0 == select(fd_ + 1, &read_set, NULL, NULL, NULL)) {
+        throw SocketCanTimeout{"$CAN Receive Timeout 1"};
+      }
+
+      if (!FD_ISSET(fd_, &read_set)) {
+        throw SocketCanTimeout{"CAN Receive Timeout 2"};
+      }
+    }
+  }
+
+  int32_t fd_;
+};  // class SocketCanReceiver
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_RECEIVER_HPP_

--- a/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/protocol/socket_can_sender.hpp
+++ b/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/protocol/socket_can_sender.hpp
@@ -1,0 +1,168 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_SENDER_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_SENDER_HPP_
+
+#include <linux/can.h>
+#include <linux/can/raw.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <stdexcept>
+#include <string>
+
+#include "socket_can_common.hpp"
+#include "socket_can_id.hpp"
+#include "visibility_control.hpp"
+
+namespace can_device
+{
+namespace socket_can
+{
+class SOCKETCAN_PUBLIC SocketCanSender
+{
+public:
+  explicit SocketCanSender(
+    const std::string & interface = "can0", bool canfd_on = false,
+    const CanId & default_id = CanId{})
+  : m_default_id{default_id}
+  {
+    if (!bind_can_socket(fd_, interface, canfd_on)) {
+      printf("bind_can_socket failed\r\n");
+      return;
+    }
+  }
+  ~SocketCanSender() noexcept
+  {
+    (void)close(fd_);
+    // I'm destructing--there's not much else I can do on an error
+    // seem not good
+  }
+
+  void send(
+    const void * const data, const std::size_t Length,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    send(data, Length, m_default_id, timeout);
+  }
+
+  void send(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    if (length > MAX_DATA_LENGTH) {
+      throw std::domain_error{"Size is too large to send via CAN"};
+    }
+    send_impl(data, length, id, timeout);
+  }
+
+  template <typename T, typename = std::enable_if_t<!std::is_pointer<T>::value>>
+  void send(
+    const T & data, const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    send(data, m_default_id, timeout);
+  }
+
+  template <typename T, typename = std::enable_if<!std::is_pointer<T>::value>>
+  void send(
+    const T & data, const CanId id,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    static_assert(sizeof(data) <= MAX_DATA_LENGTH, "Data type too large for CAN");
+    send_impl(reinterpret_cast<const char *>(&data), sizeof(data), id, timeout);
+  }
+
+  void send_fd(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    if (length > MAX_DATA_LENGTH) {
+      throw std::domain_error{"Size is too large to send via CAN"};
+    }
+    send_fd_impl(data, length, id, timeout);
+  }
+
+  CanId default_id() const noexcept { return m_default_id; }
+
+private:
+  void send_impl(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout) const
+  {
+    // (void)data;
+    // (void)length;
+    // (void)id;
+    (void)timeout;
+
+    struct can_frame data_frame;
+    data_frame.can_id = id.get();
+
+    data_frame.can_dlc = static_cast<decltype(data_frame.can_dlc)>(length);
+
+    (void)std::memcpy(static_cast<void *>(&data_frame.data[0U]), data, length);
+
+    if (write(fd_, &data_frame, static_cast<int>(CAN_MTU)) != static_cast<int>(CAN_MTU)) {
+      throw std::runtime_error{strerror(errno)};
+    }
+  }
+
+  void send_fd_impl(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout) const
+  {
+    // (void)data;
+    // (void)length;
+    // (void)id;
+    (void)timeout;
+
+    struct canfd_frame data_frame;
+    memset(&data_frame, 0, sizeof(data_frame));
+    data_frame.can_id = id.get();
+    data_frame.flags = CANFD_FDF | CANFD_BRS;
+    data_frame.len = static_cast<decltype(data_frame.len)>(length);
+    std::memcpy(static_cast<void *>(&data_frame.data[0U]), data, length);
+    if (write(fd_, &data_frame, CANFD_MTU) != CANFD_MTU) {
+      throw std::runtime_error{strerror(errno)};
+    }
+  }
+
+  SOCKETCAN_LOCAL void wait(const std::chrono::nanoseconds timeout) const
+  {
+    if (decltype(timeout)::zero() < timeout) {
+      auto c_timeout = to_timeval(timeout);
+      auto write_set = single_set(fd_);
+
+      // wait
+      if (0 == select(fd_ + 1, NULL, &write_set, NULL, &c_timeout)) {
+        throw SocketCanTimeout{"$CAN Send Timeout [1]"};
+      }
+
+      if (!FD_ISSET(fd_, &write_set)) {
+        throw SocketCanTimeout{"$CAN Send Timeout [2]"};
+      }
+    } else {
+      // do nothing
+      // auto write_set = single_set(fd_);
+    }
+  }
+
+  int32_t fd_;
+  CanId m_default_id;
+};
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_SENDER_HPP_

--- a/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/protocol/visibility_control.hpp
+++ b/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/protocol/visibility_control.hpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__VISIBILITY_CONTROL_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__VISIBILITY_CONTROL_HPP_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+#ifdef __GNUC__
+#define SOCKETCAN_EXPORT __attribute__((dllexport))
+#define SOCKETCAN_IMPORT __attribute__((dllimport))
+#else
+#define SOCKETCAN_EXPORT __declspec(dllexport)
+#define SOCKETCAN_IMPORT __declspec(dllimport)
+#endif
+#ifdef SOCKETCAN_BUILDING_LIBRARY
+#define SOCKETCAN_PUBLIC SOCKETCAN_EXPORT
+#else
+#define SOCKETCAN_PUBLIC SOCKETCAN_IMPORT
+#endif
+#define SOCKETCAN_PUBLIC_TYPE SOCKETCAN_PUBLIC
+#define SOCKETCAN_LOCAL
+#else
+#define SOCKETCAN_EXPORT __attribute__((visibility("default")))
+#define SOCKETCAN_IMPORT
+#if __GNUC__ >= 4
+#define SOCKETCAN_PUBLIC __attribute__((visibility("default")))
+#define SOCKETCAN_LOCAL __attribute__((visibility("hidden")))
+#else
+#define SOCKETCAN_PUBLIC
+#define SOCKETCAN_LOCAL
+#endif
+#define SOCKETCAN_PUBLIC_TYPE
+#endif
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__VISIBILITY_CONTROL_HPP_

--- a/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/tita_robot/can_receiver.hpp
+++ b/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/tita_robot/can_receiver.hpp
@@ -63,17 +63,9 @@ namespace can_device
   class MotorsImuCanReceiveApi
   {
   public:
-    MotorsImuCanReceiveApi(size_t size)
-    {
-      if(size % 8 == 0) leg_dof_ = 4;
-      else if(size % 6 == 0) leg_dof_ = 3;
-      leg_num_ = size / leg_dof_;
-      register_motors_device_can_filter();
-      api_motor_in_t default_motor_in;
-      std::memset(&default_motor_in, 0x00U, sizeof(api_motor_in_t));
-      motors_in_.resize(size, default_motor_in);
-      std::memset(&imu_data_, 0x00U, sizeof(api_imu_data_t));
-    }
+    MotorsImuCanReceiveApi(size_t size,
+                           std::string can_interface = "can0",
+                           uint8_t can_id_offset = 0x00U);
     ~MotorsImuCanReceiveApi() {}
     const std::vector<api_motor_in_t> *get_motors_in() const { return &motors_in_; }
     const api_imu_data_t *get_imu_data() const { return &imu_data_; }
@@ -83,21 +75,18 @@ namespace can_device
 #define MIN_TIME_OUT_US 1'000L     // 1ms
 #define MAX_TIME_OUT_US 3'000'000L // 3s
 #define CAN_MASK_AS_MOTORS_INFO (0x7E0U)
-    std::string motors_can_interface = "can0";
-    std::string motors_can_name = "motors_can";
-    bool motors_can_extended_frame = false;
-    bool motors_can_rx_is_block = false;
-    int64_t motors_timeout_us = MAX_TIME_OUT_US;
-    uint8_t motors_can_id_offset = 0x00U;
+    std::string motors_can_interface_;
+    std::string motors_can_name_;
+    bool motors_can_extended_frame_;
+    bool motors_can_rx_is_block_;
+    int64_t motors_timeout_us_;
+    uint8_t motors_can_id_offset_;
 
     void register_motors_device_can_filter();
     can_device::socket_can::can_fd_callback motors_can_receive_callback =
         std::bind(&MotorsImuCanReceiveApi::board_can_data_callback, this, std::placeholders::_1);
 
-    std::shared_ptr<can_device::socket_can::CanDev> motors_can_receive_api =
-        std::make_shared<can_device::socket_can::CanDev>(
-            motors_can_interface, motors_can_name, motors_can_extended_frame, motors_can_receive_callback,
-            motors_can_rx_is_block, motors_timeout_us, motors_can_id_offset);
+    std::shared_ptr<can_device::socket_can::CanDev> motors_can_receive_api;
 
     void board_can_data_callback(std::shared_ptr<struct canfd_frame> recv_frame);
     void motors_data_callback(std::shared_ptr<struct canfd_frame> recv_frame);

--- a/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/tita_robot/can_receiver.hpp
+++ b/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/tita_robot/can_receiver.hpp
@@ -1,0 +1,116 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MOTORS_CAN__MOTORS_CAN_API_HPP_
+#define MOTORS_CAN__MOTORS_CAN_API_HPP_
+
+#include <algorithm>
+#include <atomic>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "protocol/can_utils.hpp"
+namespace can_device
+{
+#define PACKED __attribute__((__packed__))
+#define GRAVITY 9.81f
+#define CAN_ID_MOTOR_IN 0x108
+#define CAN_ID_IMU1 0x118
+#define CAN_ID_STATE 0x102
+
+  struct api_motor_in_t
+  {
+    uint32_t timestamp;
+    float position;
+    float velocity;
+    float torque;
+  } PACKED;
+  /* 44 bytes */
+  struct api_imu_data_t
+  {
+    uint32_t timestamp;
+    float accl[3];
+    float gyro[3];
+    float quaternion[4]; // x y z w
+    float temperature;
+  } PACKED;
+  
+  struct api_motor_status_t
+  {
+    uint32_t timestamp;
+    uint16_t key;
+    uint8_t value[8];
+  } PACKED;
+
+  class MotorsImuCanReceiveApi
+  {
+  public:
+    MotorsImuCanReceiveApi(size_t size)
+    {
+      if(size % 8 == 0) leg_dof_ = 4;
+      else if(size % 6 == 0) leg_dof_ = 3;
+      leg_num_ = size / leg_dof_;
+      register_motors_device_can_filter();
+      api_motor_in_t default_motor_in;
+      std::memset(&default_motor_in, 0x00U, sizeof(api_motor_in_t));
+      motors_in_.resize(size, default_motor_in);
+      std::memset(&imu_data_, 0x00U, sizeof(api_imu_data_t));
+    }
+    ~MotorsImuCanReceiveApi() {}
+    const std::vector<api_motor_in_t> *get_motors_in() const { return &motors_in_; }
+    const api_imu_data_t *get_imu_data() const { return &imu_data_; }
+    const api_motor_status_t *get_motors_status() const { return &motors_status_; }
+
+  private:
+#define MIN_TIME_OUT_US 1'000L     // 1ms
+#define MAX_TIME_OUT_US 3'000'000L // 3s
+#define CAN_MASK_AS_MOTORS_INFO (0x7E0U)
+    std::string motors_can_interface = "can0";
+    std::string motors_can_name = "motors_can";
+    bool motors_can_extended_frame = false;
+    bool motors_can_rx_is_block = false;
+    int64_t motors_timeout_us = MAX_TIME_OUT_US;
+    uint8_t motors_can_id_offset = 0x00U;
+
+    void register_motors_device_can_filter();
+    can_device::socket_can::can_fd_callback motors_can_receive_callback =
+        std::bind(&MotorsImuCanReceiveApi::board_can_data_callback, this, std::placeholders::_1);
+
+    std::shared_ptr<can_device::socket_can::CanDev> motors_can_receive_api =
+        std::make_shared<can_device::socket_can::CanDev>(
+            motors_can_interface, motors_can_name, motors_can_extended_frame, motors_can_receive_callback,
+            motors_can_rx_is_block, motors_timeout_us, motors_can_id_offset);
+
+    void board_can_data_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+    void motors_data_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+    void imu_data_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+    void motors_status_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+
+    std::vector<api_motor_in_t> motors_in_;
+    api_imu_data_t imu_data_;
+    api_motor_status_t motors_status_;
+
+    mutable std::shared_mutex motors_in_mutex_, imu_mutex_;
+    size_t leg_dof_{4}, leg_num_{2};
+  };
+} // namespace can_device
+
+#endif // MOTORS_CAN__MOTORS_CAN_API_HPP_

--- a/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/tita_robot/can_sender.hpp
+++ b/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/tita_robot/can_sender.hpp
@@ -1,0 +1,120 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MOTORS_CAN__MOTORS_CAN_SEND_API_HPP_
+#define MOTORS_CAN__MOTORS_CAN_SEND_API_HPP_
+
+#include <algorithm>
+#include <atomic>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "protocol/can_utils.hpp"
+
+namespace can_device
+{
+
+#define CAN_ID_SEND_MOTORS (0x120U)
+#define CAN_ID_CHANNEL_INPUT (0x12DU)
+#define CAN_ID_RPC_REQUEST (0x170U)
+
+  enum ApiRpcKey
+  {
+    RPC_UNDEFINED = 0x000,
+    GET_MODEL_INFO = 0x100,
+    GET_SERIAL_NUMBER = 0x101,
+    SET_READY_NEXT = 0x200,
+    SET_BOARDCAST = 0x201,
+    SET_INPUT_MODE = 0x221,
+    SET_STAND_MODE = 0x222,
+    SET_HEAD_MODE = 0x223,
+    SET_JUMP = 0x231,
+    SET_MOTOR_ZERO = 0x280,
+  };
+  struct ChannelInput
+  {
+    uint32_t timestamp;
+    float forward;
+    float yaw;
+    float pitch;
+    float roll;
+    float height;
+    float split;
+    float tilt;
+    float forward_accel;
+    float yaw_accel;
+  };
+  struct RpcRequest
+  {
+    uint32_t timestamp;
+    uint16_t key;
+    uint32_t value;
+  };
+  struct motor_out
+  {
+    uint32_t timestamp;
+    float position;
+    float kp;
+    float velocity;
+    float kd;
+    float torque;
+  };
+
+  class MotorsCanSendApi
+  {
+  public:
+    MotorsCanSendApi(size_t size)
+    {
+      if (size % 8 == 0)
+        leg_dof_ = 4;
+      else if (size % 6 == 0)
+        leg_dof_ = 3;
+      leg_num_ = size / leg_dof_;
+    }
+    ~MotorsCanSendApi() = default;
+    bool send_motors_can(std::vector<motor_out> motors);
+    bool send_command_can_channel_input(ChannelInput data);
+    bool send_command_can_rpc_request(RpcRequest data);
+
+  private:
+#define MIN_TIME_OUT_US 1'000L     // 1ms
+#define MAX_TIME_OUT_US 3'000'000L // 3s
+    std::string can_interface = "can0";
+    std::string can_name = "motors_can_send";
+    int64_t timeout_us = MAX_TIME_OUT_US;
+    uint8_t can_id_offset = 0x00U;
+    bool can_extended_frame = false;
+    bool can_fd_mode = true;
+
+    std::shared_ptr<can_device::socket_can::CanDev> can_send_api_ =
+        std::make_shared<can_device::socket_can::CanDev>(
+            can_interface, can_name, can_extended_frame, can_fd_mode, timeout_us, can_id_offset);
+
+    inline uint32_t get_current_time()
+    {
+      struct timeval tv;
+      gettimeofday(&tv, NULL);
+      return std::move(tv.tv_sec * 1000000 + tv.tv_usec);
+    }
+    size_t leg_dof_{4}, leg_num_{2};
+  };
+} // namespace can_device
+
+#endif // MOTORS_CAN__MOTORS_CAN_SEND_API_HPP_

--- a/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/tita_robot/can_sender.hpp
+++ b/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/tita_robot/can_sender.hpp
@@ -80,14 +80,9 @@ namespace can_device
   class MotorsCanSendApi
   {
   public:
-    MotorsCanSendApi(size_t size)
-    {
-      if (size % 8 == 0)
-        leg_dof_ = 4;
-      else if (size % 6 == 0)
-        leg_dof_ = 3;
-      leg_num_ = size / leg_dof_;
-    }
+    MotorsCanSendApi(size_t size,
+                     std::string can_interface = "can0",
+                     uint8_t can_id_offset = 0x00U);
     ~MotorsCanSendApi() = default;
     bool send_motors_can(std::vector<motor_out> motors);
     bool send_command_can_channel_input(ChannelInput data);
@@ -96,16 +91,14 @@ namespace can_device
   private:
 #define MIN_TIME_OUT_US 1'000L     // 1ms
 #define MAX_TIME_OUT_US 3'000'000L // 3s
-    std::string can_interface = "can0";
-    std::string can_name = "motors_can_send";
-    int64_t timeout_us = MAX_TIME_OUT_US;
-    uint8_t can_id_offset = 0x00U;
-    bool can_extended_frame = false;
-    bool can_fd_mode = true;
+    std::string can_interface_;
+    std::string can_name_;
+    int64_t timeout_us_;
+    uint8_t can_id_offset_;
+    bool can_extended_frame_;
+    bool can_fd_mode_;
 
-    std::shared_ptr<can_device::socket_can::CanDev> can_send_api_ =
-        std::make_shared<can_device::socket_can::CanDev>(
-            can_interface, can_name, can_extended_frame, can_fd_mode, timeout_us, can_id_offset);
+    std::shared_ptr<can_device::socket_can::CanDev> can_send_api_;
 
     inline uint32_t get_current_time()
     {

--- a/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/tita_robot/canfd_router_bridge.hpp
+++ b/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/tita_robot/canfd_router_bridge.hpp
@@ -1,0 +1,45 @@
+#ifndef TITA_ROBOT_CANFD_ROUTER_BRIDGE_HPP_
+#define TITA_ROBOT_CANFD_ROUTER_BRIDGE_HPP_
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include "protocol/can_utils.hpp"
+
+namespace can_device
+{
+
+class CanfdRouterBridge
+{
+public:
+  explicit CanfdRouterBridge(const std::string &can_interface = "can0",
+                             uint8_t can_id_offset = 0x00U);
+  ~CanfdRouterBridge() = default;
+
+  void request_force_direct();
+
+private:
+  void register_canfd_router_device_can_filter();
+  void handle_router_frame(std::shared_ptr<struct canfd_frame> recv_frame);
+  void send_force_direct_sequence();
+  uint32_t get_current_time() const;
+
+  std::string can_interface_;
+  std::string can_name_;
+  bool can_extended_frame_;
+  bool can_rx_block_;
+  int64_t timeout_us_;
+  uint8_t can_id_offset_;
+
+  std::shared_ptr<can_device::socket_can::CanDev> router_can_;
+  std::shared_ptr<can_device::socket_can::CanDev> rpc_sender_;
+  std::atomic<bool> pending_force_direct_;
+  std::mutex rpc_mutex_;
+};
+
+}  // namespace can_device
+
+#endif  // TITA_ROBOT_CANFD_ROUTER_BRIDGE_HPP_

--- a/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/tita_robot/canfd_router_bridge.hpp
+++ b/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/tita_robot/canfd_router_bridge.hpp
@@ -3,6 +3,8 @@
 
 #include <atomic>
 #include <cstdint>
+#include <chrono>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -16,16 +18,20 @@ class CanfdRouterBridge
 {
 public:
   explicit CanfdRouterBridge(const std::string &can_interface = "can0",
-                             uint8_t can_id_offset = 0x00U);
+                             uint8_t can_id_offset = 0x00U,
+                             bool auto_retry = true);
   ~CanfdRouterBridge() = default;
 
   void request_force_direct();
+  void set_auto_retry(bool enable);
+  void set_status_callback(std::function<void(const std::string &)> callback);
 
 private:
   void register_canfd_router_device_can_filter();
   void handle_router_frame(std::shared_ptr<struct canfd_frame> recv_frame);
   void send_force_direct_sequence();
   uint32_t get_current_time() const;
+  void emit_status(const std::string &message);
 
   std::string can_interface_;
   std::string can_name_;
@@ -37,6 +43,12 @@ private:
   std::shared_ptr<can_device::socket_can::CanDev> router_can_;
   std::shared_ptr<can_device::socket_can::CanDev> rpc_sender_;
   std::atomic<bool> pending_force_direct_;
+  std::atomic<bool> force_direct_latched_;
+  std::atomic<uint32_t> last_router_mode_;
+  bool auto_retry_;
+  std::chrono::steady_clock::time_point last_force_direct_request_;
+  std::chrono::milliseconds min_retry_interval_;
+  std::function<void(const std::string &)> status_callback_;
   std::mutex rpc_mutex_;
 };
 

--- a/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/tita_robot/tita_robot.hpp
+++ b/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/tita_robot/tita_robot.hpp
@@ -1,0 +1,154 @@
+#include "can_receiver.hpp"
+#include "can_sender.hpp"
+
+class tita_robot
+{
+public:
+    enum ReadyNext
+    {
+        READY_WAITING = 0x00U,
+        AUTO_LOCOMOTION = 0x01U,
+        FORCE_LOCOMOTION = 0x02U,
+        FORCE_DIRECT = 0x03U,
+        MOTOR_ZERO_CAL = 0x04U,
+        BOOT_RECOVERY_MODE = 0x05U,
+        ESTOP_MODE = 0x06U,
+    };
+    struct ChannelInput
+    {
+        uint32_t timestamp;
+        float forward;
+        float yaw;
+        float pitch;
+        float roll;
+        float height;
+        float split;
+        float tilt;
+        float forward_accel;
+        float yaw_accel;
+    };
+    tita_robot(size_t num_motors)
+    {
+        // Initialize the CAN receiver
+        can_receiver_ = std::make_unique<can_device::MotorsImuCanReceiveApi>(num_motors);
+        can_sender_ = std::make_unique<can_device::MotorsCanSendApi>(num_motors);
+        motor_num_ = num_motors;
+    }
+
+    /**
+     * @brief Get the current joint positions in joint space.
+     * @return std::vector<double>: current joint positions in radians.
+     */
+    std::vector<double> get_joint_q() const;
+
+    /**
+     * @brief Get the current joint velocities in joint space.
+     * @return std::vector<double>: current joint velocities in radians per second.
+     */
+    std::vector<double> get_joint_v() const;
+
+    /**
+     * @brief Get the current joint torques in joint space.
+     * @return std::vector<double>: current joint torques in Newton meters.
+     */
+    std::vector<double> get_joint_t() const;
+
+    /**
+     * @brief Get the current joint status.
+     * @note Joints status now is in bool value, true means the joint is online(TODO).
+     * @return std::vector<uint8_t>: current joint status.
+     */
+    std::vector<uint8_t> get_joint_status() const;
+
+    /**
+     * @brief Get the current imu quaternion of mcu.
+     * @note Quaternion sequence is x y z w.
+     * @return std::array<double, 4>: current quaternion.
+     */
+    std::array<double, 4> get_imu_quaternion() const; // x y z w
+
+    /**
+     * @brief Get the current imu acceleration of mcu.
+     * @return std::array<double, 3>: current acceleration.
+     */
+    std::array<double, 3> get_imu_acceleration() const;
+
+    /**
+     * @brief Get the current imu angular velocity of mcu.
+     * @return std::array<double, 3>: current angular velocity.
+     */
+    std::array<double, 3> get_imu_angular_velocity() const;
+
+    /**
+     * @brief Set the target joint feed-forward torques.
+     * @param t the target joint feed-forward torques.
+     * @return return true if the target is set successfully.
+     */
+    bool set_target_joint_t(const std::vector<double> &t);
+
+    /**
+     * @brief MIT control method. Set the target joint positions, velocities, kp, kd and feed-forward torques of the
+     motors.
+     * @param q the target joint positions in radians.
+     * @param v the target joint velocities in radians per second.
+     * @param kp the target joint proportional gains.
+     * @param kd the target joint derivative gains.
+     * @param t the target joint feed-forward torques.
+     *
+     * @return return true if the target is set successfully
+     */
+    bool set_target_joint_mit(const std::vector<double> &q, const std::vector<double> &v, const std::vector<double> &kp, const std::vector<double> &kd, const std::vector<double> &t);
+
+    // /**
+    //  * @brief Set mcu board control mode, maybe remove in the future.
+    //  * @param mode the target mcu mode, option: READY_WAITING AUTO_LOCOMOTION FORCE_DIRECT.
+    //  *
+    //  * @return return true if the target is set successfully
+    //  */
+    // bool set_board_mode(ReadyNext mode);
+    /**
+     * @brief Set mcu board can direct drive motors, default is auto_locomotion(use mcu control).
+     * @param if_sdk true means use control motors sdk, false means use mcu control.
+     *
+     * @return return true if the target is set successfully
+     */
+    bool set_motors_sdk(bool if_sdk);
+    /**
+     * @brief Set rc input to mcu. Only used in board mode is AUTO_LOCOMOTION.
+     * @param forward the target forward.
+     * @param yaw the target yaw.
+     * @param pitch the target pitch.
+     * @param roll the target roll.
+     * @param height the target height.
+     * @param split the target split.
+     * @param tilt the target tilt.
+     * @param forward_accel the target forward acceleration.
+     * @param yaw_accel the target yaw acceleration.
+     * @return return true if the target is set successfully
+     */
+    bool set_rc_input(ChannelInput input);    
+    /**
+     * @brief Set rc input to mcu. Only used in board mode is AUTO_LOCOMOTION.
+     * @param stand true if stand.
+     * @return return true if the target is set successfully
+     */
+    bool set_robot_stand(bool stand);
+
+    /**
+     * @brief Set rc input to mcu. Only used in board mode is AUTO_LOCOMOTION.
+     * @param jump true to start robot charge, then false change to start jump.
+     * @return return true if the target is set successfully
+     */
+    bool set_robot_jump(bool jump);
+    /**
+     * @brief Set rc input to mcu. Only used in board mode is AUTO_LOCOMOTION.
+     * @return return true if the target is set successfully
+     */
+    bool set_robot_stop();
+private:
+    std::unique_ptr<can_device::MotorsImuCanReceiveApi> can_receiver_;
+    std::unique_ptr<can_device::MotorsCanSendApi> can_sender_;
+    size_t motor_num_;
+};
+
+// class tita_robot

--- a/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/tita_robot/tita_robot.hpp
+++ b/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/tita_robot/tita_robot.hpp
@@ -1,6 +1,9 @@
 #include "can_receiver.hpp"
 #include "can_sender.hpp"
 
+#include <functional>
+#include <string>
+
 namespace can_device
 {
     class CanfdRouterBridge;
@@ -146,6 +149,21 @@ public:
      * @return return true if the target is set successfully
      */
     bool set_robot_stop();
+
+    /**
+     * @brief Query whether a CAN-FD router bridge is active for this robot.
+     */
+    bool has_canfd_router() const;
+
+    /**
+     * @brief Request the CAN-FD router to enter FORCE_DIRECT mode.
+     */
+    void request_router_force_direct();
+
+    /**
+     * @brief Register a callback to receive CAN-FD router status updates.
+     */
+    void set_router_status_callback(std::function<void(const std::string &)> callback);
 private:
     std::unique_ptr<can_device::MotorsImuCanReceiveApi> can_receiver_;
     std::unique_ptr<can_device::MotorsCanSendApi> can_sender_;

--- a/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/tita_robot/tita_robot.hpp
+++ b/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/tita_robot/tita_robot.hpp
@@ -1,6 +1,11 @@
 #include "can_receiver.hpp"
 #include "can_sender.hpp"
 
+namespace can_device
+{
+    class CanfdRouterBridge;
+}
+
 class tita_robot
 {
 public:
@@ -27,13 +32,9 @@ public:
         float forward_accel;
         float yaw_accel;
     };
-    tita_robot(size_t num_motors)
-    {
-        // Initialize the CAN receiver
-        can_receiver_ = std::make_unique<can_device::MotorsImuCanReceiveApi>(num_motors);
-        can_sender_ = std::make_unique<can_device::MotorsCanSendApi>(num_motors);
-        motor_num_ = num_motors;
-    }
+    tita_robot(size_t num_motors,
+               const std::string &can_interface = "can0",
+               bool enable_canfd_router = false);
 
     /**
      * @brief Get the current joint positions in joint space.
@@ -148,6 +149,7 @@ public:
 private:
     std::unique_ptr<can_device::MotorsImuCanReceiveApi> can_receiver_;
     std::unique_ptr<can_device::MotorsCanSendApi> can_sender_;
+    std::unique_ptr<can_device::CanfdRouterBridge> can_router_;
     size_t motor_num_;
 };
 

--- a/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/tita_robot/tita_robot.hpp
+++ b/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/tita_robot/tita_robot.hpp
@@ -1,9 +1,18 @@
-#include "can_receiver.hpp"
-#include "can_sender.hpp"
-#include "canfd_router_bridge.hpp"
+#ifndef TITA_ROBOT__TITA_ROBOT_HPP_
+#define TITA_ROBOT__TITA_ROBOT_HPP_
 
+#include <array>
 #include <functional>
+#include <memory>
 #include <string>
+#include <vector>
+
+namespace can_device
+{
+class MotorsImuCanReceiveApi;
+class MotorsCanSendApi;
+class CanfdRouterBridge;
+}
 
 class tita_robot
 {
@@ -34,6 +43,7 @@ public:
     tita_robot(size_t num_motors,
                const std::string &can_interface = "can0",
                bool enable_canfd_router = false);
+    ~tita_robot();
 
     /**
      * @brief Get the current joint positions in joint space.
@@ -167,4 +177,4 @@ private:
     size_t motor_num_;
 };
 
-// class tita_robot
+#endif  // TITA_ROBOT__TITA_ROBOT_HPP_

--- a/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/tita_robot/tita_robot.hpp
+++ b/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/include/tita_robot/tita_robot.hpp
@@ -1,13 +1,9 @@
 #include "can_receiver.hpp"
 #include "can_sender.hpp"
+#include "canfd_router_bridge.hpp"
 
 #include <functional>
 #include <string>
-
-namespace can_device
-{
-    class CanfdRouterBridge;
-}
 
 class tita_robot
 {

--- a/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/src/can_receiver.cpp
+++ b/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/src/can_receiver.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tita_robot/can_receiver.hpp"
+
+namespace can_device
+{
+
+void MotorsImuCanReceiveApi::register_motors_device_can_filter()
+{
+  // if (!this->is_running.load()) {
+  //   throw std::runtime_error("MotorsImuCanReceiveApi is not running");
+  // }
+  struct can_filter motors_device_rx_filter;
+  motors_device_rx_filter.can_id = CAN_ID_MOTOR_IN;
+  motors_device_rx_filter.can_mask = CAN_MASK_AS_MOTORS_INFO;
+  this->motors_can_receive_api->set_filter(&motors_device_rx_filter, sizeof(struct can_filter));
+}
+
+void MotorsImuCanReceiveApi::board_can_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  if (recv_frame->can_id >= CAN_ID_MOTOR_IN && recv_frame->can_id < CAN_ID_MOTOR_IN + leg_num_) {
+    motors_data_callback(recv_frame);
+  } else if (recv_frame->can_id == CAN_ID_IMU1) {
+    imu_data_callback(recv_frame);
+  } else {
+    return;
+  }
+}
+void MotorsImuCanReceiveApi::motors_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  std::unique_lock<std::shared_mutex> lock(motors_in_mutex_);
+  for (size_t i = 0; i < leg_dof_; i++) {
+    api_motor_in_t motor;
+    std::memcpy(&motor, recv_frame->data + 16 * i, sizeof(api_motor_in_t));
+    auto it = recv_frame->can_id - CAN_ID_MOTOR_IN;
+    motors_in_[i + leg_dof_ * it] = motor;
+  }
+}
+void MotorsImuCanReceiveApi::imu_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  std::unique_lock<std::shared_mutex> lock(imu_mutex_);
+  std::memcpy(&imu_data_, recv_frame->data, sizeof(api_imu_data_t));
+  for (size_t i(0); i < 3; ++i) {
+    imu_data_.accl[i] *= GRAVITY;
+  }
+  return;
+}
+void MotorsImuCanReceiveApi::motors_status_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  std::memcpy(&motors_status_, recv_frame->data, sizeof(api_motor_status_t));
+}
+
+}  // namespace can_device

--- a/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/src/can_receiver.cpp
+++ b/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/src/can_receiver.cpp
@@ -14,8 +14,39 @@
 
 #include "tita_robot/can_receiver.hpp"
 
+#include <utility>
+
 namespace can_device
 {
+
+MotorsImuCanReceiveApi::MotorsImuCanReceiveApi(size_t size,
+                                               std::string can_interface,
+                                               uint8_t can_id_offset)
+  : motors_can_interface_(std::move(can_interface)),
+    motors_can_name_("motors_can"),
+    motors_can_extended_frame_(false),
+    motors_can_rx_is_block_(false),
+    motors_timeout_us_(MAX_TIME_OUT_US),
+    motors_can_id_offset_(can_id_offset)
+{
+  if (size % 8 == 0)
+  {
+    leg_dof_ = 4;
+  }
+  else if (size % 6 == 0)
+  {
+    leg_dof_ = 3;
+  }
+  leg_num_ = size / leg_dof_;
+  motors_can_receive_api = std::make_shared<can_device::socket_can::CanDev>(
+    motors_can_interface_, motors_can_name_, motors_can_extended_frame_, motors_can_receive_callback,
+    motors_can_rx_is_block_, motors_timeout_us_, motors_can_id_offset_);
+  register_motors_device_can_filter();
+  api_motor_in_t default_motor_in;
+  std::memset(&default_motor_in, 0x00U, sizeof(api_motor_in_t));
+  motors_in_.resize(size, default_motor_in);
+  std::memset(&imu_data_, 0x00U, sizeof(api_imu_data_t));
+}
 
 void MotorsImuCanReceiveApi::register_motors_device_can_filter()
 {

--- a/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/src/can_sender.cpp
+++ b/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/src/can_sender.cpp
@@ -16,6 +16,29 @@
 
 namespace can_device
 {
+MotorsCanSendApi::MotorsCanSendApi(size_t size,
+                                   std::string can_interface,
+                                   uint8_t can_id_offset)
+  : can_interface_(std::move(can_interface)),
+    can_name_("motors_can_send"),
+    timeout_us_(MAX_TIME_OUT_US),
+    can_id_offset_(can_id_offset),
+    can_extended_frame_(false),
+    can_fd_mode_(true)
+{
+  if (size % 8 == 0)
+  {
+    leg_dof_ = 4;
+  }
+  else if (size % 6 == 0)
+  {
+    leg_dof_ = 3;
+  }
+  leg_num_ = size / leg_dof_;
+  can_send_api_ = std::make_shared<can_device::socket_can::CanDev>(
+    can_interface_, can_name_, can_extended_frame_, can_fd_mode_, timeout_us_, can_id_offset_);
+}
+
 bool MotorsCanSendApi::send_command_can_channel_input(ChannelInput data)
 {
   data.timestamp = get_current_time();

--- a/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/src/can_sender.cpp
+++ b/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/src/can_sender.cpp
@@ -1,0 +1,90 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tita_robot/can_sender.hpp"
+
+namespace can_device
+{
+bool MotorsCanSendApi::send_command_can_channel_input(ChannelInput data)
+{
+  data.timestamp = get_current_time();
+  struct canfd_frame frame;
+  frame.can_id = CAN_ID_CHANNEL_INPUT;
+  frame.len = 40u;
+  memset(frame.data, 0x00U, sizeof(frame.data));
+  
+  std::memcpy(frame.data, &data, sizeof(data));
+
+  return can_send_api_->send_can_message(frame);
+}
+
+bool MotorsCanSendApi::send_command_can_rpc_request(RpcRequest data){
+  data.timestamp = get_current_time();
+
+  struct canfd_frame frame;
+  frame.can_id = CAN_ID_RPC_REQUEST;
+  frame.len = 10U;
+
+  memset(frame.data, 0x00U, sizeof(frame.data));
+
+  std::memcpy(frame.data, &data.timestamp, sizeof(data.timestamp));
+  std::memcpy(frame.data + 4, &data.key, sizeof(data.key));
+  std::memcpy(frame.data + 6, &data.value, sizeof(data.value));
+
+  return can_send_api_->send_can_message(frame);
+}
+
+bool MotorsCanSendApi::send_motors_can(std::vector<motor_out> motors)
+{
+  if (motors.size() != leg_dof_ * leg_num_) {
+    std::cerr << "[MOTORS_CAN_SEND] motors size not equal to robot dof" << std::endl;
+    return false;
+  }
+  if(leg_dof_ == 3){
+    motor_out motor = {};
+    auto it = motors.begin() + 3;
+    motors.insert(it, motor);
+    motors.push_back(motor);
+  }
+  bool send_success = true;
+  struct canfd_frame frame;
+  frame.len = 48U;
+  auto now = get_current_time();
+  for (size_t id(0); id < motors.size()/2; id++) {
+    frame.can_id = CAN_ID_SEND_MOTORS + id;
+    memset(frame.data, 0x00U, sizeof(frame.data));
+    auto motor = motors[2 * id];
+    motor.timestamp = now;
+    std::memcpy(frame.data, &motor.timestamp, sizeof(motor.timestamp));
+    std::memcpy(frame.data + 4, &motor.position, sizeof(motor.position));
+    std::memcpy(frame.data + 8, &motor.kp, sizeof(motor.kp));
+    std::memcpy(frame.data + 12, &motor.velocity, sizeof(motor.velocity));
+    std::memcpy(frame.data + 16, &motor.kd, sizeof(motor.kd));
+    std::memcpy(frame.data + 20, &motor.torque, sizeof(motor.torque));
+
+    motor = motors[2 * id + 1];
+    motor.timestamp = now;
+    std::memcpy(frame.data + 24, &motor.timestamp, sizeof(motor.timestamp));
+    std::memcpy(frame.data + 28, &motor.position, sizeof(motor.position));
+    std::memcpy(frame.data + 32, &motor.kp, sizeof(motor.kp));
+    std::memcpy(frame.data + 36, &motor.velocity, sizeof(motor.velocity));
+    std::memcpy(frame.data + 40, &motor.kd, sizeof(motor.kd));
+    std::memcpy(frame.data + 44, &motor.torque, sizeof(motor.torque));
+    send_success &= can_send_api_->send_can_message(frame);
+    std::this_thread::sleep_for(std::chrono::microseconds(150)); // 等待 100 微秒
+  }
+  return send_success;
+}
+
+}  // namespace can_device

--- a/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/src/canfd_router_bridge.cpp
+++ b/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/src/canfd_router_bridge.cpp
@@ -1,0 +1,141 @@
+#include "tita_robot/canfd_router_bridge.hpp"
+
+#include <chrono>
+#include <cstring>
+#include <iostream>
+#include <thread>
+#include <utility>
+
+#include <sys/time.h>
+
+namespace can_device
+{
+namespace
+{
+constexpr uint32_t CAN_ID_CANFD_ROUTER = 0x09FU;
+constexpr uint32_t CAN_ID_RPC_REQUEST = 0x170U;
+constexpr uint16_t RPC_KEY_SET_READY_NEXT = 0x200U;
+constexpr uint32_t RPC_VALUE_READY_WAITING = 0x00U;
+constexpr uint32_t RPC_VALUE_FORCE_DIRECT = 0x03U;
+constexpr int64_t MAX_TIME_OUT_US = 3'000'000L;
+}  // namespace
+
+CanfdRouterBridge::CanfdRouterBridge(const std::string &can_interface,
+                                     uint8_t can_id_offset)
+  : can_interface_(can_interface),
+    can_name_("canfd_router"),
+    can_extended_frame_(false),
+    can_rx_block_(false),
+    timeout_us_(MAX_TIME_OUT_US),
+    can_id_offset_(can_id_offset),
+    pending_force_direct_(false)
+{
+  using namespace std::placeholders;
+  router_can_ = std::make_shared<can_device::socket_can::CanDev>(
+    can_interface_, can_name_, can_extended_frame_,
+    std::bind(&CanfdRouterBridge::handle_router_frame, this, _1),
+    can_rx_block_, timeout_us_, can_id_offset_);
+
+  rpc_sender_ = std::make_shared<can_device::socket_can::CanDev>(
+    can_interface_, "canfd_router_rpc", false, true, timeout_us_, can_id_offset_);
+
+  register_canfd_router_device_can_filter();
+}
+
+void CanfdRouterBridge::request_force_direct()
+{
+  pending_force_direct_.store(true);
+}
+
+void CanfdRouterBridge::register_canfd_router_device_can_filter()
+{
+  struct can_filter filter;
+  filter.can_id = CAN_ID_CANFD_ROUTER;
+  filter.can_mask = 0x0FFU;
+  if (router_can_)
+  {
+    router_can_->set_filter(&filter, sizeof(struct can_filter));
+  }
+}
+
+void CanfdRouterBridge::handle_router_frame(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  if (!recv_frame || recv_frame->can_id != CAN_ID_CANFD_ROUTER)
+  {
+    return;
+  }
+
+  if (!pending_force_direct_.load())
+  {
+    return;
+  }
+
+  uint32_t mode = 0U;
+  std::memcpy(&mode, recv_frame->data + 4, sizeof(mode));
+  if (mode != 1U && mode != 2U)
+  {
+    return;
+  }
+
+  send_force_direct_sequence();
+  pending_force_direct_.store(false);
+}
+
+void CanfdRouterBridge::send_force_direct_sequence()
+{
+  if (!rpc_sender_)
+  {
+    std::cerr << "[CanfdRouterBridge] RPC sender not available" << std::endl;
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(rpc_mutex_);
+
+  struct canfd_frame frame;
+  std::memset(&frame, 0x00, sizeof(frame));
+  frame.can_id = CAN_ID_RPC_REQUEST + can_id_offset_;
+  frame.len = 10U;
+
+  uint16_t key = RPC_KEY_SET_READY_NEXT;
+  uint32_t value = RPC_VALUE_READY_WAITING;
+  uint32_t timestamp = get_current_time();
+  std::memcpy(frame.data, &timestamp, sizeof(timestamp));
+  std::memcpy(frame.data + 4, &key, sizeof(key));
+  std::memcpy(frame.data + 6, &value, sizeof(value));
+
+  try
+  {
+    rpc_sender_->send_can_message(frame);
+  }
+  catch (const std::exception &ex)
+  {
+    std::cerr << "[CanfdRouterBridge] Failed to request READY_WAITING: " << ex.what() << std::endl;
+    return;
+  }
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  value = RPC_VALUE_FORCE_DIRECT;
+  timestamp = get_current_time();
+  std::memcpy(frame.data, &timestamp, sizeof(timestamp));
+  std::memcpy(frame.data + 4, &key, sizeof(key));
+  std::memcpy(frame.data + 6, &value, sizeof(value));
+
+  try
+  {
+    rpc_sender_->send_can_message(frame);
+  }
+  catch (const std::exception &ex)
+  {
+    std::cerr << "[CanfdRouterBridge] Failed to request FORCE_DIRECT: " << ex.what() << std::endl;
+  }
+}
+
+uint32_t CanfdRouterBridge::get_current_time() const
+{
+  struct timeval tv;
+  gettimeofday(&tv, NULL);
+  return static_cast<uint32_t>(tv.tv_sec * 1000000 + tv.tv_usec);
+}
+
+}  // namespace can_device

--- a/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/src/canfd_router_bridge.cpp
+++ b/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/src/canfd_router_bridge.cpp
@@ -3,6 +3,8 @@
 #include <chrono>
 #include <cstring>
 #include <iostream>
+#include <limits>
+#include <sstream>
 #include <thread>
 #include <utility>
 
@@ -21,14 +23,20 @@ constexpr int64_t MAX_TIME_OUT_US = 3'000'000L;
 }  // namespace
 
 CanfdRouterBridge::CanfdRouterBridge(const std::string &can_interface,
-                                     uint8_t can_id_offset)
+                                     uint8_t can_id_offset,
+                                     bool auto_retry)
   : can_interface_(can_interface),
     can_name_("canfd_router"),
     can_extended_frame_(false),
     can_rx_block_(false),
     timeout_us_(MAX_TIME_OUT_US),
     can_id_offset_(can_id_offset),
-    pending_force_direct_(false)
+    pending_force_direct_(true),
+    force_direct_latched_(false),
+    last_router_mode_(std::numeric_limits<uint32_t>::max()),
+    auto_retry_(auto_retry),
+    last_force_direct_request_(std::chrono::steady_clock::time_point::min()),
+    min_retry_interval_(std::chrono::milliseconds(200))
 {
   using namespace std::placeholders;
   router_can_ = std::make_shared<can_device::socket_can::CanDev>(
@@ -45,6 +53,21 @@ CanfdRouterBridge::CanfdRouterBridge(const std::string &can_interface,
 void CanfdRouterBridge::request_force_direct()
 {
   pending_force_direct_.store(true);
+  force_direct_latched_.store(false);
+}
+
+void CanfdRouterBridge::set_auto_retry(bool enable)
+{
+  auto_retry_ = enable;
+  if (auto_retry_ && !force_direct_latched_.load())
+  {
+    pending_force_direct_.store(true);
+  }
+}
+
+void CanfdRouterBridge::set_status_callback(std::function<void(const std::string &)> callback)
+{
+  status_callback_ = std::move(callback);
 }
 
 void CanfdRouterBridge::register_canfd_router_device_can_filter()
@@ -65,20 +88,69 @@ void CanfdRouterBridge::handle_router_frame(std::shared_ptr<struct canfd_frame> 
     return;
   }
 
-  if (!pending_force_direct_.load())
-  {
-    return;
-  }
-
   uint32_t mode = 0U;
   std::memcpy(&mode, recv_frame->data + 4, sizeof(mode));
-  if (mode != 1U && mode != 2U)
+
+  uint32_t heartbeat = 0U;
+  std::memcpy(&heartbeat, recv_frame->data + 8, sizeof(heartbeat));
+
+  const uint32_t previous_mode = last_router_mode_.exchange(mode);
+  if (previous_mode != mode)
+  {
+    std::ostringstream oss;
+    oss << "[CanfdRouterBridge] Router mode changed from 0x"
+        << std::hex << previous_mode << " to 0x" << mode
+        << std::dec << ", heartbeat=" << heartbeat;
+    emit_status(oss.str());
+  }
+
+  if (mode == RPC_VALUE_FORCE_DIRECT)
+  {
+    if (!force_direct_latched_.exchange(true))
+    {
+      emit_status("[CanfdRouterBridge] Router entered FORCE_DIRECT mode.");
+    }
+    pending_force_direct_.store(false);
+    return;
+  }
+
+  force_direct_latched_.store(false);
+
+  const bool handshake_window = (mode == 1U || mode == 2U || mode == RPC_VALUE_READY_WAITING);
+  if (!handshake_window)
+  {
+    if (auto_retry_ && mode != previous_mode)
+    {
+      pending_force_direct_.store(true);
+    }
+    return;
+  }
+
+  bool should_request = pending_force_direct_.exchange(false);
+  if (!should_request && auto_retry_)
+  {
+    if (mode != previous_mode || mode == RPC_VALUE_READY_WAITING)
+    {
+      should_request = true;
+    }
+    else
+    {
+      const auto now = std::chrono::steady_clock::now();
+      if (now - last_force_direct_request_ >= min_retry_interval_)
+      {
+        should_request = true;
+      }
+    }
+  }
+
+  if (!should_request)
   {
     return;
   }
 
+  last_force_direct_request_ = std::chrono::steady_clock::now();
+  emit_status("[CanfdRouterBridge] Requesting FORCE_DIRECT handshake...");
   send_force_direct_sequence();
-  pending_force_direct_.store(false);
 }
 
 void CanfdRouterBridge::send_force_direct_sequence()
@@ -109,7 +181,7 @@ void CanfdRouterBridge::send_force_direct_sequence()
   }
   catch (const std::exception &ex)
   {
-    std::cerr << "[CanfdRouterBridge] Failed to request READY_WAITING: " << ex.what() << std::endl;
+    emit_status(std::string("[CanfdRouterBridge] Failed to request READY_WAITING: ") + ex.what());
     return;
   }
 
@@ -127,7 +199,7 @@ void CanfdRouterBridge::send_force_direct_sequence()
   }
   catch (const std::exception &ex)
   {
-    std::cerr << "[CanfdRouterBridge] Failed to request FORCE_DIRECT: " << ex.what() << std::endl;
+    emit_status(std::string("[CanfdRouterBridge] Failed to request FORCE_DIRECT: ") + ex.what());
   }
 }
 
@@ -136,6 +208,18 @@ uint32_t CanfdRouterBridge::get_current_time() const
   struct timeval tv;
   gettimeofday(&tv, NULL);
   return static_cast<uint32_t>(tv.tv_sec * 1000000 + tv.tv_usec);
+}
+
+void CanfdRouterBridge::emit_status(const std::string &message)
+{
+  if (status_callback_)
+  {
+    status_callback_(message);
+  }
+  else
+  {
+    std::cout << message << std::endl;
+  }
 }
 
 }  // namespace can_device

--- a/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/src/tita_robot.cpp
+++ b/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/src/tita_robot.cpp
@@ -1,0 +1,171 @@
+#include "tita_robot/tita_robot.hpp"
+
+std::vector<double> tita_robot::get_joint_q() const
+{
+  auto infos = can_receiver_->get_motors_in();
+  std::vector<double> joint;
+  for (const auto & info : *infos) {
+    joint.push_back(info.position);
+  }
+  return joint;
+}
+
+std::vector<double> tita_robot::get_joint_v() const
+{
+  auto infos = can_receiver_->get_motors_in();
+  std::vector<double> joint;
+  for (const auto & info : *infos) {
+    joint.push_back(info.velocity);
+  }
+  return joint;
+}
+
+std::vector<double> tita_robot::get_joint_t() const
+{
+  auto infos = can_receiver_->get_motors_in();
+  std::vector<double> joint;
+  for (const auto & info : *infos) {
+    joint.push_back(info.torque);
+  }
+  return joint;
+}
+
+std::vector<uint8_t> tita_robot::get_joint_status() const  // TODO: why 8
+{
+  auto infos = can_receiver_->get_motors_status();
+  std::vector<uint8_t> joint;
+  for (size_t id = 0; id < 8; id++) {
+    joint.push_back(infos->value[id]);
+  }
+  return joint;
+}
+
+std::array<double, 4> tita_robot::get_imu_quaternion() const
+{
+  auto infos = can_receiver_->get_imu_data();
+  std::array<double, 4> data;
+  for (size_t i = 0; i < 4; i++) {
+    data[i] = infos->quaternion[i];
+  }
+  return data;
+}
+
+std::array<double, 3> tita_robot::get_imu_acceleration() const
+{
+  auto infos = can_receiver_->get_imu_data();
+  std::array<double, 3> data;
+  for (size_t i = 0; i < 3; i++) {
+    data[i] = infos->accl[i];
+  }
+  return data;
+}
+
+std::array<double, 3> tita_robot::get_imu_angular_velocity() const
+{
+  auto infos = can_receiver_->get_imu_data();
+  std::array<double, 3> data;
+  for (size_t i = 0; i < 3; i++) {
+    data[i] = infos->gyro[i];
+  }
+  return data;
+}
+
+bool tita_robot::set_target_joint_t(const std::vector<double> & t)
+{
+  std::vector<can_device::motor_out> motors;
+  for (size_t id = 0; id < motor_num_; id++) {
+    can_device::motor_out motor;
+    motor.torque = t[id];
+    motor.kp = 0.0f;
+    motor.kd = 0.0f;
+    motor.velocity = 0.0f;
+    motor.position = 0.0f;
+    motors.push_back(motor);
+  }
+  return can_sender_->send_motors_can(motors);
+}
+
+bool tita_robot::set_target_joint_mit(
+  const std::vector<double> & q, const std::vector<double> & v, const std::vector<double> & kp,
+  const std::vector<double> & kd, const std::vector<double> & t)
+{
+  std::vector<can_device::motor_out> motors;
+  for (size_t id = 0; id < motor_num_; id++) {
+    can_device::motor_out motor;
+    motor.torque = t[id];
+    motor.kp = kp[id];
+    motor.kd = kd[id];
+    motor.velocity = v[id];
+    motor.position = q[id];
+    motors.push_back(motor);
+  }
+  return can_sender_->send_motors_can(motors);
+}
+
+// bool tita_robot::set_board_mode(ReadyNext mode)
+// {
+//   can_device::RpcRequest rpc_request;
+//   rpc_request.key = can_device::SET_READY_NEXT;
+//   rpc_request.value = mode;
+//   return can_sender_->send_command_can_rpc_request(rpc_request);
+// }
+
+bool tita_robot::set_motors_sdk(bool if_sdk)
+{
+  can_device::RpcRequest rpc_request;
+  rpc_request.key = can_device::SET_READY_NEXT;
+  rpc_request.value = READY_WAITING;
+  bool return_ok = can_sender_->send_command_can_rpc_request(rpc_request);
+  std::this_thread::sleep_for(std::chrono::microseconds(100));
+  if (if_sdk) {
+    rpc_request.value = FORCE_DIRECT;
+  } else {
+    rpc_request.value = AUTO_LOCOMOTION;
+  }
+  return_ok &= can_sender_->send_command_can_rpc_request(rpc_request);
+  return return_ok;
+}
+
+bool tita_robot::set_rc_input(ChannelInput input)
+{
+  can_device::ChannelInput can_input;
+  can_input.forward = input.forward;
+  can_input.yaw = input.yaw;
+  can_input.pitch = input.pitch;
+  can_input.roll = input.roll;
+  can_input.height = input.height;
+  can_input.split = input.split;
+  can_input.tilt = input.tilt;
+  can_input.forward_accel = input.forward_accel;
+  can_input.yaw_accel = input.yaw_accel;
+  return can_sender_->send_command_can_channel_input(can_input);
+}
+
+bool tita_robot::set_robot_stand(bool stand)
+{
+  can_device::RpcRequest rpc_request;
+  rpc_request.key = can_device::SET_STAND_MODE;
+  rpc_request.value = !stand ? 0x01U : 0x02U;
+  return can_sender_->send_command_can_rpc_request(rpc_request);
+}
+
+bool tita_robot::set_robot_jump(bool jump)
+{
+  can_device::RpcRequest rpc_request;
+  rpc_request.key = can_device::SET_JUMP;
+  rpc_request.value = !jump ? 0x01U : 0x02U;
+  return can_sender_->send_command_can_rpc_request(rpc_request);
+}
+
+bool tita_robot::set_robot_stop()
+{
+  can_device::RpcRequest rpc_request;
+  rpc_request.value = 0x01U;
+  rpc_request.key = can_device::SET_STAND_MODE;
+  bool return_ok = can_sender_->send_command_can_rpc_request(rpc_request);
+  std::this_thread::sleep_for(std::chrono::microseconds(200));
+  rpc_request.value = 0x02U;
+  rpc_request.key = can_device::SET_JUMP;
+  return_ok &= can_sender_->send_command_can_rpc_request(rpc_request);
+  return true;
+}

--- a/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/src/tita_robot.cpp
+++ b/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/src/tita_robot.cpp
@@ -2,6 +2,7 @@
 #include "tita_robot/canfd_router_bridge.hpp"
 
 #include <iostream>
+#include <utility>
 
 tita_robot::tita_robot(size_t num_motors,
                        const std::string &can_interface,
@@ -196,4 +197,25 @@ bool tita_robot::set_robot_stop()
   rpc_request.key = can_device::SET_JUMP;
   return_ok &= can_sender_->send_command_can_rpc_request(rpc_request);
   return true;
+}
+
+bool tita_robot::has_canfd_router() const
+{
+  return static_cast<bool>(can_router_);
+}
+
+void tita_robot::request_router_force_direct()
+{
+  if (can_router_)
+  {
+    can_router_->request_force_direct();
+  }
+}
+
+void tita_robot::set_router_status_callback(std::function<void(const std::string &)> callback)
+{
+  if (can_router_)
+  {
+    can_router_->set_status_callback(std::move(callback));
+  }
 }

--- a/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/src/tita_robot.cpp
+++ b/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/src/tita_robot.cpp
@@ -1,4 +1,7 @@
 #include "tita_robot/tita_robot.hpp"
+
+#include "tita_robot/can_receiver.hpp"
+#include "tita_robot/can_sender.hpp"
 #include "tita_robot/canfd_router_bridge.hpp"
 
 #include <iostream>
@@ -24,6 +27,8 @@ tita_robot::tita_robot(size_t num_motors,
   }
   motor_num_ = num_motors;
 }
+
+tita_robot::~tita_robot() = default;
 
 std::vector<double> tita_robot::get_joint_q() const
 {

--- a/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/src/tita_robot.cpp
+++ b/rl_sar/src/rl_sar/library/robot_interfaces/tita_robot/src/tita_robot.cpp
@@ -1,4 +1,28 @@
 #include "tita_robot/tita_robot.hpp"
+#include "tita_robot/canfd_router_bridge.hpp"
+
+#include <iostream>
+
+tita_robot::tita_robot(size_t num_motors,
+                       const std::string &can_interface,
+                       bool enable_canfd_router)
+{
+  can_receiver_ = std::make_unique<can_device::MotorsImuCanReceiveApi>(num_motors, can_interface);
+  can_sender_ = std::make_unique<can_device::MotorsCanSendApi>(num_motors, can_interface);
+  if (enable_canfd_router)
+  {
+    try
+    {
+      can_router_ = std::make_unique<can_device::CanfdRouterBridge>(can_interface);
+    }
+    catch (const std::exception &ex)
+    {
+      std::cerr << "[tita_robot] Failed to initialize CAN-FD router bridge on interface '"
+                << can_interface << "': " << ex.what() << std::endl;
+    }
+  }
+  motor_num_ = num_motors;
+}
 
 std::vector<double> tita_robot::get_joint_q() const
 {
@@ -123,6 +147,10 @@ bool tita_robot::set_motors_sdk(bool if_sdk)
     rpc_request.value = AUTO_LOCOMOTION;
   }
   return_ok &= can_sender_->send_command_can_rpc_request(rpc_request);
+  if (if_sdk && can_router_)
+  {
+    can_router_->request_force_direct();
+  }
   return return_ok;
 }
 

--- a/rl_sar/src/rl_sar/policy/titati/base.yaml
+++ b/rl_sar/src/rl_sar/policy/titati/base.yaml
@@ -56,3 +56,6 @@ titati:                                           # 机器人名称命名空间
 
   joint_mapping: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
                                                  # 动作/观测数组索引与物理关节的映射。这里是顺序一致 (0~15)
+
+  can_interface: "can0"                          # Titati CANFD 物理接口名称，默认使用 can0
+  use_canfd_router: true                         # 四轮足串联场景需要监听路由器心跳并下发 FORCE_DIRECT

--- a/rl_sar/src/rl_sar/src/rl_real_titati.cpp
+++ b/rl_sar/src/rl_sar/src/rl_real_titati.cpp
@@ -5,6 +5,10 @@
 
 #include "rl_real_titati.hpp"
 
+#include <algorithm>
+#include <chrono>
+#include <thread>
+
 RL_Real::RL_Real()
 #if defined(USE_ROS2) && defined(USE_ROS)
     : rclcpp::Node("rl_real_node")
@@ -24,6 +28,8 @@ RL_Real::RL_Real()
     this->ang_vel_type = "ang_vel_body";
     this->robot_name = "titati";
     this->ReadYamlBase(this->robot_name);
+    this->hardware_fixed_kp_ = this->TensorToHardwareVector(this->params.fixed_kp);
+    this->hardware_fixed_kd_ = this->TensorToHardwareVector(this->params.fixed_kd);
 
     // auto load FSM by robot_name
     if (FSMManager::GetInstance().IsTypeSupported(this->robot_name))
@@ -50,14 +56,7 @@ RL_Real::RL_Real()
         this->params.use_canfd_router);
     if (this->titati_hw)
     {
-        if (this->titati_hw->set_motors_sdk(true))
-        {
-            std::cout << LOGGER::INFO << "Motors switched to SDK control mode." << std::endl;
-        }
-        else
-        {
-            std::cout << LOGGER::WARNING << "Failed to switch motors to SDK control mode." << std::endl;
-        }
+        this->EnableSdkControl();
     }
 
     this->InitOutputs();
@@ -95,6 +94,7 @@ RL_Real::~RL_Real()
 #endif
     if (this->titati_hw)
     {
+        this->SendHoldPositionCommand();
         this->titati_hw->set_motors_sdk(false);
     }
     std::cout << LOGGER::INFO << "RL_Real exit" << std::endl;
@@ -321,6 +321,146 @@ torch::Tensor RL_Real::Forward()
     {
         return actions;
     }
+}
+
+bool RL_Real::EnableSdkControl()
+{
+    if (!this->titati_hw)
+    {
+        return false;
+    }
+
+    const int motor_count = this->params.num_of_dofs;
+    if (motor_count <= 0)
+    {
+        std::cout << LOGGER::ERROR << "Invalid motor count configured for Titati hardware." << std::endl;
+        return false;
+    }
+
+    if (static_cast<int>(this->hardware_fixed_kp_.size()) != motor_count)
+    {
+        this->hardware_fixed_kp_.assign(motor_count, 0.0);
+    }
+    if (static_cast<int>(this->hardware_fixed_kd_.size()) != motor_count)
+    {
+        this->hardware_fixed_kd_.assign(motor_count, 0.0);
+    }
+
+    std::vector<double> dq(motor_count, 0.0);
+    std::vector<double> tau(motor_count, 0.0);
+
+    constexpr int max_attempts = 5;
+    for (int attempt = 1; attempt <= max_attempts; ++attempt)
+    {
+        if (this->titati_hw->set_motors_sdk(true))
+        {
+            auto q = this->titati_hw->get_joint_q();
+            if (static_cast<int>(q.size()) != motor_count)
+            {
+                q.resize(motor_count, 0.0);
+            }
+
+            if (!this->titati_hw->set_target_joint_mit(q, dq, this->hardware_fixed_kp_, this->hardware_fixed_kd_, tau))
+            {
+                std::cout << LOGGER::WARNING << "Failed to send hold command after enabling SDK control." << std::endl;
+            }
+            else
+            {
+                std::cout << LOGGER::INFO << "Applied hold command after enabling SDK control." << std::endl;
+            }
+
+            std::cout << LOGGER::INFO << "Motors switched to SDK control mode." << std::endl;
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            return true;
+        }
+
+        std::cout << LOGGER::WARNING
+                  << "Failed to switch motors to SDK control mode (attempt " << attempt
+                  << "/" << max_attempts << ")." << std::endl;
+        this->titati_hw->set_motors_sdk(false);
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    }
+
+    std::cout << LOGGER::ERROR
+              << "Unable to switch motors to SDK control after " << max_attempts
+              << " attempts. Please verify CAN routing and power." << std::endl;
+    return false;
+}
+
+std::vector<double> RL_Real::TensorToHardwareVector(const torch::Tensor &tensor) const
+{
+    const int motor_count = this->params.num_of_dofs;
+    std::vector<double> result(motor_count, 0.0);
+    if (!tensor.defined() || tensor.numel() == 0 || motor_count <= 0)
+    {
+        return result;
+    }
+
+    const auto mapping_size = static_cast<int>(this->params.joint_mapping.size());
+    if (mapping_size == 0)
+    {
+        return result;
+    }
+
+    torch::Tensor flattened = tensor.view({-1}).to(torch::kCPU).to(torch::kDouble);
+    const auto available = std::min<int>(flattened.size(0), mapping_size);
+    const double *data = flattened.data_ptr<double>();
+
+    for (int idx = 0; idx < available; ++idx)
+    {
+        const int hw_index = this->params.joint_mapping[idx];
+        if (hw_index >= 0 && hw_index < motor_count)
+        {
+            result[hw_index] = data[idx];
+        }
+    }
+
+    return result;
+}
+
+void RL_Real::SendHoldPositionCommand()
+{
+    if (!this->titati_hw)
+    {
+        return;
+    }
+
+    const int motor_count = this->params.num_of_dofs;
+    if (motor_count <= 0)
+    {
+        return;
+    }
+
+    auto q = this->titati_hw->get_joint_q();
+    if (static_cast<int>(q.size()) != motor_count)
+    {
+        q.resize(motor_count, 0.0);
+    }
+
+    if (static_cast<int>(this->hardware_fixed_kp_.size()) != motor_count)
+    {
+        this->hardware_fixed_kp_.assign(motor_count, 0.0);
+    }
+    if (static_cast<int>(this->hardware_fixed_kd_.size()) != motor_count)
+    {
+        this->hardware_fixed_kd_.assign(motor_count, 0.0);
+    }
+
+    std::vector<double> dq(motor_count, 0.0);
+    std::vector<double> tau(motor_count, 0.0);
+
+    if (!this->titati_hw->set_target_joint_mit(q, dq, this->hardware_fixed_kp_, this->hardware_fixed_kd_, tau))
+    {
+        std::cout << LOGGER::WARNING << "Failed to send hold command before disabling SDK control." << std::endl;
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    if (!this->titati_hw->set_target_joint_t(tau))
+    {
+        std::cout << LOGGER::WARNING << "Failed to send zero torque command before disabling SDK control." << std::endl;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
 }
 
 void RL_Real::Plot()

--- a/rl_sar/src/rl_sar/src/rl_real_titati.cpp
+++ b/rl_sar/src/rl_sar/src/rl_real_titati.cpp
@@ -44,7 +44,10 @@ RL_Real::RL_Real()
     torch::set_num_threads(4);
 
     // init robot interface
-    this->titati_hw = std::make_unique<tita_robot>(this->params.num_of_dofs);
+    this->titati_hw = std::make_unique<tita_robot>(
+        this->params.num_of_dofs,
+        this->params.can_interface,
+        this->params.use_canfd_router);
     if (this->titati_hw)
     {
         if (this->titati_hw->set_motors_sdk(true))

--- a/rl_sar/src/rl_sar/src/rl_real_titati.cpp
+++ b/rl_sar/src/rl_sar/src/rl_real_titati.cpp
@@ -1,0 +1,380 @@
+/*
+* Copyright (c) 2024-2025 Ziqi Fan
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+#include "rl_real_titati.hpp"
+
+RL_Real::RL_Real()
+#if defined(USE_ROS2) && defined(USE_ROS)
+    : rclcpp::Node("rl_real_node")
+#endif
+{
+#if defined(USE_ROS1) && defined(USE_ROS)
+    ros::NodeHandle nh;
+    this->cmd_vel_subscriber = nh.subscribe<geometry_msgs::Twist>("/cmd_vel", 10, &RL_Real::CmdvelCallback, this);
+#elif defined(USE_ROS2) && defined(USE_ROS)
+    this->cmd_vel_subscriber = this->create_subscription<geometry_msgs::msg::Twist>(
+        "/cmd_vel", rclcpp::SystemDefaultsQoS(),
+        [this] (const geometry_msgs::msg::Twist::SharedPtr msg) {this->CmdvelCallback(msg);}
+    );
+#endif
+
+    // read params from yaml
+    this->ang_vel_type = "ang_vel_body";
+    this->robot_name = "titati";
+    this->ReadYamlBase(this->robot_name);
+
+    // auto load FSM by robot_name
+    if (FSMManager::GetInstance().IsTypeSupported(this->robot_name))
+    {
+        auto fsm_ptr = FSMManager::GetInstance().CreateFSM(this->robot_name, this);
+        if (fsm_ptr)
+        {
+            this->fsm = *fsm_ptr;
+        }
+    }
+    else
+    {
+        std::cout << LOGGER::ERROR << "No FSM registered for robot: " << this->robot_name << std::endl;
+    }
+
+    // init torch
+    torch::autograd::GradMode::set_enabled(false);
+    torch::set_num_threads(4);
+
+    // init robot interface
+    this->titati_hw = std::make_unique<tita_robot>(this->params.num_of_dofs);
+    if (this->titati_hw)
+    {
+        if (this->titati_hw->set_motors_sdk(true))
+        {
+            std::cout << LOGGER::INFO << "Motors switched to SDK control mode." << std::endl;
+        }
+        else
+        {
+            std::cout << LOGGER::WARNING << "Failed to switch motors to SDK control mode." << std::endl;
+        }
+    }
+
+    this->InitOutputs();
+    this->InitControl();
+
+    // loop
+    this->loop_keyboard = std::make_shared<LoopFunc>("loop_keyboard", 0.05, std::bind(&RL_Real::KeyboardInterface, this));
+    this->loop_control = std::make_shared<LoopFunc>("loop_control", this->params.dt, std::bind(&RL_Real::RobotControl, this));
+    this->loop_rl = std::make_shared<LoopFunc>("loop_rl", this->params.dt * this->params.decimation, std::bind(&RL_Real::RunModel, this));
+    this->loop_keyboard->start();
+    this->loop_control->start();
+    this->loop_rl->start();
+
+#ifdef PLOT
+    this->plot_t = std::vector<int>(this->plot_size, 0);
+    this->plot_real_joint_pos.resize(this->params.num_of_dofs);
+    this->plot_target_joint_pos.resize(this->params.num_of_dofs);
+    for (auto &vector : this->plot_real_joint_pos) { vector = std::vector<double>(this->plot_size, 0); }
+    for (auto &vector : this->plot_target_joint_pos) { vector = std::vector<double>(this->plot_size, 0); }
+    this->loop_plot = std::make_shared<LoopFunc>("loop_plot", 0.002, std::bind(&RL_Real::Plot, this));
+    this->loop_plot->start();
+#endif
+#ifdef CSV_LOGGER
+    this->CSVInit(this->robot_name);
+#endif
+}
+
+RL_Real::~RL_Real()
+{
+    this->loop_keyboard->shutdown();
+    this->loop_control->shutdown();
+    this->loop_rl->shutdown();
+#ifdef PLOT
+    this->loop_plot->shutdown();
+#endif
+    if (this->titati_hw)
+    {
+        this->titati_hw->set_motors_sdk(false);
+    }
+    std::cout << LOGGER::INFO << "RL_Real exit" << std::endl;
+}
+
+void RL_Real::GetState(RobotState<double> *state)
+{
+    if (!this->titati_hw)
+    {
+        return;
+    }
+    auto q = this->titati_hw->get_joint_q();
+    auto dq = this->titati_hw->get_joint_v();
+    auto tau = this->titati_hw->get_joint_t();
+    auto quat = this->titati_hw->get_imu_quaternion();
+    auto acc = this->titati_hw->get_imu_acceleration();
+    auto gyro = this->titati_hw->get_imu_angular_velocity();
+
+    if (quat.size() == 4)
+    {
+        state->imu.quaternion[0] = quat[3]; // w
+        state->imu.quaternion[1] = quat[0]; // x
+        state->imu.quaternion[2] = quat[1]; // y
+        state->imu.quaternion[3] = quat[2]; // z
+    }
+
+    for (int i = 0; i < 3; ++i)
+    {
+        state->imu.accelerometer[i] = acc[i];
+        state->imu.gyroscope[i] = gyro[i];
+    }
+
+    for (int i = 0; i < this->params.num_of_dofs; ++i)
+    {
+        int hw_index = this->params.joint_mapping[i];
+        if (hw_index >= 0 && hw_index < static_cast<int>(q.size()))
+        {
+            state->motor_state.q[i] = q[hw_index];
+            state->motor_state.dq[i] = dq[hw_index];
+            state->motor_state.tau_est[i] = tau[hw_index];
+        }
+    }
+}
+
+void RL_Real::SetCommand(const RobotCommand<double> *command)
+{
+    if (!this->titati_hw)
+    {
+        return;
+    }
+    std::vector<double> q_cmd(this->params.num_of_dofs, 0.0);
+    std::vector<double> dq_cmd(this->params.num_of_dofs, 0.0);
+    std::vector<double> kp_cmd(this->params.num_of_dofs, 0.0);
+    std::vector<double> kd_cmd(this->params.num_of_dofs, 0.0);
+    std::vector<double> tau_cmd(this->params.num_of_dofs, 0.0);
+
+    for (int i = 0; i < this->params.num_of_dofs; ++i)
+    {
+        int hw_index = this->params.joint_mapping[i];
+        if (hw_index >= 0 && hw_index < this->params.num_of_dofs)
+        {
+            q_cmd[hw_index] = command->motor_command.q[i];
+            dq_cmd[hw_index] = command->motor_command.dq[i];
+            kp_cmd[hw_index] = command->motor_command.kp[i];
+            kd_cmd[hw_index] = command->motor_command.kd[i];
+            tau_cmd[hw_index] = command->motor_command.tau[i];
+        }
+    }
+
+    this->titati_hw->set_target_joint_mit(q_cmd, dq_cmd, kp_cmd, kd_cmd, tau_cmd);
+}
+
+void RL_Real::RobotControl()
+{
+    this->motiontime++;
+
+    if (this->control.current_keyboard == Input::Keyboard::W)
+    {
+        this->control.x += 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::S)
+    {
+        this->control.x -= 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::A)
+    {
+        this->control.y += 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::D)
+    {
+        this->control.y -= 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::Q)
+    {
+        this->control.yaw += 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::E)
+    {
+        this->control.yaw -= 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::Space)
+    {
+        this->control.x = 0;
+        this->control.y = 0;
+        this->control.yaw = 0;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::M || this->control.current_gamepad == Input::Gamepad::LB_A)
+    {
+        if (this->titati_hw->set_motors_sdk(true))
+        {
+            std::cout << std::endl << LOGGER::INFO << "Motors enabled (SDK)." << std::endl;
+        }
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::K || this->control.current_gamepad == Input::Gamepad::LB_B)
+    {
+        if (this->titati_hw->set_motors_sdk(false))
+        {
+            std::cout << std::endl << LOGGER::INFO << "Motors disabled (MCU)." << std::endl;
+        }
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::N || this->control.current_gamepad == Input::Gamepad::X)
+    {
+        this->control.navigation_mode = !this->control.navigation_mode;
+        std::cout << std::endl << LOGGER::INFO << "Navigation mode: " << (this->control.navigation_mode ? "ON" : "OFF") << std::endl;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_gamepad == Input::Gamepad::LB_RB)
+    {
+        this->titati_hw->set_robot_stop();
+        this->control.current_gamepad = this->control.last_gamepad;
+    }
+
+    this->GetState(&this->robot_state);
+    this->StateController(&this->robot_state, &this->robot_command);
+    this->SetCommand(&this->robot_command);
+}
+
+void RL_Real::RunModel()
+{
+    if (this->rl_init_done)
+    {
+        this->episode_length_buf += 1;
+        this->obs.ang_vel = torch::tensor(this->robot_state.imu.gyroscope).unsqueeze(0);
+        if (this->control.navigation_mode)
+        {
+#if !defined(USE_CMAKE) && defined(USE_ROS)
+            this->obs.commands = torch::tensor({{this->cmd_vel.linear.x, this->cmd_vel.linear.y, this->cmd_vel.angular.z}});
+#endif
+        }
+        else
+        {
+            this->obs.commands = torch::tensor({{this->control.x, this->control.y, this->control.yaw}});
+        }
+        this->obs.base_quat = torch::tensor(this->robot_state.imu.quaternion).unsqueeze(0);
+        this->obs.dof_pos = torch::tensor(this->robot_state.motor_state.q).narrow(0, 0, this->params.num_of_dofs).unsqueeze(0);
+        this->obs.dof_vel = torch::tensor(this->robot_state.motor_state.dq).narrow(0, 0, this->params.num_of_dofs).unsqueeze(0);
+
+        this->obs.actions = this->Forward();
+        this->ComputeOutput(this->obs.actions, this->output_dof_pos, this->output_dof_vel, this->output_dof_tau);
+
+        if (this->output_dof_pos.defined() && this->output_dof_pos.numel() > 0)
+        {
+            output_dof_pos_queue.push(this->output_dof_pos);
+        }
+        if (this->output_dof_vel.defined() && this->output_dof_vel.numel() > 0)
+        {
+            output_dof_vel_queue.push(this->output_dof_vel);
+        }
+        if (this->output_dof_tau.defined() && this->output_dof_tau.numel() > 0)
+        {
+            output_dof_tau_queue.push(this->output_dof_tau);
+        }
+
+        this->TorqueProtect(this->output_dof_tau);
+
+#ifdef CSV_LOGGER
+        torch::Tensor tau_est = torch::tensor(this->robot_state.motor_state.tau_est).unsqueeze(0);
+        this->CSVLogger(this->output_dof_tau, tau_est, this->obs.dof_pos, this->output_dof_pos, this->obs.dof_vel);
+#endif
+    }
+}
+
+torch::Tensor RL_Real::Forward()
+{
+    torch::autograd::GradMode::set_enabled(false);
+
+    torch::Tensor clamped_obs = this->ComputeObservation();
+
+    torch::Tensor actions;
+    if (!this->params.observations_history.empty())
+    {
+        this->history_obs_buf.insert(clamped_obs);
+        this->history_obs = this->history_obs_buf.get_obs_vec(this->params.observations_history);
+        if (this->fsm.current_state_->GetStateName() != "RLFSMStateRL_LocomotionLab")
+        {
+            torch::Tensor myTensor = history_obs.view({1,10,57});
+            actions = this->model.forward({clamped_obs, myTensor}).toTensor();
+        }
+        else
+        {
+            actions = this->model.forward({this->history_obs}).toTensor();
+        }
+
+    }
+    else
+    {
+        actions = this->model.forward({clamped_obs}).toTensor();
+    }
+
+    if (this->params.clip_actions_upper.numel() != 0 && this->params.clip_actions_lower.numel() != 0)
+    {
+        return torch::clamp(actions, this->params.clip_actions_lower, this->params.clip_actions_upper);
+    }
+    else
+    {
+        return actions;
+    }
+}
+
+void RL_Real::Plot()
+{
+    this->plot_t.erase(this->plot_t.begin());
+    this->plot_t.push_back(this->motiontime);
+    plt::cla();
+    plt::clf();
+    for (int i = 0; i < this->params.num_of_dofs; ++i)
+    {
+        this->plot_real_joint_pos[i].erase(this->plot_real_joint_pos[i].begin());
+        this->plot_target_joint_pos[i].erase(this->plot_target_joint_pos[i].begin());
+        this->plot_real_joint_pos[i].push_back(this->robot_state.motor_state.q[i]);
+        this->plot_target_joint_pos[i].push_back(this->robot_command.motor_command.q[i]);
+        plt::subplot(this->params.num_of_dofs, 1, i + 1);
+        plt::named_plot("_real_joint_pos", this->plot_t, this->plot_real_joint_pos[i], "r");
+        plt::named_plot("_target_joint_pos", this->plot_t, this->plot_target_joint_pos[i], "b");
+        plt::xlim(this->plot_t.front(), this->plot_t.back());
+    }
+    plt::pause(0.0001);
+}
+
+#if !defined(USE_CMAKE) && defined(USE_ROS)
+void RL_Real::CmdvelCallback(
+#if defined(USE_ROS1) && defined(USE_ROS)
+    const geometry_msgs::Twist::ConstPtr &msg
+#elif defined(USE_ROS2) && defined(USE_ROS)
+    const geometry_msgs::msg::Twist::SharedPtr msg
+#endif
+)
+{
+    this->cmd_vel = *msg;
+}
+#endif
+
+#if defined(USE_ROS1) && defined(USE_ROS)
+void signalHandler(int signum)
+{
+    ros::shutdown();
+    exit(0);
+}
+#endif
+
+int main(int argc, char **argv)
+{
+#if defined(USE_ROS1) && defined(USE_ROS)
+    signal(SIGINT, signalHandler);
+    ros::init(argc, argv, "rl_sar");
+    RL_Real rl_sar;
+    ros::spin();
+#elif defined(USE_ROS2) && defined(USE_ROS)
+    rclcpp::init(argc, argv);
+    rclcpp::spin(std::make_shared<RL_Real>());
+    rclcpp::shutdown();
+#elif defined(USE_CMAKE) || !defined(USE_ROS)
+    RL_Real rl_sar;
+    while (1) { sleep(10); }
+#endif
+    return 0;
+}

--- a/rl_sar/src/rl_sar/src/rl_titati_motor_test.cpp
+++ b/rl_sar/src/rl_sar/src/rl_titati_motor_test.cpp
@@ -10,9 +10,10 @@
 #include <cstddef>
 #include <cctype>
 #include <exception>
-#include <stdexcept>
 #include <iomanip>
 #include <iostream>
+#include <sstream>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <vector>
@@ -237,7 +238,8 @@ MotorTestConfig load_motor_config(const std::string &path)
 bool enable_sdk_with_retry(tita_robot &robot,
                            int motor_count,
                            const std::vector<double> &kp,
-                           const std::vector<double> &kd)
+                           const std::vector<double> &kd,
+                           bool use_router)
 {
     std::vector<double> dq(motor_count, 0.0);
     std::vector<double> tau(motor_count, 0.0);
@@ -247,6 +249,12 @@ bool enable_sdk_with_retry(tita_robot &robot,
     {
         if (robot.set_motors_sdk(true))
         {
+            if (use_router)
+            {
+                std::cout << LOG_INFO
+                          << "Requesting CAN-FD router FORCE_DIRECT handshake after enabling SDK control." << std::endl;
+                robot.request_router_force_direct();
+            }
             auto q = robot.get_joint_q();
             if (static_cast<int>(q.size()) != motor_count)
             {
@@ -322,6 +330,43 @@ struct MotorScope
 };
 
 } // namespace
+
+void print_all_motor_feedback(const MotorTestConfig &config,
+                              const std::vector<double> &q,
+                              const std::vector<double> &dq,
+                              const std::vector<double> &tau,
+                              const std::vector<uint8_t> &status,
+                              int active_motor)
+{
+    std::cout << std::setfill(' ');
+    std::cout << LOG_INFO
+              << "  * idx | joint_name       |     q(rad) |   dq(rad/s) |    tau(Nm) | status" << std::endl;
+
+    for (int idx = 0; idx < config.num_dofs; ++idx)
+    {
+        const auto hw_index = static_cast<std::size_t>(idx);
+        const double q_val = hw_index < q.size() ? q[hw_index] : 0.0;
+        const double dq_val = hw_index < dq.size() ? dq[hw_index] : 0.0;
+        const double tau_val = hw_index < tau.size() ? tau[hw_index] : 0.0;
+
+        std::string status_str = "-";
+        if (hw_index < status.size())
+        {
+            std::ostringstream status_stream;
+            status_stream << "0x" << std::uppercase << std::hex << std::setw(2) << std::setfill('0')
+                          << static_cast<int>(status[hw_index]);
+            status_str = status_stream.str();
+        }
+
+        std::cout << LOG_INFO << "  " << (idx == active_motor ? '*' : ' ') << ' '
+                  << std::setw(2) << idx << " | ";
+        std::cout << std::left << std::setw(18) << config.joint_names_hw[hw_index] << std::right;
+        std::cout << " | " << std::setw(11) << q_val
+                  << " | " << std::setw(12) << dq_val
+                  << " | " << std::setw(11) << tau_val
+                  << " | " << std::setw(6) << status_str << std::setfill(' ') << std::endl;
+    }
+}
 
 int main(int argc, char **argv)
 {
@@ -407,7 +452,20 @@ int main(int argc, char **argv)
     tita_robot robot(static_cast<std::size_t>(config.num_dofs), options.interface, use_router);
     MotorScope guard{&robot, config.num_dofs, &config.fixed_kp_hw, &config.fixed_kd_hw};
 
-    if (!enable_sdk_with_retry(robot, config.num_dofs, config.fixed_kp_hw, config.fixed_kd_hw))
+    if (use_router && !robot.has_canfd_router())
+    {
+        std::cout << LOG_WARNING
+                  << "CAN-FD router handshake requested but the bridge is unavailable; proceeding without router support." << std::endl;
+    }
+
+    if (robot.has_canfd_router())
+    {
+        robot.set_router_status_callback([](const std::string &message) {
+            std::cout << LOG_INFO << message << std::endl;
+        });
+    }
+
+    if (!enable_sdk_with_retry(robot, config.num_dofs, config.fixed_kp_hw, config.fixed_kd_hw, use_router))
     {
         std::cerr << LOG_ERROR << "Cannot continue without SDK control." << std::endl;
         return 1;
@@ -492,6 +550,7 @@ int main(int argc, char **argv)
                 auto q_feedback = robot.get_joint_q();
                 auto dq_feedback = robot.get_joint_v();
                 auto tau_feedback = robot.get_joint_t();
+                auto status_feedback = robot.get_joint_status();
                 if (static_cast<int>(q_feedback.size()) != config.num_dofs)
                 {
                     q_feedback.resize(static_cast<std::size_t>(config.num_dofs), 0.0);
@@ -504,10 +563,7 @@ int main(int argc, char **argv)
                 {
                     tau_feedback.resize(static_cast<std::size_t>(config.num_dofs), 0.0);
                 }
-
-                std::cout << LOG_INFO << "  feedback q=" << q_feedback[static_cast<std::size_t>(hw_index)]
-                          << " rad, dq=" << dq_feedback[static_cast<std::size_t>(hw_index)]
-                          << " rad/s, tau=" << tau_feedback[static_cast<std::size_t>(hw_index)] << " Nm" << std::endl;
+                print_all_motor_feedback(config, q_feedback, dq_feedback, tau_feedback, status_feedback, hw_index);
                 next_log = now + log_interval;
             }
 

--- a/rl_sar/src/rl_sar/src/rl_titati_motor_test.cpp
+++ b/rl_sar/src/rl_sar/src/rl_titati_motor_test.cpp
@@ -1,0 +1,555 @@
+#include "tita_robot/tita_robot.hpp"
+
+#include <yaml-cpp/yaml.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <csignal>
+#include <cstddef>
+#include <cctype>
+#include <exception>
+#include <stdexcept>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+
+constexpr const char *LOG_INFO = "\033[0;37m[INFO]\033[0m ";
+constexpr const char *LOG_WARNING = "\033[0;33m[WARNING]\033[0m ";
+constexpr const char *LOG_ERROR = "\033[0;31m[ERROR]\033[0m ";
+
+std::atomic<bool> g_running{true};
+
+void handle_signal(int)
+{
+    g_running.store(false);
+}
+
+void print_usage(const char *program)
+{
+    std::cout << "Usage: " << program
+              << " [--interface canX] [--config path] [--mode mit|torque]" << std::endl;
+    std::cout << "             [--amplitude value] [--hold seconds] [--settle seconds]" << std::endl;
+    std::cout << "             [--router|--no-router]" << std::endl;
+    std::cout << std::endl;
+    std::cout << "Options:" << std::endl;
+    std::cout << "  --interface, -i   CAN interface name (default: use config or can0)" << std::endl;
+    std::cout << "  --config, -c      Path to Titati base.yaml (default: policy/titati/base.yaml)" << std::endl;
+    std::cout << "  --mode, -m        Command mode: 'mit' (default) or 'torque'" << std::endl;
+    std::cout << "  --amplitude, -a   Command amplitude (radians for MIT, Nm for torque)" << std::endl;
+    std::cout << "  --hold            Time in seconds to hold the command (default: 1.0)" << std::endl;
+    std::cout << "  --settle          Time in seconds to settle back to neutral (default: 0.5)" << std::endl;
+    std::cout << "  --router          Force enabling the CAN-FD router handshake" << std::endl;
+    std::cout << "  --no-router       Disable the CAN-FD router handshake" << std::endl;
+    std::cout << "  --help, -h        Show this message" << std::endl;
+}
+
+enum class TestMode
+{
+    MIT,
+    Torque
+};
+
+struct ProgramOptions
+{
+    std::string interface = "";
+    std::string config_path = "policy/titati/base.yaml";
+    std::string mode = "mit";
+    double amplitude = 0.05;
+    double hold_seconds = 1.0;
+    double settle_seconds = 0.5;
+    int router_override = -1; // -1 = use config, 0 = disabled, 1 = enabled
+    bool interface_overridden = false;
+};
+
+bool parse_options(int argc, char **argv, ProgramOptions &options, bool &show_usage)
+{
+    for (int idx = 1; idx < argc; ++idx)
+    {
+        const std::string arg = argv[idx];
+        if ((arg == "--interface" || arg == "-i") && idx + 1 < argc)
+        {
+            options.interface = argv[++idx];
+            options.interface_overridden = true;
+        }
+        else if ((arg == "--config" || arg == "-c") && idx + 1 < argc)
+        {
+            options.config_path = argv[++idx];
+        }
+        else if ((arg == "--mode" || arg == "-m") && idx + 1 < argc)
+        {
+            options.mode = argv[++idx];
+        }
+        else if ((arg == "--amplitude" || arg == "-a") && idx + 1 < argc)
+        {
+            try
+            {
+                options.amplitude = std::stod(argv[++idx]);
+            }
+            catch (const std::exception &ex)
+            {
+                std::cerr << LOG_ERROR << "Invalid amplitude value: " << ex.what() << std::endl;
+                return false;
+            }
+        }
+        else if (arg == "--hold" && idx + 1 < argc)
+        {
+            try
+            {
+                options.hold_seconds = std::stod(argv[++idx]);
+            }
+            catch (const std::exception &ex)
+            {
+                std::cerr << LOG_ERROR << "Invalid hold duration: " << ex.what() << std::endl;
+                return false;
+            }
+        }
+        else if (arg == "--settle" && idx + 1 < argc)
+        {
+            try
+            {
+                options.settle_seconds = std::stod(argv[++idx]);
+            }
+            catch (const std::exception &ex)
+            {
+                std::cerr << LOG_ERROR << "Invalid settle duration: " << ex.what() << std::endl;
+                return false;
+            }
+        }
+        else if (arg == "--router")
+        {
+            options.router_override = 1;
+        }
+        else if (arg == "--no-router")
+        {
+            options.router_override = 0;
+        }
+        else if (arg == "--help" || arg == "-h")
+        {
+            show_usage = true;
+            return true;
+        }
+        else
+        {
+            std::cerr << LOG_ERROR << "Unknown argument '" << arg << "'." << std::endl;
+            return false;
+        }
+    }
+
+    return true;
+}
+
+template <typename T>
+std::vector<T> reorder_to_hardware(const std::vector<T> &rl_values,
+                                   const std::vector<int> &mapping,
+                                   std::size_t motor_count,
+                                   const T &default_value)
+{
+    std::vector<T> result(motor_count, default_value);
+    for (std::size_t rl_index = 0; rl_index < rl_values.size() && rl_index < mapping.size(); ++rl_index)
+    {
+        const int hw_index = mapping[rl_index];
+        if (hw_index >= 0 && hw_index < static_cast<int>(motor_count))
+        {
+            result[static_cast<std::size_t>(hw_index)] = rl_values[rl_index];
+        }
+    }
+    return result;
+}
+
+std::vector<std::string> reorder_names_to_hardware(const std::vector<std::string> &rl_names,
+                                                   const std::vector<int> &mapping,
+                                                   std::size_t motor_count)
+{
+    std::vector<std::string> result(motor_count);
+    for (std::size_t idx = 0; idx < motor_count; ++idx)
+    {
+        result[idx] = "motor_" + std::to_string(idx);
+    }
+    for (std::size_t rl_index = 0; rl_index < rl_names.size() && rl_index < mapping.size(); ++rl_index)
+    {
+        const int hw_index = mapping[rl_index];
+        if (hw_index >= 0 && hw_index < static_cast<int>(motor_count))
+        {
+            result[static_cast<std::size_t>(hw_index)] = rl_names[rl_index];
+        }
+    }
+    return result;
+}
+
+struct MotorTestConfig
+{
+    int num_dofs = 0;
+    std::vector<int> joint_mapping;
+    std::vector<std::string> joint_names_hw;
+    std::vector<double> fixed_kp_hw;
+    std::vector<double> fixed_kd_hw;
+    std::vector<double> torque_limits_hw;
+    bool use_canfd_router = true;
+    std::string can_interface = "can0";
+};
+
+MotorTestConfig load_motor_config(const std::string &path)
+{
+    YAML::Node root = YAML::LoadFile(path);
+    if (!root["titati"])
+    {
+        throw std::runtime_error("Missing 'titati' namespace in config: " + path);
+    }
+
+    YAML::Node node = root["titati"];
+
+    MotorTestConfig config;
+    config.num_dofs = node["num_of_dofs"].as<int>();
+    config.joint_mapping = node["joint_mapping"].as<std::vector<int>>();
+    const auto joint_names = node["joint_names"].as<std::vector<std::string>>();
+    const auto fixed_kp = node["fixed_kp"].as<std::vector<double>>();
+    const auto fixed_kd = node["fixed_kd"].as<std::vector<double>>();
+    const auto torque_limits = node["torque_limits"].as<std::vector<double>>();
+
+    config.joint_names_hw = reorder_names_to_hardware(joint_names, config.joint_mapping, config.num_dofs);
+    config.fixed_kp_hw = reorder_to_hardware(fixed_kp, config.joint_mapping, config.num_dofs, 0.0);
+    config.fixed_kd_hw = reorder_to_hardware(fixed_kd, config.joint_mapping, config.num_dofs, 0.0);
+    config.torque_limits_hw = reorder_to_hardware(torque_limits, config.joint_mapping, config.num_dofs, 0.0);
+    if (node["use_canfd_router"])
+    {
+        config.use_canfd_router = node["use_canfd_router"].as<bool>();
+    }
+    else
+    {
+        config.use_canfd_router = config.num_dofs > 8;
+    }
+
+    if (node["can_interface"])
+    {
+        config.can_interface = node["can_interface"].as<std::string>();
+    }
+
+    return config;
+}
+
+bool enable_sdk_with_retry(tita_robot &robot,
+                           int motor_count,
+                           const std::vector<double> &kp,
+                           const std::vector<double> &kd)
+{
+    std::vector<double> dq(motor_count, 0.0);
+    std::vector<double> tau(motor_count, 0.0);
+
+    constexpr int max_attempts = 5;
+    for (int attempt = 1; attempt <= max_attempts; ++attempt)
+    {
+        if (robot.set_motors_sdk(true))
+        {
+            auto q = robot.get_joint_q();
+            if (static_cast<int>(q.size()) != motor_count)
+            {
+                q.resize(static_cast<std::size_t>(motor_count), 0.0);
+            }
+
+            if (!robot.set_target_joint_mit(q, dq, kp, kd, tau))
+            {
+                std::cerr << LOG_WARNING << "Failed to send hold command after enabling SDK control." << std::endl;
+            }
+            else
+            {
+                std::cout << LOG_INFO << "Applied hold command after enabling SDK control." << std::endl;
+            }
+
+            std::cout << LOG_INFO << "Motors switched to SDK control mode." << std::endl;
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            return true;
+        }
+
+        std::cerr << LOG_WARNING << "Failed to switch motors to SDK control (attempt "
+                  << attempt << "/" << max_attempts << ")." << std::endl;
+        robot.set_motors_sdk(false);
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    }
+
+    std::cerr << LOG_ERROR << "Unable to switch motors to SDK control after "
+              << max_attempts << " attempts." << std::endl;
+    return false;
+}
+
+struct MotorScope
+{
+    tita_robot *robot = nullptr;
+    int motor_count = 0;
+    const std::vector<double> *kp = nullptr;
+    const std::vector<double> *kd = nullptr;
+
+    ~MotorScope()
+    {
+        if (!robot || motor_count <= 0)
+        {
+            return;
+        }
+
+        std::vector<double> dq(static_cast<std::size_t>(motor_count), 0.0);
+        std::vector<double> tau(static_cast<std::size_t>(motor_count), 0.0);
+
+        try
+        {
+            auto q = robot->get_joint_q();
+            if (static_cast<int>(q.size()) != motor_count)
+            {
+                q.resize(static_cast<std::size_t>(motor_count), 0.0);
+            }
+
+            if (kp && kd && kp->size() == dq.size() && kd->size() == dq.size())
+            {
+                robot->set_target_joint_mit(q, dq, *kp, *kd, tau);
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            }
+
+            robot->set_target_joint_t(tau);
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+        catch (...)
+        {
+            // Ignore cleanup errors.
+        }
+
+        robot->set_motors_sdk(false);
+    }
+};
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+    std::signal(SIGINT, handle_signal);
+    std::signal(SIGTERM, handle_signal);
+
+    ProgramOptions options;
+    bool show_usage = false;
+    if (!parse_options(argc, argv, options, show_usage))
+    {
+        if (show_usage)
+        {
+            print_usage(argv[0]);
+            return 0;
+        }
+        return 1;
+    }
+
+    if (show_usage)
+    {
+        print_usage(argv[0]);
+        return 0;
+    }
+
+    std::string mode_lower = options.mode;
+    std::transform(mode_lower.begin(), mode_lower.end(), mode_lower.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+    TestMode mode = TestMode::MIT;
+    if (mode_lower == "mit")
+    {
+        mode = TestMode::MIT;
+    }
+    else if (mode_lower == "torque")
+    {
+        mode = TestMode::Torque;
+        if (std::abs(options.amplitude) < 1e-6)
+        {
+            options.amplitude = 2.0; // provide a sensible default torque pulse
+        }
+    }
+    else
+    {
+        std::cerr << LOG_ERROR << "Unsupported mode '" << options.mode << "'." << std::endl;
+        print_usage(argv[0]);
+        return 1;
+    }
+
+    if (options.hold_seconds <= 0.0)
+    {
+        std::cerr << LOG_WARNING << "Hold duration must be positive. Using 1.0 second." << std::endl;
+        options.hold_seconds = 1.0;
+    }
+    if (options.settle_seconds <= 0.0)
+    {
+        std::cerr << LOG_WARNING << "Settle duration must be positive. Using 0.5 second." << std::endl;
+        options.settle_seconds = 0.5;
+    }
+
+    MotorTestConfig config;
+    try
+    {
+        config = load_motor_config(options.config_path);
+    }
+    catch (const std::exception &ex)
+    {
+        std::cerr << LOG_ERROR << "Failed to load Titati config: " << ex.what() << std::endl;
+        return 1;
+    }
+
+    if (!options.interface_overridden)
+    {
+        options.interface = config.can_interface;
+    }
+
+    const bool use_router = (options.router_override == -1)
+                                ? config.use_canfd_router
+                                : (options.router_override == 1);
+
+    std::cout << LOG_INFO << "Opening interface '" << options.interface << "'"
+              << " (router " << (use_router ? "enabled" : "disabled") << ")" << std::endl;
+
+    tita_robot robot(static_cast<std::size_t>(config.num_dofs), options.interface, use_router);
+    MotorScope guard{&robot, config.num_dofs, &config.fixed_kp_hw, &config.fixed_kd_hw};
+
+    if (!enable_sdk_with_retry(robot, config.num_dofs, config.fixed_kp_hw, config.fixed_kd_hw))
+    {
+        std::cerr << LOG_ERROR << "Cannot continue without SDK control." << std::endl;
+        return 1;
+    }
+
+    if (std::abs(options.amplitude) < 1e-6)
+    {
+        std::cout << LOG_WARNING << "Amplitude is near zero; commands will keep the robot stationary." << std::endl;
+    }
+
+    std::cout << LOG_INFO << "Testing " << config.num_dofs << " motors in "
+              << (mode == TestMode::MIT ? "MIT" : "torque") << " mode with amplitude "
+              << options.amplitude << (mode == TestMode::MIT ? " rad" : " Nm") << "." << std::endl;
+    std::cout << LOG_INFO << "Hold duration: " << options.hold_seconds
+              << " s, settle duration: " << options.settle_seconds << " s." << std::endl;
+    std::cout << LOG_INFO << "Press Ctrl+C to abort early." << std::endl;
+
+    const auto hold_duration = std::chrono::duration<double>(options.hold_seconds);
+    const auto settle_duration = std::chrono::duration<double>(options.settle_seconds);
+    const auto command_period = std::chrono::milliseconds(5);
+    const auto log_interval = std::chrono::milliseconds(200);
+
+    std::cout << std::fixed << std::setprecision(3);
+
+    for (int hw_index = 0; hw_index < config.num_dofs && g_running.load(); ++hw_index)
+    {
+        const std::string &name = config.joint_names_hw[static_cast<std::size_t>(hw_index)];
+        std::cout << std::endl
+                  << LOG_INFO << "Testing motor " << hw_index << " (" << name << ")" << std::endl;
+
+        auto baseline_q = robot.get_joint_q();
+        if (static_cast<int>(baseline_q.size()) != config.num_dofs)
+        {
+            baseline_q.resize(static_cast<std::size_t>(config.num_dofs), 0.0);
+        }
+
+        std::vector<double> q_cmd = baseline_q;
+        std::vector<double> dq_cmd(static_cast<std::size_t>(config.num_dofs), 0.0);
+        std::vector<double> tau_cmd(static_cast<std::size_t>(config.num_dofs), 0.0);
+
+        double torque_command = options.amplitude;
+        if (mode == TestMode::Torque && hw_index < static_cast<int>(config.torque_limits_hw.size()))
+        {
+            const double limit = config.torque_limits_hw[static_cast<std::size_t>(hw_index)];
+            if (limit > 0.0 && std::abs(torque_command) > limit)
+            {
+                std::cout << LOG_WARNING << "Requested torque " << torque_command
+                          << " Nm exceeds limit " << limit << " Nm; clipping." << std::endl;
+                torque_command = std::max(-limit, std::min(limit, torque_command));
+            }
+        }
+
+        auto next_log = std::chrono::steady_clock::now();
+        const auto command_end = std::chrono::steady_clock::now() + hold_duration;
+        bool command_error_reported = false;
+
+        while (g_running.load() && std::chrono::steady_clock::now() < command_end)
+        {
+            bool sent = true;
+            if (mode == TestMode::MIT)
+            {
+                q_cmd = baseline_q;
+                q_cmd[static_cast<std::size_t>(hw_index)] = baseline_q[static_cast<std::size_t>(hw_index)] + options.amplitude;
+                sent = robot.set_target_joint_mit(q_cmd, dq_cmd, config.fixed_kp_hw, config.fixed_kd_hw, tau_cmd);
+            }
+            else
+            {
+                tau_cmd.assign(tau_cmd.size(), 0.0);
+                tau_cmd[static_cast<std::size_t>(hw_index)] = torque_command;
+                sent = robot.set_target_joint_t(tau_cmd);
+            }
+
+            if (!sent && !command_error_reported)
+            {
+                std::cout << LOG_WARNING << "Failed to transmit command frame." << std::endl;
+                command_error_reported = true;
+            }
+
+            const auto now = std::chrono::steady_clock::now();
+            if (now >= next_log)
+            {
+                auto q_feedback = robot.get_joint_q();
+                auto dq_feedback = robot.get_joint_v();
+                auto tau_feedback = robot.get_joint_t();
+                if (static_cast<int>(q_feedback.size()) != config.num_dofs)
+                {
+                    q_feedback.resize(static_cast<std::size_t>(config.num_dofs), 0.0);
+                }
+                if (static_cast<int>(dq_feedback.size()) != config.num_dofs)
+                {
+                    dq_feedback.resize(static_cast<std::size_t>(config.num_dofs), 0.0);
+                }
+                if (static_cast<int>(tau_feedback.size()) != config.num_dofs)
+                {
+                    tau_feedback.resize(static_cast<std::size_t>(config.num_dofs), 0.0);
+                }
+
+                std::cout << LOG_INFO << "  feedback q=" << q_feedback[static_cast<std::size_t>(hw_index)]
+                          << " rad, dq=" << dq_feedback[static_cast<std::size_t>(hw_index)]
+                          << " rad/s, tau=" << tau_feedback[static_cast<std::size_t>(hw_index)] << " Nm" << std::endl;
+                next_log = now + log_interval;
+            }
+
+            std::this_thread::sleep_for(command_period);
+        }
+
+        if (!g_running.load())
+        {
+            break;
+        }
+
+        baseline_q = robot.get_joint_q();
+        if (static_cast<int>(baseline_q.size()) != config.num_dofs)
+        {
+            baseline_q.resize(static_cast<std::size_t>(config.num_dofs), 0.0);
+        }
+
+        const auto settle_end = std::chrono::steady_clock::now() + settle_duration;
+        while (g_running.load() && std::chrono::steady_clock::now() < settle_end)
+        {
+            bool sent = true;
+            if (mode == TestMode::MIT)
+            {
+                q_cmd = baseline_q;
+                sent = robot.set_target_joint_mit(q_cmd, dq_cmd, config.fixed_kp_hw, config.fixed_kd_hw, tau_cmd);
+            }
+            else
+            {
+                tau_cmd.assign(tau_cmd.size(), 0.0);
+                sent = robot.set_target_joint_t(tau_cmd);
+            }
+
+            if (!sent && !command_error_reported)
+            {
+                std::cout << LOG_WARNING << "Failed to transmit settle command." << std::endl;
+                command_error_reported = true;
+            }
+
+            std::this_thread::sleep_for(command_period);
+        }
+    }
+
+    std::cout << std::endl << LOG_INFO << "Motor test finished." << std::endl;
+    return 0;
+}

--- a/rl_sar/src/rl_sar/src/rl_titati_motor_test.cpp
+++ b/rl_sar/src/rl_sar/src/rl_titati_motor_test.cpp
@@ -10,6 +10,7 @@
 #include <cstddef>
 #include <cctype>
 #include <exception>
+#include <filesystem>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
@@ -17,6 +18,7 @@
 #include <string>
 #include <thread>
 #include <vector>
+#include <cstdlib>
 
 namespace
 {
@@ -196,12 +198,56 @@ struct MotorTestConfig
     std::string can_interface = "can0";
 };
 
+std::string resolve_config_path(const std::string &input)
+{
+    namespace fs = std::filesystem;
+
+    const fs::path requested(input);
+    if (requested.is_absolute())
+    {
+        if (fs::exists(requested))
+        {
+            return requested.lexically_normal().string();
+        }
+        throw std::runtime_error("bad file: " + requested.string());
+    }
+
+    std::vector<fs::path> candidates;
+    candidates.emplace_back(fs::current_path() / requested);
+
+    if (const char *config_dir = std::getenv("RL_SAR_CONFIG_DIR"))
+    {
+        candidates.emplace_back(fs::path(config_dir) / requested);
+    }
+
+    candidates.emplace_back(fs::path(CMAKE_CURRENT_SOURCE_DIR) / requested);
+
+    for (const auto &candidate : candidates)
+    {
+        std::error_code ec;
+        if (fs::exists(candidate, ec) && !fs::is_directory(candidate, ec))
+        {
+            return candidate.lexically_normal().string();
+        }
+    }
+
+    std::ostringstream oss;
+    oss << "bad file: " << input << " (searched:";
+    for (const auto &candidate : candidates)
+    {
+        oss << " " << candidate.string();
+    }
+    oss << ")";
+    throw std::runtime_error(oss.str());
+}
+
 MotorTestConfig load_motor_config(const std::string &path)
 {
-    YAML::Node root = YAML::LoadFile(path);
+    const std::string resolved = resolve_config_path(path);
+    YAML::Node root = YAML::LoadFile(resolved);
     if (!root["titati"])
     {
-        throw std::runtime_error("Missing 'titati' namespace in config: " + path);
+        throw std::runtime_error("Missing 'titati' namespace in config: " + resolved);
     }
 
     YAML::Node node = root["titati"];

--- a/rl_sar/src/rl_sar/src/rl_titati_router.cpp
+++ b/rl_sar/src/rl_sar/src/rl_titati_router.cpp
@@ -1,0 +1,112 @@
+#include "tita_robot/canfd_router_bridge.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <exception>
+#include <iostream>
+#include <string>
+#include <thread>
+
+namespace
+{
+std::atomic<bool> g_running{true};
+
+void handle_signal(int)
+{
+  g_running.store(false);
+}
+
+void print_usage(const char *program)
+{
+  std::cout << "Usage: " << program
+            << " [--interface canX] [--offset <value>] [--no-auto-retry]" << std::endl;
+  std::cout << "  --interface, -i    CAN interface name (default: can0)" << std::endl;
+  std::cout << "  --offset, -o       Optional CAN ID offset in decimal or hex (e.g. 0x10)" << std::endl;
+  std::cout << "  --no-auto-retry    Disable automatic re-handshake when the router drops out" << std::endl;
+}
+}
+
+int main(int argc, char **argv)
+{
+  std::string interface = "can0";
+  uint8_t can_id_offset = 0x00U;
+  bool auto_retry = true;
+
+  for (int idx = 1; idx < argc; ++idx)
+  {
+    const std::string arg = argv[idx];
+    if ((arg == "-i" || arg == "--interface") && idx + 1 < argc)
+    {
+      interface = argv[++idx];
+    }
+    else if ((arg == "-o" || arg == "--offset") && idx + 1 < argc)
+    {
+      const std::string value = argv[++idx];
+      try
+      {
+        size_t processed = 0U;
+        const unsigned long parsed = std::stoul(value, &processed, 0);
+        if (processed != value.size() || parsed > 0xFFUL)
+        {
+          throw std::out_of_range("offset");
+        }
+        can_id_offset = static_cast<uint8_t>(parsed);
+      }
+      catch (const std::exception &ex)
+      {
+        std::cerr << "[rl_titati_router] Invalid CAN ID offset '" << value << "': "
+                  << ex.what() << std::endl;
+        print_usage(argv[0]);
+        return 1;
+      }
+    }
+    else if (arg == "--no-auto-retry")
+    {
+      auto_retry = false;
+    }
+    else if (arg == "-h" || arg == "--help")
+    {
+      print_usage(argv[0]);
+      return 0;
+    }
+    else
+    {
+      std::cerr << "[rl_titati_router] Unknown argument '" << arg << "'." << std::endl;
+      print_usage(argv[0]);
+      return 1;
+    }
+  }
+
+  std::signal(SIGINT, handle_signal);
+  std::signal(SIGTERM, handle_signal);
+
+  try
+  {
+    can_device::CanfdRouterBridge router(interface, can_id_offset, auto_retry);
+    router.set_status_callback([](const std::string &message) {
+      std::cout << message << std::endl;
+    });
+
+    router.request_force_direct();
+
+    std::cout << "[rl_titati_router] Listening on interface '" << interface
+              << "' (offset 0x" << std::hex << static_cast<int>(can_id_offset) << std::dec
+              << ") with " << (auto_retry ? "auto" : "manual")
+              << " retry. Press Ctrl+C to exit." << std::endl;
+
+    while (g_running.load())
+    {
+      std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+  }
+  catch (const std::exception &ex)
+  {
+    std::cerr << "[rl_titati_router] Failed to initialise CAN-FD router bridge: "
+              << ex.what() << std::endl;
+    return 1;
+  }
+
+  std::cout << "[rl_titati_router] Shutdown complete." << std::endl;
+  return 0;
+}


### PR DESCRIPTION
## Summary
- replace the placeholder root README with a detailed guide for running Titati on rl_sar
- document CAN bringup, dependency setup, build commands, policy configuration, and runtime controls
- add troubleshooting tips and notes for coexisting with the legacy titati_control stack

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d4f36726648321925d4e24ca653e7e