### PR TITLE
Add Titati hardware support to rl_sar

### DIFF
--- a/rl_sar/README.md
+++ b/rl_sar/README.md
@@ -158,6 +158,73 @@ Examples:
 
 In the following text, **\<ROBOT\>/\<CONFIG\>** is used to represent different environments, such as `go2/himloco` and `go2w/robot_lab`.
 
+## Titati Real Robot (No ROS)
+
+The Titati platform consists of two Tita bases connected through a master hub. A single host Jetson must control all 16 motors across the unified CAN-FD bus—no ROS nodes are required.
+
+### 1. Prepare both Jetsons
+
+1. Configure the CAN interface on **each** Jetson (master and slave) after every reboot:
+
+   ```bash
+   sudo ip link set can0 down
+   sudo ip link set can0 up type can bitrate 1000000 sample-point 0.80 dbitrate 8000000 dsample-point 0.80 fd on restart-ms 100
+   sudo ifconfig can0 txqueuelen 1000
+   ```
+
+2. Ensure the CAN cable between master and slave is connected. No ROS processes need to run on either Jetson when using the RL controller.
+
+### 2. Build only the Titati executables (host Jetson)
+
+```bash
+./build.sh -m rl_real_titati titati_motor_test
+```
+
+This configures the project for CMake (C++17) and builds only the real-robot controller together with the standalone motor test utility.
+
+### 3. Motor sanity test (host Jetson)
+
+Before running the policy, verify that all joints respond and that communication with the slave side works:
+
+```bash
+./cmake_build/bin/titati_motor_test        # optional argument: number_of_motors (default 16)
+```
+
+Useful tester commands:
+
+| Command | Description |
+| ------- | ----------- |
+| `status` | Print the current position/velocity/torque for all motors |
+| `torque <id> <tau>` | Apply a pure torque command (Nm) to one motor (0-based index) |
+| `mit <id> <q> <dq> <kp> <kd> <tau>` | Send a single-motor MIT command (radians, rad/s, gains, feed-forward torque) |
+| `watch <seconds>` | Continuously print motor states (default 5 s) |
+| `zero` | Remove all torques |
+| `exit` / `quit` | Leave the tester (motors are zeroed and MCU control is restored) |
+
+The tester automatically switches the MCU into SDK/force-direct mode when it starts and releases it on exit.
+
+### 4. Run the reinforcement-learning controller (host Jetson)
+
+```bash
+./cmake_build/bin/rl_real_titati
+```
+
+Keyboard shortcuts:
+
+| Key | Action |
+| --- | ------ |
+| `Num0` | Stand up / enter ready state |
+| `Num1` | Start RL locomotion |
+| `Num9` | Sit down |
+| `P`    | Passive mode |
+| `W/S`  | Increase / decrease forward velocity command |
+| `A/D`  | Lateral command |
+| `Q/E`  | Yaw command |
+| `Space`| Clear commanded velocities |
+| `N`    | Toggle navigation mode (hold external command at zero) |
+
+The RL controller automatically pushes Titati into SDK control mode and enforces torque limits from `policy/titati/base.yaml`. Ensure the environment is clear before enabling motion.
+
 Before running, copy the trained pt model file to `rl_sar/src/rl_sar/policy/<ROBOT>/<CONFIG>`, and configure the parameters in `<ROBOT>/<CONFIG>/config.yaml` and `<ROBOT>/base.yaml`.
 
 ### Simulation

--- a/rl_sar/README_CN.md
+++ b/rl_sar/README_CN.md
@@ -160,6 +160,73 @@ Examples:
 
 运行前请将训练好的pt模型文件拷贝到`rl_sar/src/rl_sar/policy/<ROBOT>/<CONFIG>`中，并配置`<ROBOT>/<CONFIG>/config.yaml`和`<ROBOT>/base.yaml`中的参数。
 
+## Titati 真机部署（不依赖 ROS）
+
+Titati 由两台 Tita 机器人通过主控盒和线束拼接而成，主 Jetson 需要通过同一条 CAN-FD 总线直接控制全部 16 个电机，无需启动任何 ROS 节点。
+
+### 1. 主从机准备
+
+1. 每次开机后都需要在 **主、从两台 Jetson** 上重新初始化 CAN 接口：
+
+   ```bash
+   sudo ip link set can0 down
+   sudo ip link set can0 up type can bitrate 1000000 sample-point 0.80 dbitrate 8000000 dsample-point 0.80 fd on restart-ms 100
+   sudo ifconfig can0 txqueuelen 1000
+   ```
+
+2. 确认主从之间的 CAN 线缆连接完好。使用本方案时两台 Jetson 上均无需启动 ROS。
+
+### 2. 在主机上仅编译 Titati 相关程序
+
+```bash
+./build.sh -m rl_real_titati titati_motor_test
+```
+
+脚本会以 CMake（C++17）方式配置项目，只构建真机控制器和电机测试工具。
+
+### 3. 电机连通性测试（主机）
+
+在加载策略前，先确认 16 个电机状态可读、命令可下发：
+
+```bash
+./cmake_build/bin/titati_motor_test        # 可选参数：电机数量（默认 16）
+```
+
+测试工具常用指令：
+
+| 指令 | 说明 |
+| ---- | ---- |
+| `status` | 打印所有电机的角度/速度/力矩 |
+| `torque <id> <tau>` | 给指定电机施加纯力矩指令（单位 Nm，电机编号从 0 开始） |
+| `mit <id> <q> <dq> <kp> <kd> <tau>` | 给单个电机发送 MIT 控制（单位分别为 rad、rad/s、增益、力矩） |
+| `watch <seconds>` | 连续输出电机状态（默认 5 秒） |
+| `zero` | 清除全部电机力矩 |
+| `exit` / `quit` | 退出测试程序（自动清零并恢复 MCU 控制） |
+
+程序启动时会自动将底层切换到 SDK 直控模式，退出时自动恢复 MCU 控制。
+
+### 4. 运行强化学习控制器（主机）
+
+```bash
+./cmake_build/bin/rl_real_titati
+```
+
+键盘控制：
+
+| 按键 | 功能 |
+| ---- | ---- |
+| `Num0` | 机器人起身并进入准备状态 |
+| `Num1` | 进入 RL 行走模式 |
+| `Num9` | 机器人下蹲 |
+| `P`    | 被动模式 |
+| `W/S`  | 增减前进速度指令 |
+| `A/D`  | 侧向速度指令 |
+| `Q/E`  | 角速度指令 |
+| `Space`| 清空速度指令 |
+| `N`    | 切换导航模式（保持零指令） |
+
+控制器会自动将 Titati 切换到 SDK 直控模式，并按照 `policy/titati/base.yaml` 中的力矩限制运行，启用前务必确认周围环境安全。
+
 ### 仿真
 
 打开一个终端，启动gazebo仿真环境

--- a/rl_sar/build.sh
+++ b/rl_sar/build.sh
@@ -64,12 +64,17 @@ ask_confirmation() {
 # ========================
 
 run_cmake_build() {
+    local targets=("$@")
     print_header "[Running CMake Build]"
     print_warning "NOTE: CMake build is for hardware deployment only, not for simulation."
     print_separator
 
     cmake src/rl_sar/ -B cmake_build -DUSE_CMAKE=ON
-    cmake --build cmake_build -j4
+    if [ ${#targets[@]} -eq 0 ]; then
+        cmake --build cmake_build -j4
+    else
+        cmake --build cmake_build -j4 --target "${targets[@]}"
+    fi
 
     print_success "CMake build completed!"
 }
@@ -346,7 +351,7 @@ main() {
 
     # Handle CMake build mode
     if [ "$cmake_mode" = true ]; then
-        run_cmake_build
+        run_cmake_build "${packages[@]}"
         exit 0
     fi
 

--- a/rl_sar/src/rl_sar/CMakeLists.txt
+++ b/rl_sar/src/rl_sar/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 project(rl_sar VERSION 3.0.0 LANGUAGES CXX)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 set(USE_CMAKE OFF CACHE BOOL "Use Cmake build system")
 message(STATUS "USE_CMAKE: ${USE_CMAKE}")
 if(USE_CMAKE)
@@ -134,6 +137,17 @@ if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
     )
 endif()
 
+# titati sdk
+add_library(titati_sdk
+    library/thirdparty/titati_sdk/src/can_receiver.cpp
+    library/thirdparty/titati_sdk/src/can_sender.cpp
+    library/thirdparty/titati_sdk/src/tita_robot.cpp
+)
+target_include_directories(titati_sdk PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/titati_sdk/include
+)
+target_link_libraries(titati_sdk PUBLIC Threads::Threads)
+
 # Retroid Gamepad
 set(GAMEPAD_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/gamepad/src/gamepad.cpp
@@ -158,10 +172,6 @@ include_directories(
 )
 
 add_library(rl_sdk library/core/rl_sdk/rl_sdk.cpp)
-set_target_properties(rl_sdk PROPERTIES
-    CXX_STANDARD 14
-    CXX_STANDARD_REQUIRED ON
-)
 target_link_libraries(rl_sdk PUBLIC
     "${TORCH_LIBRARIES}"
     Python3::Python
@@ -182,10 +192,6 @@ endif()
 
 add_library(observation_buffer library/core/observation_buffer/observation_buffer.cpp)
 target_link_libraries(observation_buffer PUBLIC "${TORCH_LIBRARIES}")
-set_target_properties(observation_buffer PROPERTIES
-    CXX_STANDARD 14
-    CXX_STANDARD_REQUIRED ON
-)
 if(NOT USE_CMAKE)
     if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
         install(TARGETS observation_buffer DESTINATION lib/${PROJECT_NAME})
@@ -320,6 +326,22 @@ if(NOT USE_CMAKE)
         install(TARGETS rl_real_l4w4 DESTINATION lib/${PROJECT_NAME})
     endif()
 endif()
+
+add_executable(rl_real_titati src/rl_real_titati.cpp)
+target_link_libraries(rl_real_titati
+    titati_sdk
+    rl_sdk
+    observation_buffer
+    yaml-cpp
+)
+target_include_directories(rl_real_titati PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/titati_sdk/include
+)
+
+add_executable(titati_motor_test src/titati_motor_test.cpp)
+target_link_libraries(titati_motor_test
+    titati_sdk
+)
 
 if(NOT USE_CMAKE)
     if($ENV{ROS_DISTRO} MATCHES "noetic")

--- a/rl_sar/src/rl_sar/include/rl_real_titati.hpp
+++ b/rl_sar/src/rl_sar/include/rl_real_titati.hpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024-2025 Ziqi Fan
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef RL_REAL_TITATI_HPP
+#define RL_REAL_TITATI_HPP
+
+// #define PLOT
+// #define CSV_LOGGER
+
+#include "rl_sdk.hpp"
+#include "observation_buffer.hpp"
+#include "loop.hpp"
+#include "fsm.hpp"
+
+#include "titati_sdk/tita_robot.hpp"
+
+#include <csignal>
+#include <memory>
+#include <vector>
+
+class RL_Real : public RL
+{
+public:
+    RL_Real();
+    ~RL_Real();
+
+private:
+    torch::Tensor Forward() override;
+    void GetState(RobotState<double> *state) override;
+    void SetCommand(const RobotCommand<double> *command) override;
+    void RunModel();
+    void RobotControl();
+
+    std::shared_ptr<LoopFunc> loop_keyboard;
+    std::shared_ptr<LoopFunc> loop_control;
+    std::shared_ptr<LoopFunc> loop_rl;
+    std::shared_ptr<LoopFunc> loop_plot;
+
+#ifdef PLOT
+    const int plot_size = 100;
+    std::vector<int> plot_t;
+    std::vector<std::vector<double>> plot_real_joint_pos, plot_target_joint_pos;
+    void Plot();
+#endif
+
+    std::unique_ptr<titati::TitatiRobot> robot;
+
+    int motiontime = 0;
+};
+
+#endif // RL_REAL_TITATI_HPP
+

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_sdk/include/titati_sdk/can_receiver.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_sdk/include/titati_sdk/can_receiver.hpp
@@ -1,0 +1,116 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MOTORS_CAN__MOTORS_CAN_API_HPP_
+#define MOTORS_CAN__MOTORS_CAN_API_HPP_
+
+#include <algorithm>
+#include <atomic>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "protocol/can_utils.hpp"
+namespace can_device
+{
+#define PACKED __attribute__((__packed__))
+#define GRAVITY 9.81f
+#define CAN_ID_MOTOR_IN 0x108
+#define CAN_ID_IMU1 0x118
+#define CAN_ID_STATE 0x102
+
+  struct api_motor_in_t
+  {
+    uint32_t timestamp;
+    float position;
+    float velocity;
+    float torque;
+  } PACKED;
+  /* 44 bytes */
+  struct api_imu_data_t
+  {
+    uint32_t timestamp;
+    float accl[3];
+    float gyro[3];
+    float quaternion[4]; // x y z w
+    float temperature;
+  } PACKED;
+  
+  struct api_motor_status_t
+  {
+    uint32_t timestamp;
+    uint16_t key;
+    uint8_t value[8];
+  } PACKED;
+
+  class MotorsImuCanReceiveApi
+  {
+  public:
+    MotorsImuCanReceiveApi(size_t size)
+    {
+      if(size % 8 == 0) leg_dof_ = 4;
+      else if(size % 6 == 0) leg_dof_ = 3;
+      leg_num_ = size / leg_dof_;
+      register_motors_device_can_filter();
+      api_motor_in_t default_motor_in;
+      std::memset(&default_motor_in, 0x00U, sizeof(api_motor_in_t));
+      motors_in_.resize(size, default_motor_in);
+      std::memset(&imu_data_, 0x00U, sizeof(api_imu_data_t));
+    }
+    ~MotorsImuCanReceiveApi() {}
+    const std::vector<api_motor_in_t> *get_motors_in() const { return &motors_in_; }
+    const api_imu_data_t *get_imu_data() const { return &imu_data_; }
+    const api_motor_status_t *get_motors_status() const { return &motors_status_; }
+
+  private:
+#define MIN_TIME_OUT_US 1'000L     // 1ms
+#define MAX_TIME_OUT_US 3'000'000L // 3s
+#define CAN_MASK_AS_MOTORS_INFO (0x7E0U)
+    std::string motors_can_interface = "can0";
+    std::string motors_can_name = "motors_can";
+    bool motors_can_extended_frame = false;
+    bool motors_can_rx_is_block = false;
+    int64_t motors_timeout_us = MAX_TIME_OUT_US;
+    uint8_t motors_can_id_offset = 0x00U;
+
+    void register_motors_device_can_filter();
+    can_device::socket_can::can_fd_callback motors_can_receive_callback =
+        std::bind(&MotorsImuCanReceiveApi::board_can_data_callback, this, std::placeholders::_1);
+
+    std::shared_ptr<can_device::socket_can::CanDev> motors_can_receive_api =
+        std::make_shared<can_device::socket_can::CanDev>(
+            motors_can_interface, motors_can_name, motors_can_extended_frame, motors_can_receive_callback,
+            motors_can_rx_is_block, motors_timeout_us, motors_can_id_offset);
+
+    void board_can_data_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+    void motors_data_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+    void imu_data_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+    void motors_status_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+
+    std::vector<api_motor_in_t> motors_in_;
+    api_imu_data_t imu_data_;
+    api_motor_status_t motors_status_;
+
+    mutable std::shared_mutex motors_in_mutex_, imu_mutex_;
+    size_t leg_dof_{4}, leg_num_{2};
+  };
+} // namespace can_device
+
+#endif // MOTORS_CAN__MOTORS_CAN_API_HPP_

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_sdk/include/titati_sdk/can_sender.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_sdk/include/titati_sdk/can_sender.hpp
@@ -1,0 +1,120 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MOTORS_CAN__MOTORS_CAN_SEND_API_HPP_
+#define MOTORS_CAN__MOTORS_CAN_SEND_API_HPP_
+
+#include <algorithm>
+#include <atomic>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "protocol/can_utils.hpp"
+
+namespace can_device
+{
+
+#define CAN_ID_SEND_MOTORS (0x120U)
+#define CAN_ID_CHANNEL_INPUT (0x12DU)
+#define CAN_ID_RPC_REQUEST (0x170U)
+
+  enum ApiRpcKey
+  {
+    RPC_UNDEFINED = 0x000,
+    GET_MODEL_INFO = 0x100,
+    GET_SERIAL_NUMBER = 0x101,
+    SET_READY_NEXT = 0x200,
+    SET_BOARDCAST = 0x201,
+    SET_INPUT_MODE = 0x221,
+    SET_STAND_MODE = 0x222,
+    SET_HEAD_MODE = 0x223,
+    SET_JUMP = 0x231,
+    SET_MOTOR_ZERO = 0x280,
+  };
+  struct ChannelInput
+  {
+    uint32_t timestamp;
+    float forward;
+    float yaw;
+    float pitch;
+    float roll;
+    float height;
+    float split;
+    float tilt;
+    float forward_accel;
+    float yaw_accel;
+  };
+  struct RpcRequest
+  {
+    uint32_t timestamp;
+    uint16_t key;
+    uint32_t value;
+  };
+  struct motor_out
+  {
+    uint32_t timestamp;
+    float position;
+    float kp;
+    float velocity;
+    float kd;
+    float torque;
+  };
+
+  class MotorsCanSendApi
+  {
+  public:
+    MotorsCanSendApi(size_t size)
+    {
+      if (size % 8 == 0)
+        leg_dof_ = 4;
+      else if (size % 6 == 0)
+        leg_dof_ = 3;
+      leg_num_ = size / leg_dof_;
+    }
+    ~MotorsCanSendApi() = default;
+    bool send_motors_can(std::vector<motor_out> motors);
+    bool send_command_can_channel_input(ChannelInput data);
+    bool send_command_can_rpc_request(RpcRequest data);
+
+  private:
+#define MIN_TIME_OUT_US 1'000L     // 1ms
+#define MAX_TIME_OUT_US 3'000'000L // 3s
+    std::string can_interface = "can0";
+    std::string can_name = "motors_can_send";
+    int64_t timeout_us = MAX_TIME_OUT_US;
+    uint8_t can_id_offset = 0x00U;
+    bool can_extended_frame = false;
+    bool can_fd_mode = true;
+
+    std::shared_ptr<can_device::socket_can::CanDev> can_send_api_ =
+        std::make_shared<can_device::socket_can::CanDev>(
+            can_interface, can_name, can_extended_frame, can_fd_mode, timeout_us, can_id_offset);
+
+    inline uint32_t get_current_time()
+    {
+      struct timeval tv;
+      gettimeofday(&tv, NULL);
+      return std::move(tv.tv_sec * 1000000 + tv.tv_usec);
+    }
+    size_t leg_dof_{4}, leg_num_{2};
+  };
+} // namespace can_device
+
+#endif // MOTORS_CAN__MOTORS_CAN_SEND_API_HPP_

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_sdk/include/titati_sdk/protocol/can_utils.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_sdk/include/titati_sdk/protocol/can_utils.hpp
@@ -1,0 +1,468 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__CAN_UTILS_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__CAN_UTILS_HPP_
+
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "linux/can.h"
+#include "linux/can/error.h"
+#include "linux/can/raw.h"
+#include "socket_can_receiver.hpp"
+#include "socket_can_sender.hpp"
+
+#define C_END "\033[m"
+// #define C_RED "\033[0;32;31m"
+#define C_RED "\033[0;31m"
+#define C_YELLOW "\033[1;33m"
+
+#ifdef GCC_OPTIMIZE_03
+#pragma GCC optimize("O3")
+#else
+#pragma GCC optimize("O0")
+#endif
+namespace can_device
+{
+namespace socket_can
+{
+using can_std_callback = std::function<void(std::shared_ptr<struct can_frame> recv_frame)>;
+using can_fd_callback = std::function<void(std::shared_ptr<struct canfd_frame> recv_frame)>;
+class CanRxDev
+{
+public:
+  explicit CanRxDev(
+    const std::string & interface, const std::string & name, can_std_callback recv_callback,
+    bool is_block, int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    init(interface, name, false, recv_callback, nullptr, is_block, nano_timeout);
+  }
+  explicit CanRxDev(
+    const std::string & interface, const std::string & name, can_fd_callback recv_callback,
+    bool is_block, int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    init(interface, name, true, nullptr, recv_callback, is_block, nano_timeout);
+  }
+
+  ~CanRxDev()
+  {
+    ready_ = false;
+    isthreadrunning_ = false;
+    if (main_T_ != nullptr) {
+      main_T_->join();
+    }
+    main_T_ = nullptr;
+    receiver_ = nullptr;
+  }
+
+  bool is_ready() { return ready_; }
+  bool is_timeout() { return is_timeout_; }
+  void set_filter(const struct can_filter filter[], size_t s)
+  {
+    if (receiver_ != nullptr) {
+      receiver_->set_filter(filter, s);
+    }
+  }
+
+  std::shared_ptr<canfd_frame> wait_for_can_data_block()
+  {
+    can_device::socket_can::CanId receive_id{};
+    std::string can_type;
+    if (canfd_) {
+      can_type = "FD";
+      rx_fd_frame_ = std::make_shared<struct canfd_frame>();
+    } else {
+      can_type = "STD";
+      rx_std_frame_ = std::make_shared<struct can_frame>();
+    }
+    if (receiver_ != nullptr) {
+      try {
+        bool result =
+          canfd_ ? receiver_->receive(rx_fd_frame_, std::chrono::nanoseconds(nano_timeout_))
+                 : receiver_->receive(rx_std_frame_, std::chrono::nanoseconds(nano_timeout_));
+        if (result) {
+          is_timeout_ = false;
+          return rx_fd_frame_;
+        } else {
+          return nullptr;
+        }
+      } catch (const std::exception & ex) {
+        if (ex.what()[0] == '$') {
+          is_timeout_ = true;
+          return nullptr;
+        }
+      }
+    } else {
+      isthreadrunning_ = false;
+      printf(
+        C_RED
+        "[CAN_RX %s][ERROR][%s] Error receiving CAN %s message: %s, "
+        "no receiver init\r\n" C_END,
+        can_type.c_str(), name_.c_str(), can_type.c_str(), interface_.c_str());
+    }
+    return nullptr;
+  }
+
+#ifdef COMMON_PROTOCOL_TEST
+  bool testing_setcandata(can_frame frame)
+  {
+    if (can_std_callback_ != nullptr) {
+      can_std_callback_(std::make_shared<struct can_frame>(frame));
+      return true;
+    }
+    return false;
+  }
+  bool testing_setcandata(canfd_frame frame)
+  {
+    if (can_fd_callback_ != nullptr) {
+      can_fd_callback_(std::make_shared<struct canfd_frame>(frame));
+      return true;
+    }
+    return false;
+  }
+#endif  // COMMON_PROTOCOL_TEST
+
+private:
+  bool ready_;
+  bool canfd_;
+  bool is_timeout_;
+  bool extended_frame_;
+  bool isthreadrunning_;
+  int64_t nano_timeout_;
+  std::string name_;
+  std::string interface_;
+  can_std_callback can_std_callback_;
+  can_fd_callback can_fd_callback_;
+  std::unique_ptr<std::thread> main_T_;
+  std::shared_ptr<struct can_frame> rx_std_frame_;
+  std::shared_ptr<struct canfd_frame> rx_fd_frame_;
+  std::unique_ptr<can_device::socket_can::SocketCanReceiver> receiver_;
+  uint8_t can_id_offset_ = 0;
+  void init(
+    const std::string & interface, const std::string & name, bool canfd_on,
+    can_std_callback std_callback, can_fd_callback fd_callback, bool is_block, int64_t nano_timeout)
+  {
+    name_ = name;
+    interface_ = interface;
+    canfd_ = canfd_on;
+    nano_timeout_ = nano_timeout;
+    is_timeout_ = false;
+    interface_ = interface;
+    can_std_callback_ = std_callback;
+    can_fd_callback_ = fd_callback;
+    try {
+      receiver_ = std::make_unique<can_device::socket_can::SocketCanReceiver>(interface_, canfd_);
+      if (!is_block) {
+        isthreadrunning_ = true;
+        ready_ = true;
+        main_T_ = std::make_unique<std::thread>(std::bind(&CanRxDev::main_recv_func, this));
+      }
+    } catch (const std::exception & ex) {
+      printf(
+        C_RED "[CAN_RX][ERROR][%s] %s receiver creat error! %s\r\n" C_END, name_.c_str(),
+        interface_.c_str(), ex.what());
+      return;
+    }
+  }
+
+  bool wait_for_can_data()
+  {
+    can_device::socket_can::CanId receive_id{};
+    std::string can_type;
+    if (canfd_) {
+      can_type = "FD";
+      rx_fd_frame_ = std::make_shared<struct canfd_frame>();
+    } else {
+      can_type = "STD";
+      rx_std_frame_ = std::make_shared<struct can_frame>();
+    }
+
+    if (receiver_ != nullptr) {
+      try {
+        bool result =
+          canfd_ ? receiver_->receive(rx_fd_frame_, std::chrono::nanoseconds(nano_timeout_))
+                 : receiver_->receive(rx_std_frame_, std::chrono::nanoseconds(nano_timeout_));
+        if (result) {
+          is_timeout_ = false;
+        }
+        return result;
+      } catch (const std::exception & ex) {
+        if (ex.what()[0] == '$') {
+          is_timeout_ = true;
+          return false;
+        }
+        printf(
+          C_RED "[CAN_RX %s][ERROR][%s] Error receiving CAN %s message: %s - %s\n" C_END,
+          can_type.c_str(), name_.c_str(), can_type.c_str(), interface_.c_str(), ex.what());
+      }
+    } else {
+      isthreadrunning_ = false;
+      printf(
+        C_RED
+        "[CAN_RX %s][ERROR][%s] Error receiving CAN %s message: %s, "
+        "no receiver init\r\n" C_END,
+        can_type.c_str(), name_.c_str(), can_type.c_str(), interface_.c_str());
+    }
+    return false;
+  }
+
+  void main_recv_func()
+  {
+#ifdef DEBUG_LOG
+    printf("[CAN_RX][INFO][%s] Start recv thread: %s\r\n", interface_.c_str(), name_.c_str());
+#endif  // DEBUG_LOG
+    while (isthreadrunning_ && ready_) {
+      if (wait_for_can_data()) {
+        if (!canfd_ && can_std_callback_ != nullptr) {
+          can_std_callback_(rx_std_frame_);
+        } else if (canfd_ && can_fd_callback_ != nullptr) {
+          can_fd_callback_(rx_fd_frame_);
+        }
+      }
+    }
+#ifdef DEBUG_LOG
+    printf("[CAN_RX][INFO][%s] Exit recv thread: %s\r\n", interface_.c_str(), name_.c_str());
+#endif  // DEBUG_LOG
+  }
+};
+
+class CanTxDev
+{
+public:
+  explicit CanTxDev(
+    const std::string & interface, const std::string & name, bool extended_frame, bool canfd_on,
+    int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    can_id_offset_ = can_id_offset;
+    ready_ = false;
+    name_ = name;
+    nano_timeout_ = nano_timeout;
+    is_timeout_ = false;
+    canfd_on_ = canfd_on;
+    interface_ = interface;
+    extended_frame_ = extended_frame;
+    try {
+      sender_ = std::make_unique<can_device::socket_can::SocketCanSender>(interface_, canfd_on_);
+    } catch (const std::exception & ex) {
+      printf(
+        C_RED "[CAN_TX][ERROR][%s] %s sender creat error! %s\r\n" C_END, name_.c_str(),
+        interface_.c_str(), ex.what());
+      return;
+    }
+    ready_ = true;
+  }
+
+  ~CanTxDev()
+  {
+    ready_ = false;
+    sender_ = nullptr;
+  }
+
+  bool send_can_message(struct can_frame & tx_frame)
+  {
+    return send_can_message(&tx_frame, nullptr);
+  }
+  bool send_can_message(struct canfd_frame & tx_frame)
+  {
+    return send_can_message(nullptr, &tx_frame);
+  }
+
+  bool is_ready() { return ready_; }
+  bool is_timeout() { return is_timeout_; }
+
+private:
+  bool ready_;
+  bool canfd_on_;
+  bool is_timeout_;
+  bool extended_frame_;
+  int64_t nano_timeout_;
+  std::string name_;
+  std::string interface_;
+  std::unique_ptr<can_device::socket_can::SocketCanSender> sender_;
+  uint8_t can_id_offset_;
+
+  bool send_can_message(struct can_frame * std_frame, struct canfd_frame * fd_frame)
+  {
+    bool self_fd = (fd_frame != nullptr);
+    std::string can_type = self_fd ? "FD" : "STD";
+    if (canfd_on_ != self_fd) {
+      printf(
+        C_RED
+        "[CAN_TX %s][ERROR][%s] Error sending CAN message: %s - "
+        "Not support can/canfd frame mixed\r\n" C_END,
+        can_type.c_str(), name_.c_str(), interface_.c_str());
+      return false;
+    }
+    canid_t * canid = self_fd ? &fd_frame->can_id : &std_frame->can_id;
+
+    bool result = true;
+    can_device::socket_can::CanId send_id =
+      extended_frame_
+        ? can_device::socket_can::CanId(
+            *canid, can_device::socket_can::FrameType::DATA, can_device::socket_can::ExtendedFrame)
+        : can_device::socket_can::CanId(
+            *canid, can_device::socket_can::FrameType::DATA, can_device::socket_can::StandardFrame);
+    if (sender_ != nullptr) {
+      try {
+        if (self_fd) {
+          sender_->send_fd(
+            fd_frame->data, (fd_frame->len == 0) ? 64 : fd_frame->len, send_id,
+            std::chrono::nanoseconds(nano_timeout_));
+          is_timeout_ = false;
+        } else {
+          sender_->send(
+            std_frame->data, (std_frame->can_dlc == 0) ? 8 : std_frame->can_dlc, send_id,
+            std::chrono::nanoseconds(nano_timeout_));
+          is_timeout_ = false;
+        }
+      } catch (const std::exception & ex) {
+        if (ex.what()[0] == '$') {
+          is_timeout_ = true;
+          return false;
+        }
+        result = false;
+        printf(
+          C_RED "[CAN_TX %s][ERROR][%s] Error sending CAN message: %s - %s\r\n" C_END,
+          can_type.c_str(), name_.c_str(), interface_.c_str(), ex.what());
+      }
+    } else {
+      result = false;
+      printf(
+        C_RED "[CAN_TX %s][ERROR][%s] Error sending CAN message: %s - No device\r\n" C_END,
+        can_type.c_str(), name_.c_str(), interface_.c_str());
+    }
+    return result;
+  }
+};
+
+class CanDev
+{
+public:
+  explicit CanDev(
+    const std::string & interface, const std::string & name, bool extended_frame,
+    can_std_callback recv_callback, bool is_block, int64_t nano_timeout = -1,
+    uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    name_ = name;
+    send_only_ = false;
+    tx_op_ = std::make_unique<CanTxDev>(
+      interface, name_, extended_frame, false, nano_timeout, can_id_offset_);
+    rx_op_ = std::make_unique<CanRxDev>(
+      interface, name_, recv_callback, is_block, nano_timeout, can_id_offset_);
+  }
+  explicit CanDev(
+    const std::string & interface, const std::string & name, bool extended_frame,
+    can_fd_callback recv_callback, bool is_block, int64_t nano_timeout = -1,
+    uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    name_ = name;
+    send_only_ = false;
+    tx_op_ = std::make_unique<CanTxDev>(
+      interface, name_, extended_frame, true, nano_timeout, can_id_offset_);
+    rx_op_ = std::make_unique<CanRxDev>(
+      interface, name_, recv_callback, is_block, nano_timeout, can_id_offset_);
+  }
+  explicit CanDev(
+    const std::string & interface, const std::string & name, bool extended_frame, bool canfd_on,
+    int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    name_ = name;
+    send_only_ = true;
+    tx_op_ = std::make_unique<CanTxDev>(
+      interface, name_, extended_frame, canfd_on, nano_timeout, can_id_offset_);
+  }
+
+  ~CanDev()
+  {
+    rx_op_ = nullptr;
+    tx_op_ = nullptr;
+  }
+
+  std::shared_ptr<canfd_frame> receive_can_message_block()
+  {
+    return rx_op_->wait_for_can_data_block();
+  }
+
+  bool send_can_message(struct can_frame & tx_frame)
+  {
+#ifdef COMMON_PROTOCOL_TEST
+    if (rx_op_ != nullptr) {
+      return rx_op_->testing_setcandata(tx_frame);
+    }
+    return false;
+#else
+    if (tx_op_ != nullptr) {
+      return tx_op_->send_can_message(tx_frame);
+    }
+    return false;
+#endif  // COMMON_PROTOCOL_TEST
+  }
+
+  bool send_can_message(struct canfd_frame & tx_frame)
+  {
+#ifdef COMMON_PROTOCOL_TEST
+    if (rx_op_ != nullptr) {
+      return rx_op_->testing_setcandata(tx_frame);
+    }
+    return false;
+#else
+    if (tx_op_ != nullptr) {
+      return tx_op_->send_can_message(tx_frame);
+    }
+    return false;
+#endif  // COMMON_PROTOCOL_TEST
+  }
+
+  void set_filter(const struct can_filter filter[], size_t s)
+  {
+    if (rx_op_ != nullptr) {
+      rx_op_->set_filter(filter, s);
+    }
+  }
+  bool is_send_only() { return send_only_; }
+  bool is_ready()
+  {
+    bool result = (tx_op_ == nullptr) ? false : tx_op_->is_ready();
+    if (send_only_) {
+      return result;
+    } else {
+      return result && ((rx_op_ == nullptr) ? false : rx_op_->is_ready());
+    }
+  }
+  bool is_rx_timeout() { return rx_op_->is_timeout(); }
+  bool is_tx_timeout() { return tx_op_->is_timeout(); }
+
+private:
+  bool send_only_;
+  std::string name_;
+  std::unique_ptr<CanRxDev> rx_op_;
+  std::unique_ptr<CanTxDev> tx_op_;
+  uint8_t can_id_offset_ = 0;
+};
+
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__CAN_UTILS_HPP_

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_sdk/include/titati_sdk/protocol/socket_can_common.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_sdk/include/titati_sdk/protocol/socket_can_common.hpp
@@ -1,0 +1,122 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_COMMON_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_COMMON_HPP_
+
+#include <linux/can.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <sys/time.h>
+
+#include <chrono>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+
+#define GCC_OPTIMIZE_03
+
+#ifdef GCC_OPTIMIZE_03
+#pragma GCC optimize("O3")
+#else
+#pragma GCC optimize("O0")
+#endif
+
+namespace can_device
+{
+namespace socket_can
+{
+inline bool bind_can_socket(int & fd, const std::string & interface, const bool canfd_on = false)
+{
+  if (interface.length() >= static_cast<std::string::size_type>(IFNAMSIZ)) {
+    throw std::domain_error{"CAN interface name too long"};
+    return false;
+  }
+
+  fd = socket(PF_CAN, static_cast<int32_t>(SOCK_RAW), CAN_RAW);
+  if (0 > fd) {
+    throw std::runtime_error{"Failed to open CAN socket"};
+    return false;
+  }
+
+  // Make it non-blocking so we can use timeouts
+
+  struct ifreq ifr;
+  (void)strncpy(&ifr.ifr_name[0U], interface.c_str(), IFNAMSIZ - 1);
+  ifr.ifr_name[IFNAMSIZ - 1] = '\0';
+  ifr.ifr_ifindex = if_nametoindex(ifr.ifr_name);
+  if (!ifr.ifr_ifindex) {
+    perror("if_nametoindex");
+    return false;
+  }
+
+  struct sockaddr_can addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.can_family = AF_CAN;
+  addr.can_ifindex = ifr.ifr_ifindex;
+
+  if (canfd_on) {
+    if (ioctl(fd, SIOCGIFMTU, &ifr) < 0) {
+      throw std::runtime_error{"Failed to set CAN FD socket name via ioctl()"};
+      return false;
+    }
+    if (ifr.ifr_mtu != CANFD_MTU) {
+      throw std::runtime_error{"Interface does not support CAN FD"};
+      return false;
+    }
+    int _canfd_on = canfd_on ? 1 : 0;
+    auto ret = setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FD_FRAMES, &_canfd_on, sizeof(_canfd_on));
+    if (ret) {
+      throw std::runtime_error{"error whem enable canfd"};
+      return false;
+    }
+  }
+
+  /* disable default receive filter on this RAW socket */
+  /* This is obsolete as we do not read from the socket at all, but for */
+  /* this reason we can remove the receive list in the Kernel to save a */
+  /* little (really a very little!) CPU usage.                          */
+  setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FILTER, NULL, 0);
+
+  if (0 > bind(fd, (struct sockaddr *)&addr, sizeof(addr))) {
+    throw std::runtime_error{"Failed to bind CAN socket"};
+    return false;
+  }
+
+  return true;
+}
+
+inline struct timeval to_timeval(const std::chrono::nanoseconds timeout) noexcept
+{
+  const auto count = timeout.count();
+  constexpr auto BILLION = 1'000'000'000LL;
+  struct timeval c_timeout;
+  c_timeout.tv_sec = static_cast<decltype(c_timeout.tv_sec)>(count / BILLION);
+  c_timeout.tv_usec = static_cast<decltype(c_timeout.tv_usec)>((count % BILLION) * (0.001));
+
+  return c_timeout;
+}
+
+inline fd_set single_set(int32_t file_descriptor) noexcept
+{
+  fd_set descriptor_set;
+  FD_ZERO(&descriptor_set);
+  FD_SET(file_descriptor, &descriptor_set);
+
+  return descriptor_set;
+}
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_COMMON_HPP_

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_sdk/include/titati_sdk/protocol/socket_can_id.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_sdk/include/titati_sdk/protocol/socket_can_id.hpp
@@ -1,0 +1,188 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_ID_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_ID_HPP_
+
+#include <linux/can.h>
+
+#include <stdexcept>
+#include <utility>
+
+#include "visibility_control.hpp"
+
+namespace can_device
+{
+namespace socket_can
+{
+using IdT = uint32_t;
+using LengthT = uint32_t;
+
+constexpr std::size_t MAX_DATA_LENGTH = 64U;
+
+static_assert(
+  MAX_DATA_LENGTH == sizeof(std::declval<struct canfd_frame>().data),
+  "Unexpected CAN frame data size");
+static_assert(std::is_same<IdT, canid_t>::value, "Underlying type of CanId is incorrect");
+constexpr IdT EXTENDED_MASK = CAN_EFF_FLAG;
+constexpr IdT REMOTE_MASK = CAN_RTR_FLAG;
+constexpr IdT ERROR_MASK = CAN_ERR_FLAG;
+constexpr IdT EXTENDED_ID_MASK = CAN_EFF_MASK;
+constexpr IdT STANDARD_ID_MASK = CAN_SFF_MASK;
+
+class SOCKETCAN_PUBLIC SocketCanTimeout : public std::runtime_error
+{
+public:
+  explicit SocketCanTimeout(const char * const what) : runtime_error{what} {};
+};  // class SocketCanTimeout
+
+enum class FrameType : uint32_t { DATA, ERROR, REMOTE };
+
+struct StandardFrame_
+{
+};
+
+constexpr StandardFrame_ StandardFrame;
+
+struct ExtendedFrame_
+{
+};
+
+constexpr ExtendedFrame_ ExtendedFrame;
+
+class SOCKETCAN_PUBLIC CanId
+{
+public:
+  CanId() = default;
+  explicit CanId(const IdT raw_id, const LengthT data_length = 0U)
+  : m_id{raw_id}, m_data_length{data_length}
+  {
+    (void)frame_type();
+  }
+
+  CanId(const IdT id, FrameType type, StandardFrame_) : CanId{id, type, false} {}
+  CanId(const IdT id, FrameType type, ExtendedFrame_) : CanId{id, type, true} {}
+
+  CanId & standard() noexcept
+  {
+    m_id = m_id & (~EXTENDED_MASK);
+    return *this;
+  }
+
+  CanId & extended() noexcept
+  {
+    m_id = m_id | EXTENDED_MASK;
+    return *this;
+  }
+
+  CanId & error_frame() noexcept
+  {
+    m_id = m_id & (~REMOTE_MASK);
+    m_id = m_id | ERROR_MASK;
+    return *this;
+  }
+
+  CanId & remote_frame() noexcept
+  {
+    m_id = m_id & (~ERROR_MASK);
+    m_id = m_id | REMOTE_MASK;
+    return *this;
+  }
+
+  CanId & data_frame() noexcept
+  {
+    m_id = m_id & (~ERROR_MASK);
+    m_id = m_id & (~REMOTE_MASK);
+    return *this;
+  }
+
+  CanId & frame_type(const FrameType type)
+  {
+    switch (type) {
+      case FrameType::DATA:
+        (void)data_frame();
+        break;
+      case FrameType::ERROR:
+        (void)error_frame();
+        break;
+      case FrameType::REMOTE:
+        (void)remote_frame();
+        break;
+      default:
+        throw std::logic_error{"CanId: No such type"};
+    }
+    return *this;
+  }
+
+  CanId & identifier(const IdT id)
+  {
+    constexpr auto MAX_EXTENDED = 0x1FBF'FFFFU;
+    constexpr auto MAX_STANDARD = 0x7FFU;
+
+    static_assert(MAX_EXTENDED <= EXTENDED_ID_MASK, "Max extended id value is wrong");
+    static_assert(MAX_STANDARD <= STANDARD_ID_MASK, "Max standed id value is wrong");
+    const auto max_id = is_extended() ? MAX_EXTENDED : MAX_STANDARD;
+    if (max_id < id) {
+      throw std::domain_error{"CanId would be truncated!"};
+    }
+    m_id = m_id & (~EXTENDED_ID_MASK);
+    m_id = m_id | id;
+    return *this;
+  }
+
+  IdT identifier() const noexcept
+  {
+    const auto mask = is_extended() ? EXTENDED_ID_MASK : STANDARD_ID_MASK;
+    return m_id & mask;
+  }
+
+  IdT get() const noexcept { return m_id; }
+
+  bool is_extended() const noexcept { return (m_id & EXTENDED_MASK) == EXTENDED_MASK; }
+
+  FrameType frame_type() const
+  {
+    const auto is_error = (m_id & ERROR_MASK) == ERROR_MASK;
+    const auto is_remote = (m_id & REMOTE_MASK) == REMOTE_MASK;
+    if (is_error && is_remote) {
+      throw std::domain_error{"CanId has both bit 29 and 30 set! Inconsistent"};
+    }
+    if (is_error) {
+      return FrameType::ERROR;
+    }
+    if (is_remote) {
+      return FrameType::REMOTE;
+    }
+    return FrameType::DATA;
+  }
+
+  LengthT length() const noexcept { return m_data_length; }
+  IdT m_id{};
+
+private:
+  SOCKETCAN_LOCAL CanId(const IdT id, FrameType type, bool is_extended)
+  {
+    if (is_extended) {
+      (void)extended();
+    }
+    (void)frame_type(type);
+    (void)identifier(id);
+  }
+
+  LengthT m_data_length{};
+};  // class CanId
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_ID_HPP_

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_sdk/include/titati_sdk/protocol/socket_can_receiver.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_sdk/include/titati_sdk/protocol/socket_can_receiver.hpp
@@ -1,0 +1,145 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_RECEIVER_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_RECEIVER_HPP_
+#include <linux/can.h>
+#include <linux/can/raw.h>
+#include <sys/socket.h>
+#include <unistd.h>  // for close()
+
+#include <chrono>
+#include <cstring>
+#include <memory>
+#include <string>
+
+#include "socket_can_common.hpp"
+#include "socket_can_id.hpp"
+#include "visibility_control.hpp"
+
+namespace can_device
+{
+namespace socket_can
+{
+// using target_can_device = static_cast<std::string>(TARGET_CAN_DEVICE);
+
+class SOCKETCAN_PUBLIC SocketCanReceiver
+{
+public:
+  explicit SocketCanReceiver(
+    const std::string & interface = "can0", bool canfd_on = false)
+  {
+    if (!bind_can_socket(fd_, interface, canfd_on)) {
+      printf("bind_can_socket failed!\r\n");
+      return;
+    }
+  }
+
+  ~SocketCanReceiver() noexcept { (void)close(fd_); }
+
+  bool receive(
+    std::shared_ptr<struct can_frame> rx_frame,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero())
+  {
+    wait(timeout);
+
+    struct canfd_frame frame;
+    memset(&frame, 0, sizeof(frame));
+    const auto nbytes = read(fd_, &frame, sizeof(frame));
+
+    if (nbytes < 0) {
+      throw std::runtime_error{strerror(errno)};
+    }
+    if (static_cast<std::size_t>(nbytes) < CAN_MTU) {
+      throw std::logic_error{"read: incomplete CAN frame"};
+    }
+    if (static_cast<std::size_t>(nbytes) != CAN_MTU) {
+      throw std::logic_error{"Message was wrong size"};
+    }
+
+    auto receive_id = CanId{frame.can_id, frame.len};
+    if (receive_id.frame_type() == can_device::socket_can::FrameType::DATA) {
+      rx_frame->can_id = receive_id.standard().get();
+      rx_frame->can_id = receive_id.length();
+      std::memcpy(rx_frame->data, frame.data, sizeof(rx_frame->data));
+      return true;
+    }
+    return false;
+  }
+
+  bool receive(
+    std::shared_ptr<struct canfd_frame> rx_frame,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero())
+  {
+    wait(timeout);
+
+    struct canfd_frame frame;
+    const auto nbytes = read(fd_, &frame, sizeof(frame));
+
+    uint8_t except_len = CAN_MTU - 8 + frame.len;
+    if (nbytes < 0) {
+      throw std::runtime_error{strerror(errno)};
+    }
+    if (static_cast<std::size_t>(nbytes) < except_len) {
+      throw std::runtime_error{"read: incomplete CAN frame"};
+    }
+
+    auto receive_id = CanId{frame.can_id, frame.len};
+    if (receive_id.frame_type() == can_device::socket_can::FrameType::DATA) {
+      rx_frame->can_id = receive_id.standard().get();
+      rx_frame->len = receive_id.length();
+      std::memcpy(rx_frame->data, frame.data, sizeof(rx_frame->data));
+      return true;
+    }
+    return false;
+  }
+
+  void set_filter(const struct can_filter filter[], size_t s)
+  {
+    setsockopt(fd_, SOL_CAN_RAW, CAN_RAW_FILTER, filter, s);
+  }
+
+private:
+  SOCKETCAN_LOCAL void wait(const std::chrono::nanoseconds timeout) const
+  {
+    if (decltype(timeout)::zero() < timeout) {
+      auto c_timeout = to_timeval(timeout);
+      auto read_set = single_set(fd_);
+
+      if (0 == select(fd_ + 1, &read_set, NULL, NULL, &c_timeout)) {
+        throw SocketCanTimeout{"$CAN Receive Timeout 1"};
+      }
+
+      if (!FD_ISSET(fd_, &read_set)) {
+        throw SocketCanTimeout{"$CAN Receive Timeout 2"};
+      }
+    } else {
+      auto read_set = single_set(fd_);
+
+      if (0 == select(fd_ + 1, &read_set, NULL, NULL, NULL)) {
+        throw SocketCanTimeout{"$CAN Receive Timeout 1"};
+      }
+
+      if (!FD_ISSET(fd_, &read_set)) {
+        throw SocketCanTimeout{"CAN Receive Timeout 2"};
+      }
+    }
+  }
+
+  int32_t fd_;
+};  // class SocketCanReceiver
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_RECEIVER_HPP_

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_sdk/include/titati_sdk/protocol/socket_can_sender.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_sdk/include/titati_sdk/protocol/socket_can_sender.hpp
@@ -1,0 +1,168 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_SENDER_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_SENDER_HPP_
+
+#include <linux/can.h>
+#include <linux/can/raw.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <stdexcept>
+#include <string>
+
+#include "socket_can_common.hpp"
+#include "socket_can_id.hpp"
+#include "visibility_control.hpp"
+
+namespace can_device
+{
+namespace socket_can
+{
+class SOCKETCAN_PUBLIC SocketCanSender
+{
+public:
+  explicit SocketCanSender(
+    const std::string & interface = "can0", bool canfd_on = false,
+    const CanId & default_id = CanId{})
+  : m_default_id{default_id}
+  {
+    if (!bind_can_socket(fd_, interface, canfd_on)) {
+      printf("bind_can_socket failed\r\n");
+      return;
+    }
+  }
+  ~SocketCanSender() noexcept
+  {
+    (void)close(fd_);
+    // I'm destructing--there's not much else I can do on an error
+    // seem not good
+  }
+
+  void send(
+    const void * const data, const std::size_t Length,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    send(data, Length, m_default_id, timeout);
+  }
+
+  void send(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    if (length > MAX_DATA_LENGTH) {
+      throw std::domain_error{"Size is too large to send via CAN"};
+    }
+    send_impl(data, length, id, timeout);
+  }
+
+  template <typename T, typename = std::enable_if_t<!std::is_pointer<T>::value>>
+  void send(
+    const T & data, const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    send(data, m_default_id, timeout);
+  }
+
+  template <typename T, typename = std::enable_if<!std::is_pointer<T>::value>>
+  void send(
+    const T & data, const CanId id,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    static_assert(sizeof(data) <= MAX_DATA_LENGTH, "Data type too large for CAN");
+    send_impl(reinterpret_cast<const char *>(&data), sizeof(data), id, timeout);
+  }
+
+  void send_fd(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    if (length > MAX_DATA_LENGTH) {
+      throw std::domain_error{"Size is too large to send via CAN"};
+    }
+    send_fd_impl(data, length, id, timeout);
+  }
+
+  CanId default_id() const noexcept { return m_default_id; }
+
+private:
+  void send_impl(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout) const
+  {
+    // (void)data;
+    // (void)length;
+    // (void)id;
+    (void)timeout;
+
+    struct can_frame data_frame;
+    data_frame.can_id = id.get();
+
+    data_frame.can_dlc = static_cast<decltype(data_frame.can_dlc)>(length);
+
+    (void)std::memcpy(static_cast<void *>(&data_frame.data[0U]), data, length);
+
+    if (write(fd_, &data_frame, static_cast<int>(CAN_MTU)) != static_cast<int>(CAN_MTU)) {
+      throw std::runtime_error{strerror(errno)};
+    }
+  }
+
+  void send_fd_impl(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout) const
+  {
+    // (void)data;
+    // (void)length;
+    // (void)id;
+    (void)timeout;
+
+    struct canfd_frame data_frame;
+    memset(&data_frame, 0, sizeof(data_frame));
+    data_frame.can_id = id.get();
+    data_frame.flags = CANFD_FDF | CANFD_BRS;
+    data_frame.len = static_cast<decltype(data_frame.len)>(length);
+    std::memcpy(static_cast<void *>(&data_frame.data[0U]), data, length);
+    if (write(fd_, &data_frame, CANFD_MTU) != CANFD_MTU) {
+      throw std::runtime_error{strerror(errno)};
+    }
+  }
+
+  SOCKETCAN_LOCAL void wait(const std::chrono::nanoseconds timeout) const
+  {
+    if (decltype(timeout)::zero() < timeout) {
+      auto c_timeout = to_timeval(timeout);
+      auto write_set = single_set(fd_);
+
+      // wait
+      if (0 == select(fd_ + 1, NULL, &write_set, NULL, &c_timeout)) {
+        throw SocketCanTimeout{"$CAN Send Timeout [1]"};
+      }
+
+      if (!FD_ISSET(fd_, &write_set)) {
+        throw SocketCanTimeout{"$CAN Send Timeout [2]"};
+      }
+    } else {
+      // do nothing
+      // auto write_set = single_set(fd_);
+    }
+  }
+
+  int32_t fd_;
+  CanId m_default_id;
+};
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_SENDER_HPP_

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_sdk/include/titati_sdk/protocol/visibility_control.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_sdk/include/titati_sdk/protocol/visibility_control.hpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__VISIBILITY_CONTROL_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__VISIBILITY_CONTROL_HPP_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+#ifdef __GNUC__
+#define SOCKETCAN_EXPORT __attribute__((dllexport))
+#define SOCKETCAN_IMPORT __attribute__((dllimport))
+#else
+#define SOCKETCAN_EXPORT __declspec(dllexport)
+#define SOCKETCAN_IMPORT __declspec(dllimport)
+#endif
+#ifdef SOCKETCAN_BUILDING_LIBRARY
+#define SOCKETCAN_PUBLIC SOCKETCAN_EXPORT
+#else
+#define SOCKETCAN_PUBLIC SOCKETCAN_IMPORT
+#endif
+#define SOCKETCAN_PUBLIC_TYPE SOCKETCAN_PUBLIC
+#define SOCKETCAN_LOCAL
+#else
+#define SOCKETCAN_EXPORT __attribute__((visibility("default")))
+#define SOCKETCAN_IMPORT
+#if __GNUC__ >= 4
+#define SOCKETCAN_PUBLIC __attribute__((visibility("default")))
+#define SOCKETCAN_LOCAL __attribute__((visibility("hidden")))
+#else
+#define SOCKETCAN_PUBLIC
+#define SOCKETCAN_LOCAL
+#endif
+#define SOCKETCAN_PUBLIC_TYPE
+#endif
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__VISIBILITY_CONTROL_HPP_

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_sdk/include/titati_sdk/tita_robot.hpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_sdk/include/titati_sdk/tita_robot.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "titati_sdk/can_receiver.hpp"
+#include "titati_sdk/can_sender.hpp"
+
+namespace titati
+{
+
+class TitatiRobot
+{
+public:
+    enum ReadyNext
+    {
+        READY_WAITING = 0x00U,
+        AUTO_LOCOMOTION = 0x01U,
+        FORCE_LOCOMOTION = 0x02U,
+        FORCE_DIRECT = 0x03U,
+        MOTOR_ZERO_CAL = 0x04U,
+        BOOT_RECOVERY_MODE = 0x05U,
+        ESTOP_MODE = 0x06U,
+    };
+
+    struct ChannelInput
+    {
+        uint32_t timestamp;
+        float forward;
+        float yaw;
+        float pitch;
+        float roll;
+        float height;
+        float split;
+        float tilt;
+        float forward_accel;
+        float yaw_accel;
+    };
+
+    explicit TitatiRobot(std::size_t num_motors)
+    {
+        can_receiver_ = std::make_unique<can_device::MotorsImuCanReceiveApi>(num_motors);
+        can_sender_ = std::make_unique<can_device::MotorsCanSendApi>(num_motors);
+        motor_num_ = num_motors;
+    }
+
+    TitatiRobot(const TitatiRobot &) = delete;
+    TitatiRobot &operator=(const TitatiRobot &) = delete;
+    TitatiRobot(TitatiRobot &&) = delete;
+    TitatiRobot &operator=(TitatiRobot &&) = delete;
+    ~TitatiRobot() = default;
+
+    std::vector<double> get_joint_q() const;
+    std::vector<double> get_joint_v() const;
+    std::vector<double> get_joint_t() const;
+    std::vector<uint8_t> get_joint_status() const;
+
+    std::array<double, 4> get_imu_quaternion() const;
+    std::array<double, 3> get_imu_acceleration() const;
+    std::array<double, 3> get_imu_angular_velocity() const;
+
+    bool set_target_joint_t(const std::vector<double> &t);
+    bool set_target_joint_mit(const std::vector<double> &q, const std::vector<double> &v,
+        const std::vector<double> &kp, const std::vector<double> &kd, const std::vector<double> &t);
+
+    bool set_motors_sdk(bool if_sdk);
+    bool set_rc_input(ChannelInput input);
+    bool set_robot_stand(bool stand);
+    bool set_robot_jump(bool jump);
+    bool set_robot_stop();
+
+    std::size_t motor_count() const { return motor_num_; }
+
+private:
+    std::unique_ptr<can_device::MotorsImuCanReceiveApi> can_receiver_;
+    std::unique_ptr<can_device::MotorsCanSendApi> can_sender_;
+    std::size_t motor_num_;
+};
+
+} // namespace titati
+

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_sdk/src/can_receiver.cpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_sdk/src/can_receiver.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "titati_sdk/can_receiver.hpp"
+
+namespace can_device
+{
+
+void MotorsImuCanReceiveApi::register_motors_device_can_filter()
+{
+  // if (!this->is_running.load()) {
+  //   throw std::runtime_error("MotorsImuCanReceiveApi is not running");
+  // }
+  struct can_filter motors_device_rx_filter;
+  motors_device_rx_filter.can_id = CAN_ID_MOTOR_IN;
+  motors_device_rx_filter.can_mask = CAN_MASK_AS_MOTORS_INFO;
+  this->motors_can_receive_api->set_filter(&motors_device_rx_filter, sizeof(struct can_filter));
+}
+
+void MotorsImuCanReceiveApi::board_can_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  if (recv_frame->can_id >= CAN_ID_MOTOR_IN && recv_frame->can_id < CAN_ID_MOTOR_IN + leg_num_) {
+    motors_data_callback(recv_frame);
+  } else if (recv_frame->can_id == CAN_ID_IMU1) {
+    imu_data_callback(recv_frame);
+  } else {
+    return;
+  }
+}
+void MotorsImuCanReceiveApi::motors_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  std::unique_lock<std::shared_mutex> lock(motors_in_mutex_);
+  for (size_t i = 0; i < leg_dof_; i++) {
+    api_motor_in_t motor;
+    std::memcpy(&motor, recv_frame->data + 16 * i, sizeof(api_motor_in_t));
+    auto it = recv_frame->can_id - CAN_ID_MOTOR_IN;
+    motors_in_[i + leg_dof_ * it] = motor;
+  }
+}
+void MotorsImuCanReceiveApi::imu_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  std::unique_lock<std::shared_mutex> lock(imu_mutex_);
+  std::memcpy(&imu_data_, recv_frame->data, sizeof(api_imu_data_t));
+  for (size_t i(0); i < 3; ++i) {
+    imu_data_.accl[i] *= GRAVITY;
+  }
+  return;
+}
+void MotorsImuCanReceiveApi::motors_status_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  std::memcpy(&motors_status_, recv_frame->data, sizeof(api_motor_status_t));
+}
+
+}  // namespace can_device

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_sdk/src/can_sender.cpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_sdk/src/can_sender.cpp
@@ -1,0 +1,95 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "titati_sdk/can_sender.hpp"
+
+namespace can_device
+{
+bool MotorsCanSendApi::send_command_can_channel_input(ChannelInput data)
+{
+  data.timestamp = get_current_time();
+  struct canfd_frame frame;
+  frame.can_id = CAN_ID_CHANNEL_INPUT;
+  frame.len = 40u;
+  memset(frame.data, 0x00U, sizeof(frame.data));
+
+  std::memcpy(frame.data, &data, sizeof(data));
+
+  return can_send_api_->send_can_message(frame);
+}
+
+bool MotorsCanSendApi::send_command_can_rpc_request(RpcRequest data)
+{
+  data.timestamp = get_current_time();
+
+  struct canfd_frame frame;
+  frame.can_id = CAN_ID_RPC_REQUEST;
+  frame.len = 10U;
+
+  memset(frame.data, 0x00U, sizeof(frame.data));
+
+  std::memcpy(frame.data, &data.timestamp, sizeof(data.timestamp));
+  std::memcpy(frame.data + 4, &data.key, sizeof(data.key));
+  std::memcpy(frame.data + 6, &data.value, sizeof(data.value));
+
+  return can_send_api_->send_can_message(frame);
+}
+
+bool MotorsCanSendApi::send_motors_can(std::vector<motor_out> motors)
+{
+  if (motors.size() != leg_dof_ * leg_num_)
+  {
+    std::cerr << "[MOTORS_CAN_SEND] motors size not equal to robot dof" << std::endl;
+    return false;
+  }
+  if (leg_dof_ == 3)
+  {
+    motor_out motor = {};
+    auto it = motors.begin() + 3;
+    motors.insert(it, motor);
+    motors.push_back(motor);
+  }
+  bool send_success = true;
+  struct canfd_frame frame;
+  frame.len = 48U;
+  auto now = get_current_time();
+  for (size_t id(0); id < motors.size() / 2; id++)
+  {
+    frame.can_id = CAN_ID_SEND_MOTORS + id;
+    memset(frame.data, 0x00U, sizeof(frame.data));
+    auto motor = motors[2 * id];
+    motor.timestamp = now;
+    std::memcpy(frame.data, &motor.timestamp, sizeof(motor.timestamp));
+    std::memcpy(frame.data + 4, &motor.position, sizeof(motor.position));
+    std::memcpy(frame.data + 8, &motor.kp, sizeof(motor.kp));
+    std::memcpy(frame.data + 12, &motor.velocity, sizeof(motor.velocity));
+    std::memcpy(frame.data + 16, &motor.kd, sizeof(motor.kd));
+    std::memcpy(frame.data + 20, &motor.torque, sizeof(motor.torque));
+
+    motor = motors[2 * id + 1];
+    motor.timestamp = now;
+    std::memcpy(frame.data + 24, &motor.timestamp, sizeof(motor.timestamp));
+    std::memcpy(frame.data + 28, &motor.position, sizeof(motor.position));
+    std::memcpy(frame.data + 32, &motor.kp, sizeof(motor.kp));
+    std::memcpy(frame.data + 36, &motor.velocity, sizeof(motor.velocity));
+    std::memcpy(frame.data + 40, &motor.kd, sizeof(motor.kd));
+    std::memcpy(frame.data + 44, &motor.torque, sizeof(motor.torque));
+    send_success &= can_send_api_->send_can_message(frame);
+    std::this_thread::sleep_for(std::chrono::microseconds(150));
+  }
+  return send_success;
+}
+
+}  // namespace can_device
+

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_sdk/src/tita_robot.cpp
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_sdk/src/tita_robot.cpp
@@ -1,0 +1,181 @@
+#include "titati_sdk/tita_robot.hpp"
+
+namespace titati
+{
+
+std::vector<double> TitatiRobot::get_joint_q() const
+{
+  auto infos = can_receiver_->get_motors_in();
+  std::vector<double> joint;
+  joint.reserve(infos->size());
+  for (const auto &info : *infos)
+  {
+    joint.push_back(info.position);
+  }
+  return joint;
+}
+
+std::vector<double> TitatiRobot::get_joint_v() const
+{
+  auto infos = can_receiver_->get_motors_in();
+  std::vector<double> joint;
+  joint.reserve(infos->size());
+  for (const auto &info : *infos)
+  {
+    joint.push_back(info.velocity);
+  }
+  return joint;
+}
+
+std::vector<double> TitatiRobot::get_joint_t() const
+{
+  auto infos = can_receiver_->get_motors_in();
+  std::vector<double> joint;
+  joint.reserve(infos->size());
+  for (const auto &info : *infos)
+  {
+    joint.push_back(info.torque);
+  }
+  return joint;
+}
+
+std::vector<uint8_t> TitatiRobot::get_joint_status() const
+{
+  auto infos = can_receiver_->get_motors_status();
+  std::vector<uint8_t> joint;
+  joint.reserve(8);
+  for (size_t id = 0; id < 8; id++)
+  {
+    joint.push_back(infos->value[id]);
+  }
+  return joint;
+}
+
+std::array<double, 4> TitatiRobot::get_imu_quaternion() const
+{
+  auto infos = can_receiver_->get_imu_data();
+  std::array<double, 4> data{};
+  for (size_t i = 0; i < 4; i++)
+  {
+    data[i] = infos->quaternion[i];
+  }
+  return data;
+}
+
+std::array<double, 3> TitatiRobot::get_imu_acceleration() const
+{
+  auto infos = can_receiver_->get_imu_data();
+  std::array<double, 3> data{};
+  for (size_t i = 0; i < 3; i++)
+  {
+    data[i] = infos->accl[i];
+  }
+  return data;
+}
+
+std::array<double, 3> TitatiRobot::get_imu_angular_velocity() const
+{
+  auto infos = can_receiver_->get_imu_data();
+  std::array<double, 3> data{};
+  for (size_t i = 0; i < 3; i++)
+  {
+    data[i] = infos->gyro[i];
+  }
+  return data;
+}
+
+bool TitatiRobot::set_target_joint_t(const std::vector<double> &t)
+{
+  std::vector<can_device::motor_out> motors;
+  motors.reserve(motor_num_);
+  for (size_t id = 0; id < motor_num_; id++)
+  {
+    can_device::motor_out motor{};
+    motor.torque = t[id];
+    motor.kp = 0.0f;
+    motor.kd = 0.0f;
+    motor.velocity = 0.0f;
+    motor.position = 0.0f;
+    motors.push_back(motor);
+  }
+  return can_sender_->send_motors_can(motors);
+}
+
+bool TitatiRobot::set_target_joint_mit(
+  const std::vector<double> &q, const std::vector<double> &v,
+  const std::vector<double> &kp, const std::vector<double> &kd,
+  const std::vector<double> &t)
+{
+  std::vector<can_device::motor_out> motors;
+  motors.reserve(motor_num_);
+  for (size_t id = 0; id < motor_num_; id++)
+  {
+    can_device::motor_out motor{};
+    motor.torque = t[id];
+    motor.kp = kp[id];
+    motor.kd = kd[id];
+    motor.velocity = v[id];
+    motor.position = q[id];
+    motors.push_back(motor);
+  }
+  return can_sender_->send_motors_can(motors);
+}
+
+bool TitatiRobot::set_motors_sdk(bool if_sdk)
+{
+  can_device::RpcRequest rpc_request{};
+  rpc_request.key = can_device::SET_READY_NEXT;
+  rpc_request.value = READY_WAITING;
+  bool return_ok = can_sender_->send_command_can_rpc_request(rpc_request);
+  std::this_thread::sleep_for(std::chrono::microseconds(100));
+  rpc_request.value = if_sdk ? FORCE_DIRECT : AUTO_LOCOMOTION;
+  return_ok &= can_sender_->send_command_can_rpc_request(rpc_request);
+  return return_ok;
+}
+
+bool TitatiRobot::set_rc_input(ChannelInput input)
+{
+  can_device::ChannelInput can_input{};
+  can_input.forward = input.forward;
+  can_input.yaw = input.yaw;
+  can_input.pitch = input.pitch;
+  can_input.roll = input.roll;
+  can_input.height = input.height;
+  can_input.split = input.split;
+  can_input.tilt = input.tilt;
+  can_input.forward_accel = input.forward_accel;
+  can_input.yaw_accel = input.yaw_accel;
+  return can_sender_->send_command_can_channel_input(can_input);
+}
+
+bool TitatiRobot::set_robot_stand(bool stand)
+{
+  can_device::RpcRequest rpc_request{};
+  rpc_request.key = can_device::SET_STAND_MODE;
+  rpc_request.value = !stand ? 0x01U : 0x02U;
+  return can_sender_->send_command_can_rpc_request(rpc_request);
+}
+
+bool TitatiRobot::set_robot_jump(bool jump)
+{
+  can_device::RpcRequest rpc_request{};
+  rpc_request.key = can_device::SET_JUMP;
+  rpc_request.value = !jump ? 0x01U : 0x02U;
+  return can_sender_->send_command_can_rpc_request(rpc_request);
+}
+
+bool TitatiRobot::set_robot_stop()
+{
+  can_device::RpcRequest rpc_request{};
+  rpc_request.value = 0x01U;
+  rpc_request.key = can_device::SET_STAND_MODE;
+  bool return_ok = can_sender_->send_command_can_rpc_request(rpc_request);
+  std::this_thread::sleep_for(std::chrono::microseconds(200));
+  rpc_request.value = 0x02U;
+  rpc_request.key = can_device::SET_JUMP;
+  return_ok &= can_sender_->send_command_can_rpc_request(rpc_request);
+  return return_ok;
+}
+
+}  // namespace titati
+

--- a/rl_sar/src/rl_sar/src/rl_real_titati.cpp
+++ b/rl_sar/src/rl_sar/src/rl_real_titati.cpp
@@ -1,0 +1,288 @@
+/*
+* Copyright (c) 2024-2025 Ziqi Fan
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+#include "rl_real_titati.hpp"
+
+#include <unistd.h>
+
+#include <iostream>
+
+RL_Real::RL_Real()
+    : robot(nullptr)
+{
+    this->ang_vel_type = "ang_vel_body";
+    this->robot_name = "titati";
+    this->ReadYamlBase(this->robot_name);
+
+    if (FSMManager::GetInstance().IsTypeSupported(this->robot_name))
+    {
+        auto fsm_ptr = FSMManager::GetInstance().CreateFSM(this->robot_name, this);
+        if (fsm_ptr)
+        {
+            this->fsm = *fsm_ptr;
+        }
+    }
+    else
+    {
+        std::cout << LOGGER::ERROR << "No FSM registered for robot: " << this->robot_name << std::endl;
+    }
+
+    torch::autograd::GradMode::set_enabled(false);
+    torch::set_num_threads(4);
+
+    this->robot = std::make_unique<titati::TitatiRobot>(this->params.num_of_dofs);
+    if (!this->robot->set_motors_sdk(true))
+    {
+        std::cout << LOGGER::WARNING << "Failed to switch Titati into SDK control mode" << std::endl;
+    }
+
+    this->InitOutputs();
+    this->InitControl();
+
+    this->loop_keyboard = std::make_shared<LoopFunc>("loop_keyboard", 0.05, std::bind(&RL_Real::KeyboardInterface, this));
+    this->loop_control = std::make_shared<LoopFunc>("loop_control", this->params.dt, std::bind(&RL_Real::RobotControl, this));
+    this->loop_rl = std::make_shared<LoopFunc>("loop_rl", this->params.dt * this->params.decimation, std::bind(&RL_Real::RunModel, this));
+    this->loop_keyboard->start();
+    this->loop_control->start();
+    this->loop_rl->start();
+
+#ifdef PLOT
+    this->plot_t = std::vector<int>(this->plot_size, 0);
+    this->plot_real_joint_pos.resize(this->params.num_of_dofs);
+    this->plot_target_joint_pos.resize(this->params.num_of_dofs);
+    for (auto &vector : this->plot_real_joint_pos) { vector = std::vector<double>(this->plot_size, 0); }
+    for (auto &vector : this->plot_target_joint_pos) { vector = std::vector<double>(this->plot_size, 0); }
+    this->loop_plot = std::make_shared<LoopFunc>("loop_plot", 0.002, std::bind(&RL_Real::Plot, this));
+    this->loop_plot->start();
+#endif
+#ifdef CSV_LOGGER
+    this->CSVInit(this->robot_name);
+#endif
+}
+
+RL_Real::~RL_Real()
+{
+    this->loop_keyboard->shutdown();
+    this->loop_control->shutdown();
+    this->loop_rl->shutdown();
+#ifdef PLOT
+    this->loop_plot->shutdown();
+#endif
+
+    if (this->robot)
+    {
+        std::vector<double> zero_torque(this->params.num_of_dofs, 0.0);
+        this->robot->set_target_joint_t(zero_torque);
+        this->robot->set_motors_sdk(false);
+    }
+
+    std::cout << LOGGER::INFO << "RL_Real exit" << std::endl;
+}
+
+void RL_Real::GetState(RobotState<double> *state)
+{
+    auto joint_q = this->robot->get_joint_q();
+    auto joint_dq = this->robot->get_joint_v();
+    auto joint_t = this->robot->get_joint_t();
+
+    auto quat = this->robot->get_imu_quaternion();
+    auto acc = this->robot->get_imu_acceleration();
+    auto gyro = this->robot->get_imu_angular_velocity();
+
+    state->imu.quaternion[0] = quat[3];
+    state->imu.quaternion[1] = quat[0];
+    state->imu.quaternion[2] = quat[1];
+    state->imu.quaternion[3] = quat[2];
+
+    for (int i = 0; i < 3; ++i)
+    {
+        state->imu.gyroscope[i] = gyro[i];
+        state->imu.accelerometer[i] = acc[i];
+    }
+
+    for (int i = 0; i < this->params.num_of_dofs; ++i)
+    {
+        state->motor_state.q[i] = joint_q[i];
+        state->motor_state.dq[i] = joint_dq[i];
+        state->motor_state.tau_est[i] = joint_t[i];
+    }
+}
+
+void RL_Real::SetCommand(const RobotCommand<double> *command)
+{
+    std::vector<double> q(this->params.num_of_dofs, 0.0);
+    std::vector<double> dq(this->params.num_of_dofs, 0.0);
+    std::vector<double> kp(this->params.num_of_dofs, 0.0);
+    std::vector<double> kd(this->params.num_of_dofs, 0.0);
+    std::vector<double> tau(this->params.num_of_dofs, 0.0);
+
+    for (int i = 0; i < this->params.num_of_dofs; ++i)
+    {
+        q[i] = command->motor_command.q[i];
+        dq[i] = command->motor_command.dq[i];
+        kp[i] = command->motor_command.kp[i];
+        kd[i] = command->motor_command.kd[i];
+        tau[i] = command->motor_command.tau[i];
+    }
+
+    this->robot->set_target_joint_mit(q, dq, kp, kd, tau);
+}
+
+void RL_Real::RobotControl()
+{
+    this->motiontime++;
+
+    if (this->control.current_keyboard == Input::Keyboard::W)
+    {
+        this->control.x += 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::S)
+    {
+        this->control.x -= 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::A)
+    {
+        this->control.y += 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::D)
+    {
+        this->control.y -= 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::Q)
+    {
+        this->control.yaw += 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::E)
+    {
+        this->control.yaw -= 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::Space)
+    {
+        this->control.x = 0;
+        this->control.y = 0;
+        this->control.yaw = 0;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::N)
+    {
+        this->control.navigation_mode = !this->control.navigation_mode;
+        std::cout << std::endl << LOGGER::INFO << "Navigation mode: " << (this->control.navigation_mode ? "ON" : "OFF") << std::endl;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+
+    this->GetState(&this->robot_state);
+    this->StateController(&this->robot_state, &this->robot_command);
+    this->SetCommand(&this->robot_command);
+}
+
+void RL_Real::RunModel()
+{
+    if (this->rl_init_done)
+    {
+        this->episode_length_buf += 1;
+        this->obs.ang_vel = torch::tensor(this->robot_state.imu.gyroscope).unsqueeze(0);
+        if (this->control.navigation_mode)
+        {
+            this->obs.commands = torch::zeros({1, 3});
+        }
+        else
+        {
+            this->obs.commands = torch::tensor({{this->control.x, this->control.y, this->control.yaw}});
+        }
+        this->obs.base_quat = torch::tensor(this->robot_state.imu.quaternion).unsqueeze(0);
+        this->obs.dof_pos = torch::tensor(this->robot_state.motor_state.q).narrow(0, 0, this->params.num_of_dofs).unsqueeze(0);
+        this->obs.dof_vel = torch::tensor(this->robot_state.motor_state.dq).narrow(0, 0, this->params.num_of_dofs).unsqueeze(0);
+
+        this->obs.actions = this->Forward();
+        this->ComputeOutput(this->obs.actions, this->output_dof_pos, this->output_dof_vel, this->output_dof_tau);
+
+        if (this->output_dof_pos.defined() && this->output_dof_pos.numel() > 0)
+        {
+            output_dof_pos_queue.push(this->output_dof_pos);
+        }
+        if (this->output_dof_vel.defined() && this->output_dof_vel.numel() > 0)
+        {
+            output_dof_vel_queue.push(this->output_dof_vel);
+        }
+        if (this->output_dof_tau.defined() && this->output_dof_tau.numel() > 0)
+        {
+            output_dof_tau_queue.push(this->output_dof_tau);
+        }
+
+        this->TorqueProtect(this->output_dof_tau);
+
+#ifdef CSV_LOGGER
+        torch::Tensor tau_est = torch::tensor(this->robot_state.motor_state.tau_est).unsqueeze(0);
+        this->CSVLogger(this->output_dof_tau, tau_est, this->obs.dof_pos, this->output_dof_pos, this->obs.dof_vel);
+#endif
+    }
+}
+
+torch::Tensor RL_Real::Forward()
+{
+    torch::autograd::GradMode::set_enabled(false);
+
+    torch::Tensor clamped_obs = this->ComputeObservation();
+
+    torch::Tensor actions;
+    if (!this->params.observations_history.empty())
+    {
+        this->history_obs_buf.insert(clamped_obs);
+        this->history_obs = this->history_obs_buf.get_obs_vec(this->params.observations_history);
+        actions = this->model.forward({this->history_obs}).toTensor();
+    }
+    else
+    {
+        actions = this->model.forward({clamped_obs}).toTensor();
+    }
+
+    if (this->params.clip_actions_upper.numel() != 0 && this->params.clip_actions_lower.numel() != 0)
+    {
+        return torch::clamp(actions, this->params.clip_actions_lower, this->params.clip_actions_upper);
+    }
+    else
+    {
+        return actions;
+    }
+}
+
+#ifdef PLOT
+void RL_Real::Plot()
+{
+    this->plot_t.erase(this->plot_t.begin());
+    this->plot_t.push_back(this->motiontime);
+    plt::cla();
+    plt::clf();
+    for (int i = 0; i < this->params.num_of_dofs; ++i)
+    {
+        this->plot_real_joint_pos[i].erase(this->plot_real_joint_pos[i].begin());
+        this->plot_target_joint_pos[i].erase(this->plot_target_joint_pos[i].begin());
+        this->plot_real_joint_pos[i].push_back(this->robot_state.motor_state.q[i]);
+        this->plot_target_joint_pos[i].push_back(this->output_dof_pos[0][i].item<double>());
+        plt::subplot(this->params.num_of_dofs, 1, i + 1);
+        plt::named_plot("_real_joint_pos", this->plot_t, this->plot_real_joint_pos[i], "r");
+        plt::named_plot("_target_joint_pos", this->plot_t, this->plot_target_joint_pos[i], "b");
+        plt::xlim(this->plot_t.front(), this->plot_t.back());
+    }
+    plt::pause(0.0001);
+}
+#endif
+
+int main(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    RL_Real rl_sar;
+    while (1) { sleep(10); }
+    return 0;
+}
+

--- a/rl_sar/src/rl_sar/src/titati_motor_test.cpp
+++ b/rl_sar/src/rl_sar/src/titati_motor_test.cpp
@@ -1,0 +1,188 @@
+#include "titati_sdk/tita_robot.hpp"
+
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+void PrintState(const titati::TitatiRobot &robot)
+{
+    auto q = robot.get_joint_q();
+    auto dq = robot.get_joint_v();
+    auto tau = robot.get_joint_t();
+
+    std::cout << "\n=== Titati Motor State ===" << std::endl;
+    std::cout << std::fixed << std::setprecision(4);
+    for (std::size_t i = 0; i < q.size(); ++i)
+    {
+        std::cout << "Motor " << std::setw(2) << i
+                  << " | q: " << std::setw(9) << q[i]
+                  << " rad | dq: " << std::setw(9) << dq[i]
+                  << " rad/s | tau: " << std::setw(9) << tau[i] << " Nm" << std::endl;
+    }
+    std::cout << std::endl;
+}
+
+void SendTorque(titati::TitatiRobot &robot, std::size_t index, double torque)
+{
+    std::vector<double> torques(robot.motor_count(), 0.0);
+    if (index < torques.size())
+    {
+        torques[index] = torque;
+    }
+    robot.set_target_joint_t(torques);
+}
+
+void SendMIT(titati::TitatiRobot &robot, std::size_t index, double q, double dq, double kp, double kd, double tau)
+{
+    std::size_t count = robot.motor_count();
+    std::vector<double> target_q(count, 0.0);
+    std::vector<double> target_dq(count, 0.0);
+    std::vector<double> target_kp(count, 0.0);
+    std::vector<double> target_kd(count, 0.0);
+    std::vector<double> target_tau(count, 0.0);
+
+    if (index < count)
+    {
+        target_q[index] = q;
+        target_dq[index] = dq;
+        target_kp[index] = kp;
+        target_kd[index] = kd;
+        target_tau[index] = tau;
+    }
+    robot.set_target_joint_mit(target_q, target_dq, target_kp, target_kd, target_tau);
+}
+}
+
+int main(int argc, char **argv)
+{
+    std::size_t motor_count = 16;
+    if (argc > 1)
+    {
+        motor_count = static_cast<std::size_t>(std::stoul(argv[1]));
+    }
+
+    titati::TitatiRobot robot(motor_count);
+    if (!robot.set_motors_sdk(true))
+    {
+        std::cerr << "[WARNING] Failed to switch Titati into SDK control mode. Commands may not take effect." << std::endl;
+    }
+
+    std::cout << "Titati motor test utility" << std::endl;
+    std::cout << "Commands:" << std::endl;
+    std::cout << "  status                -> print current joint state" << std::endl;
+    std::cout << "  torque <id> <tau>     -> apply feed-forward torque (Nm) to a motor" << std::endl;
+    std::cout << "  mit <id> <q> <dq> <kp> <kd> <tau> -> send MIT command to a motor" << std::endl;
+    std::cout << "  zero                  -> zero torque on all motors" << std::endl;
+    std::cout << "  watch <seconds>       -> continuously print state" << std::endl;
+    std::cout << "  help                  -> print this help" << std::endl;
+    std::cout << "  exit / quit           -> leave test program" << std::endl;
+
+    std::string line;
+    while (true)
+    {
+        std::cout << "tester> " << std::flush;
+        if (!std::getline(std::cin, line))
+        {
+            break;
+        }
+
+        std::istringstream iss(line);
+        std::string cmd;
+        if (!(iss >> cmd))
+        {
+            continue;
+        }
+
+        if (cmd == "status")
+        {
+            PrintState(robot);
+        }
+        else if (cmd == "watch")
+        {
+            double seconds = 5.0;
+            iss >> seconds;
+            auto start = std::chrono::steady_clock::now();
+            while (std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count() < seconds)
+            {
+                PrintState(robot);
+                std::this_thread::sleep_for(std::chrono::milliseconds(200));
+            }
+        }
+        else if (cmd == "torque")
+        {
+            std::size_t id;
+            double tau;
+            if (iss >> id >> tau)
+            {
+                if (id >= robot.motor_count())
+                {
+                    std::cout << "[ERROR] Motor id out of range" << std::endl;
+                    continue;
+                }
+                SendTorque(robot, id, tau);
+                std::cout << "Applied torque command to motor " << id << std::endl;
+            }
+            else
+            {
+                std::cout << "Usage: torque <id> <tau>" << std::endl;
+            }
+        }
+        else if (cmd == "mit")
+        {
+            std::size_t id;
+            double q, dq, kp, kd, tau;
+            if (iss >> id >> q >> dq >> kp >> kd >> tau)
+            {
+                if (id >= robot.motor_count())
+                {
+                    std::cout << "[ERROR] Motor id out of range" << std::endl;
+                    continue;
+                }
+                SendMIT(robot, id, q, dq, kp, kd, tau);
+                std::cout << "Sent MIT command to motor " << id << std::endl;
+            }
+            else
+            {
+                std::cout << "Usage: mit <id> <q> <dq> <kp> <kd> <tau>" << std::endl;
+            }
+        }
+        else if (cmd == "zero")
+        {
+            std::vector<double> torques(robot.motor_count(), 0.0);
+            robot.set_target_joint_t(torques);
+            std::cout << "All torques cleared" << std::endl;
+        }
+        else if (cmd == "help")
+        {
+            std::cout << "Commands:" << std::endl;
+            std::cout << "  status                -> print current joint state" << std::endl;
+            std::cout << "  torque <id> <tau>     -> apply feed-forward torque (Nm) to a motor" << std::endl;
+            std::cout << "  mit <id> <q> <dq> <kp> <kd> <tau> -> send MIT command to a motor" << std::endl;
+            std::cout << "  zero                  -> zero torque on all motors" << std::endl;
+            std::cout << "  watch <seconds>       -> continuously print state" << std::endl;
+            std::cout << "  help                  -> print this help" << std::endl;
+            std::cout << "  exit / quit           -> leave test program" << std::endl;
+        }
+        else if (cmd == "exit" || cmd == "quit")
+        {
+            break;
+        }
+        else
+        {
+            std::cout << "Unknown command. Type 'help' for usage." << std::endl;
+        }
+    }
+
+    std::vector<double> torques(robot.motor_count(), 0.0);
+    robot.set_target_joint_t(torques);
+    robot.set_motors_sdk(false);
+    std::cout << "Tester exit" << std::endl;
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- port the Titati CAN hardware SDK into rl_sar and expose a reusable C++17 TitatiRobot wrapper
- add a real-robot controller (rl_real_titati) and an interactive titati_motor_test utility for torque/MIT checks
- update the CMake build, build script and documentation for C++17, Titati-only deployment and no-ROS workflow

## Testing
- `./build.sh -m rl_real_titati titati_motor_test` *(fails: TorchConfig.cmake not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d501f4482883219d6c5aa482e16ccb