### PR TITLE
Add Titati hardware support and tooling for rl_sar deployment

### DIFF
--- a/rl_sar/README.md
+++ b/rl_sar/README.md
@@ -343,6 +343,67 @@ Pull the code and compile it. The process is the same as above.
 
 <details>
 
+<summary>DDTRobot Titati (Click to expand)</summary>
+
+This configuration targets the Titati quadruped assembled from two Tita wheel-legged bases. No ROS runtime is required when
+building with `./build.sh -m`.
+
+#### Build
+
+```bash
+# Compile only the binaries needed for Titati hardware deployment
+./build.sh -m rl_real_titati titati_motor_test
+```
+
+The resulting executables are located in `cmake_build/bin/`.
+
+#### Preparation on each Jetson (master and slave)
+
+1. Bring up the CAN FD interface (adjust parameters to match your wiring):
+   ```bash
+   sudo ip link set can0 down
+   sudo ip link set can0 up type can bitrate 1000000 sample-point 0.80 dbitrate 8000000 dsample-point 0.80 fd on
+   sudo ifconfig can0 txqueuelen 1000
+   ```
+2. Switch the MCU to direct SDK mode using the helper tool:
+   ```bash
+   # On the master (controls 16 motors)
+   ./cmake_build/bin/titati_motor_test --mode direct --motors 16
+
+   # On the slave (controls 8 motors)
+   ./cmake_build/bin/titati_motor_test --mode direct --motors 8
+   ```
+   Running the command once is sufficient; it sends the required CAN RPC to change control mode. Use `--disable-sdk` to revert to
+   MCU control if needed.
+
+#### Optional motor sanity check
+
+Before deploying RL control, you can verify the drive chain:
+
+```bash
+# Apply 2 Nm sequential torque pulses to each joint
+./cmake_build/bin/titati_motor_test --mode torque --motors 16 --amplitude 2.0 --duration 0.6
+
+# Command small MIT position offsets (0.1 rad) sequentially
+./cmake_build/bin/titati_motor_test --mode mit --motors 16 --amplitude 0.1 --duration 0.6
+```
+
+Adjust `--motors` to `8` when checking an individual Tita base.
+
+#### Running the RL controller (master Jetson only)
+
+```bash
+./cmake_build/bin/rl_real_titati
+```
+
+Keyboard commands follow the standard mapping documented above. The slave Jetson only needs the `titati_motor_test --mode direct` step
+to keep its MCU in SDK mode; no additional process is required there. Ensure both machines remain connected through the Titati
+communication box during operation.
+
+</details>
+
+<details>
+
 <summary>Deeprobotics Lite3 (Click to expand)</summary>
 
 Deeprobotics Lite3 can be connected using wireless method.

--- a/rl_sar/README.md
+++ b/rl_sar/README.md
@@ -133,6 +133,12 @@ If simulation is not needed and you only want to run on the robot, you can compi
 ./build.sh -m  # or ./build.sh --cmake
 ```
 
+When using the CMake workflow you can optionally pass specific targets after `-m` to avoid building robots you do not use:
+
+```bash
+./build.sh -m rl_real_titati titati_motor_test
+```
+
 For detailed usage instructions, you can check them via `./build.sh -h`:
 
 ```bash

--- a/rl_sar/build.sh
+++ b/rl_sar/build.sh
@@ -64,12 +64,18 @@ ask_confirmation() {
 # ========================
 
 run_cmake_build() {
+    local targets=("$@")
     print_header "[Running CMake Build]"
     print_warning "NOTE: CMake build is for hardware deployment only, not for simulation."
     print_separator
 
     cmake src/rl_sar/ -B cmake_build -DUSE_CMAKE=ON
-    cmake --build cmake_build -j4
+    if [ ${#targets[@]} -gt 0 ]; then
+        print_info "Building CMake targets: ${targets[*]}"
+        cmake --build cmake_build --target "${targets[@]}" -j4
+    else
+        cmake --build cmake_build -j4
+    fi
 
     print_success "CMake build completed!"
 }
@@ -346,7 +352,7 @@ main() {
 
     # Handle CMake build mode
     if [ "$cmake_mode" = true ]; then
-        run_cmake_build
+        run_cmake_build "${packages[@]}"
         exit 0
     fi
 

--- a/rl_sar/src/rl_sar/CMakeLists.txt
+++ b/rl_sar/src/rl_sar/CMakeLists.txt
@@ -333,6 +333,9 @@ target_link_libraries(rl_real_titati
     observation_buffer
     yaml-cpp
 )
+target_include_directories(rl_real_titati PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/policy
+)
 if(NOT USE_CMAKE)
     if($ENV{ROS_DISTRO} MATCHES "noetic")
         target_link_libraries(rl_real_titati ${catkin_LIBRARIES})

--- a/rl_sar/src/rl_sar/CMakeLists.txt
+++ b/rl_sar/src/rl_sar/CMakeLists.txt
@@ -350,6 +350,11 @@ target_link_libraries(titati_motor_test
     titati_hw
     yaml-cpp
 )
+if(TARGET Torch::Torch)
+    target_link_libraries(titati_motor_test PRIVATE Torch::Torch)
+elseif(DEFINED TORCH_INCLUDE_DIRS)
+    target_include_directories(titati_motor_test PRIVATE ${TORCH_INCLUDE_DIRS})
+endif()
 
 if(NOT USE_CMAKE)
     if($ENV{ROS_DISTRO} MATCHES "noetic")

--- a/rl_sar/src/rl_sar/CMakeLists.txt
+++ b/rl_sar/src/rl_sar/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 project(rl_sar VERSION 3.0.0 LANGUAGES CXX)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 set(USE_CMAKE OFF CACHE BOOL "Use Cmake build system")
 message(STATUS "USE_CMAKE: ${USE_CMAKE}")
 if(USE_CMAKE)
@@ -158,10 +161,6 @@ include_directories(
 )
 
 add_library(rl_sdk library/core/rl_sdk/rl_sdk.cpp)
-set_target_properties(rl_sdk PROPERTIES
-    CXX_STANDARD 14
-    CXX_STANDARD_REQUIRED ON
-)
 target_link_libraries(rl_sdk PUBLIC
     "${TORCH_LIBRARIES}"
     Python3::Python
@@ -182,15 +181,21 @@ endif()
 
 add_library(observation_buffer library/core/observation_buffer/observation_buffer.cpp)
 target_link_libraries(observation_buffer PUBLIC "${TORCH_LIBRARIES}")
-set_target_properties(observation_buffer PROPERTIES
-    CXX_STANDARD 14
-    CXX_STANDARD_REQUIRED ON
-)
 if(NOT USE_CMAKE)
     if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
         install(TARGETS observation_buffer DESTINATION lib/${PROJECT_NAME})
     endif()
 endif()
+
+add_library(titati_hw
+    library/hardware/titati/src/can_receiver.cpp
+    library/hardware/titati/src/can_sender.cpp
+    library/hardware/titati/src/tita_robot.cpp
+)
+target_include_directories(titati_hw PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/library/hardware/titati/include
+)
+target_link_libraries(titati_hw PUBLIC Threads::Threads)
 
 if(NOT USE_CMAKE)
     add_executable(rl_sim src/rl_sim.cpp)
@@ -320,6 +325,31 @@ if(NOT USE_CMAKE)
         install(TARGETS rl_real_l4w4 DESTINATION lib/${PROJECT_NAME})
     endif()
 endif()
+
+add_executable(rl_real_titati src/rl_real_titati.cpp)
+target_link_libraries(rl_real_titati
+    titati_hw
+    rl_sdk
+    observation_buffer
+    yaml-cpp
+)
+if(NOT USE_CMAKE)
+    if($ENV{ROS_DISTRO} MATCHES "noetic")
+        target_link_libraries(rl_real_titati ${catkin_LIBRARIES})
+    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+        ament_target_dependencies(rl_real_titati
+            rclcpp
+            geometry_msgs
+        )
+        install(TARGETS rl_real_titati DESTINATION lib/${PROJECT_NAME})
+    endif()
+endif()
+
+add_executable(titati_motor_test src/titati_motor_test.cpp)
+target_link_libraries(titati_motor_test
+    titati_hw
+    yaml-cpp
+)
 
 if(NOT USE_CMAKE)
     if($ENV{ROS_DISTRO} MATCHES "noetic")

--- a/rl_sar/src/rl_sar/include/rl_real_titati.hpp
+++ b/rl_sar/src/rl_sar/include/rl_real_titati.hpp
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef RL_REAL_TITATI_HPP
+#define RL_REAL_TITATI_HPP
+
+// #define CSV_LOGGER
+
+#include "rl_sdk.hpp"
+#include "observation_buffer.hpp"
+#include "loop.hpp"
+#include "fsm.hpp"
+
+#include "titati_hw/tita_robot.hpp"
+
+#include <chrono>
+#include <memory>
+#include <vector>
+
+class RL_Real : public RL
+{
+public:
+    explicit RL_Real(bool wheel_torque_mode = true);
+    ~RL_Real();
+
+private:
+    torch::Tensor Forward() override;
+    void GetState(RobotState<double> *state) override;
+    void SetCommand(const RobotCommand<double> *command) override;
+    void RunModel();
+    void RobotControl();
+
+    std::shared_ptr<LoopFunc> loop_keyboard;
+    std::shared_ptr<LoopFunc> loop_control;
+    std::shared_ptr<LoopFunc> loop_rl;
+
+    std::unique_ptr<titati::hardware::TitatiRobot> robot_;
+    bool wheel_torque_mode_;
+
+    std::vector<double> joint_command_pos_;
+    std::vector<double> joint_command_vel_;
+    std::vector<double> joint_command_tau_;
+
+    int motiontime_ = 0;
+    std::chrono::steady_clock::time_point last_print_time_;
+};
+
+#endif  // RL_REAL_TITATI_HPP

--- a/rl_sar/src/rl_sar/library/hardware/titati/include/titati_hw/can_receiver.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/include/titati_hw/can_receiver.hpp
@@ -1,0 +1,116 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RL_SAR_TITATI_HW_CAN_RECEIVER_HPP_
+#define RL_SAR_TITATI_HW_CAN_RECEIVER_HPP_
+
+#include <algorithm>
+#include <atomic>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "titati_hw/protocol/can_utils.hpp"
+namespace can_device
+{
+#define PACKED __attribute__((__packed__))
+#define GRAVITY 9.81f
+#define CAN_ID_MOTOR_IN 0x108
+#define CAN_ID_IMU1 0x118
+#define CAN_ID_STATE 0x102
+
+  struct api_motor_in_t
+  {
+    uint32_t timestamp;
+    float position;
+    float velocity;
+    float torque;
+  } PACKED;
+  /* 44 bytes */
+  struct api_imu_data_t
+  {
+    uint32_t timestamp;
+    float accl[3];
+    float gyro[3];
+    float quaternion[4]; // x y z w
+    float temperature;
+  } PACKED;
+  
+  struct api_motor_status_t
+  {
+    uint32_t timestamp;
+    uint16_t key;
+    uint8_t value[8];
+  } PACKED;
+
+  class MotorsImuCanReceiveApi
+  {
+  public:
+    MotorsImuCanReceiveApi(size_t size)
+    {
+      if(size % 8 == 0) leg_dof_ = 4;
+      else if(size % 6 == 0) leg_dof_ = 3;
+      leg_num_ = size / leg_dof_;
+      register_motors_device_can_filter();
+      api_motor_in_t default_motor_in;
+      std::memset(&default_motor_in, 0x00U, sizeof(api_motor_in_t));
+      motors_in_.resize(size, default_motor_in);
+      std::memset(&imu_data_, 0x00U, sizeof(api_imu_data_t));
+    }
+    ~MotorsImuCanReceiveApi() {}
+    const std::vector<api_motor_in_t> *get_motors_in() const { return &motors_in_; }
+    const api_imu_data_t *get_imu_data() const { return &imu_data_; }
+    const api_motor_status_t *get_motors_status() const { return &motors_status_; }
+
+  private:
+#define MIN_TIME_OUT_US 1'000L     // 1ms
+#define MAX_TIME_OUT_US 3'000'000L // 3s
+#define CAN_MASK_AS_MOTORS_INFO (0x7E0U)
+    std::string motors_can_interface = "can0";
+    std::string motors_can_name = "motors_can";
+    bool motors_can_extended_frame = false;
+    bool motors_can_rx_is_block = false;
+    int64_t motors_timeout_us = MAX_TIME_OUT_US;
+    uint8_t motors_can_id_offset = 0x00U;
+
+    void register_motors_device_can_filter();
+    can_device::socket_can::can_fd_callback motors_can_receive_callback =
+        std::bind(&MotorsImuCanReceiveApi::board_can_data_callback, this, std::placeholders::_1);
+
+    std::shared_ptr<can_device::socket_can::CanDev> motors_can_receive_api =
+        std::make_shared<can_device::socket_can::CanDev>(
+            motors_can_interface, motors_can_name, motors_can_extended_frame, motors_can_receive_callback,
+            motors_can_rx_is_block, motors_timeout_us, motors_can_id_offset);
+
+    void board_can_data_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+    void motors_data_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+    void imu_data_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+    void motors_status_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+
+    std::vector<api_motor_in_t> motors_in_;
+    api_imu_data_t imu_data_;
+    api_motor_status_t motors_status_;
+
+    mutable std::shared_mutex motors_in_mutex_, imu_mutex_;
+    size_t leg_dof_{4}, leg_num_{2};
+  };
+} // namespace can_device
+
+#endif  // RL_SAR_TITATI_HW_CAN_RECEIVER_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/include/titati_hw/can_sender.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/include/titati_hw/can_sender.hpp
@@ -1,0 +1,120 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RL_SAR_TITATI_HW_CAN_SENDER_HPP_
+#define RL_SAR_TITATI_HW_CAN_SENDER_HPP_
+
+#include <algorithm>
+#include <atomic>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "titati_hw/protocol/can_utils.hpp"
+
+namespace can_device
+{
+
+#define CAN_ID_SEND_MOTORS (0x120U)
+#define CAN_ID_CHANNEL_INPUT (0x12DU)
+#define CAN_ID_RPC_REQUEST (0x170U)
+
+  enum ApiRpcKey
+  {
+    RPC_UNDEFINED = 0x000,
+    GET_MODEL_INFO = 0x100,
+    GET_SERIAL_NUMBER = 0x101,
+    SET_READY_NEXT = 0x200,
+    SET_BOARDCAST = 0x201,
+    SET_INPUT_MODE = 0x221,
+    SET_STAND_MODE = 0x222,
+    SET_HEAD_MODE = 0x223,
+    SET_JUMP = 0x231,
+    SET_MOTOR_ZERO = 0x280,
+  };
+  struct ChannelInput
+  {
+    uint32_t timestamp;
+    float forward;
+    float yaw;
+    float pitch;
+    float roll;
+    float height;
+    float split;
+    float tilt;
+    float forward_accel;
+    float yaw_accel;
+  };
+  struct RpcRequest
+  {
+    uint32_t timestamp;
+    uint16_t key;
+    uint32_t value;
+  };
+  struct motor_out
+  {
+    uint32_t timestamp;
+    float position;
+    float kp;
+    float velocity;
+    float kd;
+    float torque;
+  };
+
+  class MotorsCanSendApi
+  {
+  public:
+    MotorsCanSendApi(size_t size)
+    {
+      if (size % 8 == 0)
+        leg_dof_ = 4;
+      else if (size % 6 == 0)
+        leg_dof_ = 3;
+      leg_num_ = size / leg_dof_;
+    }
+    ~MotorsCanSendApi() = default;
+    bool send_motors_can(std::vector<motor_out> motors);
+    bool send_command_can_channel_input(ChannelInput data);
+    bool send_command_can_rpc_request(RpcRequest data);
+
+  private:
+#define MIN_TIME_OUT_US 1'000L     // 1ms
+#define MAX_TIME_OUT_US 3'000'000L // 3s
+    std::string can_interface = "can0";
+    std::string can_name = "motors_can_send";
+    int64_t timeout_us = MAX_TIME_OUT_US;
+    uint8_t can_id_offset = 0x00U;
+    bool can_extended_frame = false;
+    bool can_fd_mode = true;
+
+    std::shared_ptr<can_device::socket_can::CanDev> can_send_api_ =
+        std::make_shared<can_device::socket_can::CanDev>(
+            can_interface, can_name, can_extended_frame, can_fd_mode, timeout_us, can_id_offset);
+
+    inline uint32_t get_current_time()
+    {
+      struct timeval tv;
+      gettimeofday(&tv, NULL);
+      return std::move(tv.tv_sec * 1000000 + tv.tv_usec);
+    }
+    size_t leg_dof_{4}, leg_num_{2};
+  };
+} // namespace can_device
+
+#endif  // RL_SAR_TITATI_HW_CAN_SENDER_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/include/titati_hw/protocol/can_utils.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/include/titati_hw/protocol/can_utils.hpp
@@ -1,0 +1,468 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RL_SAR_TITATI_HW_PROTOCOL_CAN_UTILS_HPP_
+#define RL_SAR_TITATI_HW_PROTOCOL_CAN_UTILS_HPP_
+
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "linux/can.h"
+#include "linux/can/error.h"
+#include "linux/can/raw.h"
+#include "titati_hw/protocol/socket_can_receiver.hpp"
+#include "titati_hw/protocol/socket_can_sender.hpp"
+
+#define C_END "\033[m"
+// #define C_RED "\033[0;32;31m"
+#define C_RED "\033[0;31m"
+#define C_YELLOW "\033[1;33m"
+
+#ifdef GCC_OPTIMIZE_03
+#pragma GCC optimize("O3")
+#else
+#pragma GCC optimize("O0")
+#endif
+namespace can_device
+{
+namespace socket_can
+{
+using can_std_callback = std::function<void(std::shared_ptr<struct can_frame> recv_frame)>;
+using can_fd_callback = std::function<void(std::shared_ptr<struct canfd_frame> recv_frame)>;
+class CanRxDev
+{
+public:
+  explicit CanRxDev(
+    const std::string & interface, const std::string & name, can_std_callback recv_callback,
+    bool is_block, int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    init(interface, name, false, recv_callback, nullptr, is_block, nano_timeout);
+  }
+  explicit CanRxDev(
+    const std::string & interface, const std::string & name, can_fd_callback recv_callback,
+    bool is_block, int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    init(interface, name, true, nullptr, recv_callback, is_block, nano_timeout);
+  }
+
+  ~CanRxDev()
+  {
+    ready_ = false;
+    isthreadrunning_ = false;
+    if (main_T_ != nullptr) {
+      main_T_->join();
+    }
+    main_T_ = nullptr;
+    receiver_ = nullptr;
+  }
+
+  bool is_ready() { return ready_; }
+  bool is_timeout() { return is_timeout_; }
+  void set_filter(const struct can_filter filter[], size_t s)
+  {
+    if (receiver_ != nullptr) {
+      receiver_->set_filter(filter, s);
+    }
+  }
+
+  std::shared_ptr<canfd_frame> wait_for_can_data_block()
+  {
+    can_device::socket_can::CanId receive_id{};
+    std::string can_type;
+    if (canfd_) {
+      can_type = "FD";
+      rx_fd_frame_ = std::make_shared<struct canfd_frame>();
+    } else {
+      can_type = "STD";
+      rx_std_frame_ = std::make_shared<struct can_frame>();
+    }
+    if (receiver_ != nullptr) {
+      try {
+        bool result =
+          canfd_ ? receiver_->receive(rx_fd_frame_, std::chrono::nanoseconds(nano_timeout_))
+                 : receiver_->receive(rx_std_frame_, std::chrono::nanoseconds(nano_timeout_));
+        if (result) {
+          is_timeout_ = false;
+          return rx_fd_frame_;
+        } else {
+          return nullptr;
+        }
+      } catch (const std::exception & ex) {
+        if (ex.what()[0] == '$') {
+          is_timeout_ = true;
+          return nullptr;
+        }
+      }
+    } else {
+      isthreadrunning_ = false;
+      printf(
+        C_RED
+        "[CAN_RX %s][ERROR][%s] Error receiving CAN %s message: %s, "
+        "no receiver init\r\n" C_END,
+        can_type.c_str(), name_.c_str(), can_type.c_str(), interface_.c_str());
+    }
+    return nullptr;
+  }
+
+#ifdef COMMON_PROTOCOL_TEST
+  bool testing_setcandata(can_frame frame)
+  {
+    if (can_std_callback_ != nullptr) {
+      can_std_callback_(std::make_shared<struct can_frame>(frame));
+      return true;
+    }
+    return false;
+  }
+  bool testing_setcandata(canfd_frame frame)
+  {
+    if (can_fd_callback_ != nullptr) {
+      can_fd_callback_(std::make_shared<struct canfd_frame>(frame));
+      return true;
+    }
+    return false;
+  }
+#endif  // COMMON_PROTOCOL_TEST
+
+private:
+  bool ready_;
+  bool canfd_;
+  bool is_timeout_;
+  bool extended_frame_;
+  bool isthreadrunning_;
+  int64_t nano_timeout_;
+  std::string name_;
+  std::string interface_;
+  can_std_callback can_std_callback_;
+  can_fd_callback can_fd_callback_;
+  std::unique_ptr<std::thread> main_T_;
+  std::shared_ptr<struct can_frame> rx_std_frame_;
+  std::shared_ptr<struct canfd_frame> rx_fd_frame_;
+  std::unique_ptr<can_device::socket_can::SocketCanReceiver> receiver_;
+  uint8_t can_id_offset_ = 0;
+  void init(
+    const std::string & interface, const std::string & name, bool canfd_on,
+    can_std_callback std_callback, can_fd_callback fd_callback, bool is_block, int64_t nano_timeout)
+  {
+    name_ = name;
+    interface_ = interface;
+    canfd_ = canfd_on;
+    nano_timeout_ = nano_timeout;
+    is_timeout_ = false;
+    interface_ = interface;
+    can_std_callback_ = std_callback;
+    can_fd_callback_ = fd_callback;
+    try {
+      receiver_ = std::make_unique<can_device::socket_can::SocketCanReceiver>(interface_, canfd_);
+      if (!is_block) {
+        isthreadrunning_ = true;
+        ready_ = true;
+        main_T_ = std::make_unique<std::thread>(std::bind(&CanRxDev::main_recv_func, this));
+      }
+    } catch (const std::exception & ex) {
+      printf(
+        C_RED "[CAN_RX][ERROR][%s] %s receiver creat error! %s\r\n" C_END, name_.c_str(),
+        interface_.c_str(), ex.what());
+      return;
+    }
+  }
+
+  bool wait_for_can_data()
+  {
+    can_device::socket_can::CanId receive_id{};
+    std::string can_type;
+    if (canfd_) {
+      can_type = "FD";
+      rx_fd_frame_ = std::make_shared<struct canfd_frame>();
+    } else {
+      can_type = "STD";
+      rx_std_frame_ = std::make_shared<struct can_frame>();
+    }
+
+    if (receiver_ != nullptr) {
+      try {
+        bool result =
+          canfd_ ? receiver_->receive(rx_fd_frame_, std::chrono::nanoseconds(nano_timeout_))
+                 : receiver_->receive(rx_std_frame_, std::chrono::nanoseconds(nano_timeout_));
+        if (result) {
+          is_timeout_ = false;
+        }
+        return result;
+      } catch (const std::exception & ex) {
+        if (ex.what()[0] == '$') {
+          is_timeout_ = true;
+          return false;
+        }
+        printf(
+          C_RED "[CAN_RX %s][ERROR][%s] Error receiving CAN %s message: %s - %s\n" C_END,
+          can_type.c_str(), name_.c_str(), can_type.c_str(), interface_.c_str(), ex.what());
+      }
+    } else {
+      isthreadrunning_ = false;
+      printf(
+        C_RED
+        "[CAN_RX %s][ERROR][%s] Error receiving CAN %s message: %s, "
+        "no receiver init\r\n" C_END,
+        can_type.c_str(), name_.c_str(), can_type.c_str(), interface_.c_str());
+    }
+    return false;
+  }
+
+  void main_recv_func()
+  {
+#ifdef DEBUG_LOG
+    printf("[CAN_RX][INFO][%s] Start recv thread: %s\r\n", interface_.c_str(), name_.c_str());
+#endif  // DEBUG_LOG
+    while (isthreadrunning_ && ready_) {
+      if (wait_for_can_data()) {
+        if (!canfd_ && can_std_callback_ != nullptr) {
+          can_std_callback_(rx_std_frame_);
+        } else if (canfd_ && can_fd_callback_ != nullptr) {
+          can_fd_callback_(rx_fd_frame_);
+        }
+      }
+    }
+#ifdef DEBUG_LOG
+    printf("[CAN_RX][INFO][%s] Exit recv thread: %s\r\n", interface_.c_str(), name_.c_str());
+#endif  // DEBUG_LOG
+  }
+};
+
+class CanTxDev
+{
+public:
+  explicit CanTxDev(
+    const std::string & interface, const std::string & name, bool extended_frame, bool canfd_on,
+    int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    can_id_offset_ = can_id_offset;
+    ready_ = false;
+    name_ = name;
+    nano_timeout_ = nano_timeout;
+    is_timeout_ = false;
+    canfd_on_ = canfd_on;
+    interface_ = interface;
+    extended_frame_ = extended_frame;
+    try {
+      sender_ = std::make_unique<can_device::socket_can::SocketCanSender>(interface_, canfd_on_);
+    } catch (const std::exception & ex) {
+      printf(
+        C_RED "[CAN_TX][ERROR][%s] %s sender creat error! %s\r\n" C_END, name_.c_str(),
+        interface_.c_str(), ex.what());
+      return;
+    }
+    ready_ = true;
+  }
+
+  ~CanTxDev()
+  {
+    ready_ = false;
+    sender_ = nullptr;
+  }
+
+  bool send_can_message(struct can_frame & tx_frame)
+  {
+    return send_can_message(&tx_frame, nullptr);
+  }
+  bool send_can_message(struct canfd_frame & tx_frame)
+  {
+    return send_can_message(nullptr, &tx_frame);
+  }
+
+  bool is_ready() { return ready_; }
+  bool is_timeout() { return is_timeout_; }
+
+private:
+  bool ready_;
+  bool canfd_on_;
+  bool is_timeout_;
+  bool extended_frame_;
+  int64_t nano_timeout_;
+  std::string name_;
+  std::string interface_;
+  std::unique_ptr<can_device::socket_can::SocketCanSender> sender_;
+  uint8_t can_id_offset_;
+
+  bool send_can_message(struct can_frame * std_frame, struct canfd_frame * fd_frame)
+  {
+    bool self_fd = (fd_frame != nullptr);
+    std::string can_type = self_fd ? "FD" : "STD";
+    if (canfd_on_ != self_fd) {
+      printf(
+        C_RED
+        "[CAN_TX %s][ERROR][%s] Error sending CAN message: %s - "
+        "Not support can/canfd frame mixed\r\n" C_END,
+        can_type.c_str(), name_.c_str(), interface_.c_str());
+      return false;
+    }
+    canid_t * canid = self_fd ? &fd_frame->can_id : &std_frame->can_id;
+
+    bool result = true;
+    can_device::socket_can::CanId send_id =
+      extended_frame_
+        ? can_device::socket_can::CanId(
+            *canid, can_device::socket_can::FrameType::DATA, can_device::socket_can::ExtendedFrame)
+        : can_device::socket_can::CanId(
+            *canid, can_device::socket_can::FrameType::DATA, can_device::socket_can::StandardFrame);
+    if (sender_ != nullptr) {
+      try {
+        if (self_fd) {
+          sender_->send_fd(
+            fd_frame->data, (fd_frame->len == 0) ? 64 : fd_frame->len, send_id,
+            std::chrono::nanoseconds(nano_timeout_));
+          is_timeout_ = false;
+        } else {
+          sender_->send(
+            std_frame->data, (std_frame->can_dlc == 0) ? 8 : std_frame->can_dlc, send_id,
+            std::chrono::nanoseconds(nano_timeout_));
+          is_timeout_ = false;
+        }
+      } catch (const std::exception & ex) {
+        if (ex.what()[0] == '$') {
+          is_timeout_ = true;
+          return false;
+        }
+        result = false;
+        printf(
+          C_RED "[CAN_TX %s][ERROR][%s] Error sending CAN message: %s - %s\r\n" C_END,
+          can_type.c_str(), name_.c_str(), interface_.c_str(), ex.what());
+      }
+    } else {
+      result = false;
+      printf(
+        C_RED "[CAN_TX %s][ERROR][%s] Error sending CAN message: %s - No device\r\n" C_END,
+        can_type.c_str(), name_.c_str(), interface_.c_str());
+    }
+    return result;
+  }
+};
+
+class CanDev
+{
+public:
+  explicit CanDev(
+    const std::string & interface, const std::string & name, bool extended_frame,
+    can_std_callback recv_callback, bool is_block, int64_t nano_timeout = -1,
+    uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    name_ = name;
+    send_only_ = false;
+    tx_op_ = std::make_unique<CanTxDev>(
+      interface, name_, extended_frame, false, nano_timeout, can_id_offset_);
+    rx_op_ = std::make_unique<CanRxDev>(
+      interface, name_, recv_callback, is_block, nano_timeout, can_id_offset_);
+  }
+  explicit CanDev(
+    const std::string & interface, const std::string & name, bool extended_frame,
+    can_fd_callback recv_callback, bool is_block, int64_t nano_timeout = -1,
+    uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    name_ = name;
+    send_only_ = false;
+    tx_op_ = std::make_unique<CanTxDev>(
+      interface, name_, extended_frame, true, nano_timeout, can_id_offset_);
+    rx_op_ = std::make_unique<CanRxDev>(
+      interface, name_, recv_callback, is_block, nano_timeout, can_id_offset_);
+  }
+  explicit CanDev(
+    const std::string & interface, const std::string & name, bool extended_frame, bool canfd_on,
+    int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    name_ = name;
+    send_only_ = true;
+    tx_op_ = std::make_unique<CanTxDev>(
+      interface, name_, extended_frame, canfd_on, nano_timeout, can_id_offset_);
+  }
+
+  ~CanDev()
+  {
+    rx_op_ = nullptr;
+    tx_op_ = nullptr;
+  }
+
+  std::shared_ptr<canfd_frame> receive_can_message_block()
+  {
+    return rx_op_->wait_for_can_data_block();
+  }
+
+  bool send_can_message(struct can_frame & tx_frame)
+  {
+#ifdef COMMON_PROTOCOL_TEST
+    if (rx_op_ != nullptr) {
+      return rx_op_->testing_setcandata(tx_frame);
+    }
+    return false;
+#else
+    if (tx_op_ != nullptr) {
+      return tx_op_->send_can_message(tx_frame);
+    }
+    return false;
+#endif  // COMMON_PROTOCOL_TEST
+  }
+
+  bool send_can_message(struct canfd_frame & tx_frame)
+  {
+#ifdef COMMON_PROTOCOL_TEST
+    if (rx_op_ != nullptr) {
+      return rx_op_->testing_setcandata(tx_frame);
+    }
+    return false;
+#else
+    if (tx_op_ != nullptr) {
+      return tx_op_->send_can_message(tx_frame);
+    }
+    return false;
+#endif  // COMMON_PROTOCOL_TEST
+  }
+
+  void set_filter(const struct can_filter filter[], size_t s)
+  {
+    if (rx_op_ != nullptr) {
+      rx_op_->set_filter(filter, s);
+    }
+  }
+  bool is_send_only() { return send_only_; }
+  bool is_ready()
+  {
+    bool result = (tx_op_ == nullptr) ? false : tx_op_->is_ready();
+    if (send_only_) {
+      return result;
+    } else {
+      return result && ((rx_op_ == nullptr) ? false : rx_op_->is_ready());
+    }
+  }
+  bool is_rx_timeout() { return rx_op_->is_timeout(); }
+  bool is_tx_timeout() { return tx_op_->is_timeout(); }
+
+private:
+  bool send_only_;
+  std::string name_;
+  std::unique_ptr<CanRxDev> rx_op_;
+  std::unique_ptr<CanTxDev> tx_op_;
+  uint8_t can_id_offset_ = 0;
+};
+
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__CAN_UTILS_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/include/titati_hw/protocol/socket_can_common.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/include/titati_hw/protocol/socket_can_common.hpp
@@ -1,0 +1,122 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RL_SAR_TITATI_HW_PROTOCOL_SOCKET_CAN_COMMON_HPP_
+#define RL_SAR_TITATI_HW_PROTOCOL_SOCKET_CAN_COMMON_HPP_
+
+#include <linux/can.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <sys/time.h>
+
+#include <chrono>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+
+#define GCC_OPTIMIZE_03
+
+#ifdef GCC_OPTIMIZE_03
+#pragma GCC optimize("O3")
+#else
+#pragma GCC optimize("O0")
+#endif
+
+namespace can_device
+{
+namespace socket_can
+{
+inline bool bind_can_socket(int & fd, const std::string & interface, const bool canfd_on = false)
+{
+  if (interface.length() >= static_cast<std::string::size_type>(IFNAMSIZ)) {
+    throw std::domain_error{"CAN interface name too long"};
+    return false;
+  }
+
+  fd = socket(PF_CAN, static_cast<int32_t>(SOCK_RAW), CAN_RAW);
+  if (0 > fd) {
+    throw std::runtime_error{"Failed to open CAN socket"};
+    return false;
+  }
+
+  // Make it non-blocking so we can use timeouts
+
+  struct ifreq ifr;
+  (void)strncpy(&ifr.ifr_name[0U], interface.c_str(), IFNAMSIZ - 1);
+  ifr.ifr_name[IFNAMSIZ - 1] = '\0';
+  ifr.ifr_ifindex = if_nametoindex(ifr.ifr_name);
+  if (!ifr.ifr_ifindex) {
+    perror("if_nametoindex");
+    return false;
+  }
+
+  struct sockaddr_can addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.can_family = AF_CAN;
+  addr.can_ifindex = ifr.ifr_ifindex;
+
+  if (canfd_on) {
+    if (ioctl(fd, SIOCGIFMTU, &ifr) < 0) {
+      throw std::runtime_error{"Failed to set CAN FD socket name via ioctl()"};
+      return false;
+    }
+    if (ifr.ifr_mtu != CANFD_MTU) {
+      throw std::runtime_error{"Interface does not support CAN FD"};
+      return false;
+    }
+    int _canfd_on = canfd_on ? 1 : 0;
+    auto ret = setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FD_FRAMES, &_canfd_on, sizeof(_canfd_on));
+    if (ret) {
+      throw std::runtime_error{"error whem enable canfd"};
+      return false;
+    }
+  }
+
+  /* disable default receive filter on this RAW socket */
+  /* This is obsolete as we do not read from the socket at all, but for */
+  /* this reason we can remove the receive list in the Kernel to save a */
+  /* little (really a very little!) CPU usage.                          */
+  setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FILTER, NULL, 0);
+
+  if (0 > bind(fd, (struct sockaddr *)&addr, sizeof(addr))) {
+    throw std::runtime_error{"Failed to bind CAN socket"};
+    return false;
+  }
+
+  return true;
+}
+
+inline struct timeval to_timeval(const std::chrono::nanoseconds timeout) noexcept
+{
+  const auto count = timeout.count();
+  constexpr auto BILLION = 1'000'000'000LL;
+  struct timeval c_timeout;
+  c_timeout.tv_sec = static_cast<decltype(c_timeout.tv_sec)>(count / BILLION);
+  c_timeout.tv_usec = static_cast<decltype(c_timeout.tv_usec)>((count % BILLION) * (0.001));
+
+  return c_timeout;
+}
+
+inline fd_set single_set(int32_t file_descriptor) noexcept
+{
+  fd_set descriptor_set;
+  FD_ZERO(&descriptor_set);
+  FD_SET(file_descriptor, &descriptor_set);
+
+  return descriptor_set;
+}
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // RL_SAR_TITATI_HW_PROTOCOL_SOCKET_CAN_COMMON_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/include/titati_hw/protocol/socket_can_id.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/include/titati_hw/protocol/socket_can_id.hpp
@@ -1,0 +1,188 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RL_SAR_TITATI_HW_PROTOCOL_SOCKET_CAN_ID_HPP_
+#define RL_SAR_TITATI_HW_PROTOCOL_SOCKET_CAN_ID_HPP_
+
+#include <linux/can.h>
+
+#include <stdexcept>
+#include <utility>
+
+#include "visibility_control.hpp"
+
+namespace can_device
+{
+namespace socket_can
+{
+using IdT = uint32_t;
+using LengthT = uint32_t;
+
+constexpr std::size_t MAX_DATA_LENGTH = 64U;
+
+static_assert(
+  MAX_DATA_LENGTH == sizeof(std::declval<struct canfd_frame>().data),
+  "Unexpected CAN frame data size");
+static_assert(std::is_same<IdT, canid_t>::value, "Underlying type of CanId is incorrect");
+constexpr IdT EXTENDED_MASK = CAN_EFF_FLAG;
+constexpr IdT REMOTE_MASK = CAN_RTR_FLAG;
+constexpr IdT ERROR_MASK = CAN_ERR_FLAG;
+constexpr IdT EXTENDED_ID_MASK = CAN_EFF_MASK;
+constexpr IdT STANDARD_ID_MASK = CAN_SFF_MASK;
+
+class SOCKETCAN_PUBLIC SocketCanTimeout : public std::runtime_error
+{
+public:
+  explicit SocketCanTimeout(const char * const what) : runtime_error{what} {};
+};  // class SocketCanTimeout
+
+enum class FrameType : uint32_t { DATA, ERROR, REMOTE };
+
+struct StandardFrame_
+{
+};
+
+constexpr StandardFrame_ StandardFrame;
+
+struct ExtendedFrame_
+{
+};
+
+constexpr ExtendedFrame_ ExtendedFrame;
+
+class SOCKETCAN_PUBLIC CanId
+{
+public:
+  CanId() = default;
+  explicit CanId(const IdT raw_id, const LengthT data_length = 0U)
+  : m_id{raw_id}, m_data_length{data_length}
+  {
+    (void)frame_type();
+  }
+
+  CanId(const IdT id, FrameType type, StandardFrame_) : CanId{id, type, false} {}
+  CanId(const IdT id, FrameType type, ExtendedFrame_) : CanId{id, type, true} {}
+
+  CanId & standard() noexcept
+  {
+    m_id = m_id & (~EXTENDED_MASK);
+    return *this;
+  }
+
+  CanId & extended() noexcept
+  {
+    m_id = m_id | EXTENDED_MASK;
+    return *this;
+  }
+
+  CanId & error_frame() noexcept
+  {
+    m_id = m_id & (~REMOTE_MASK);
+    m_id = m_id | ERROR_MASK;
+    return *this;
+  }
+
+  CanId & remote_frame() noexcept
+  {
+    m_id = m_id & (~ERROR_MASK);
+    m_id = m_id | REMOTE_MASK;
+    return *this;
+  }
+
+  CanId & data_frame() noexcept
+  {
+    m_id = m_id & (~ERROR_MASK);
+    m_id = m_id & (~REMOTE_MASK);
+    return *this;
+  }
+
+  CanId & frame_type(const FrameType type)
+  {
+    switch (type) {
+      case FrameType::DATA:
+        (void)data_frame();
+        break;
+      case FrameType::ERROR:
+        (void)error_frame();
+        break;
+      case FrameType::REMOTE:
+        (void)remote_frame();
+        break;
+      default:
+        throw std::logic_error{"CanId: No such type"};
+    }
+    return *this;
+  }
+
+  CanId & identifier(const IdT id)
+  {
+    constexpr auto MAX_EXTENDED = 0x1FBF'FFFFU;
+    constexpr auto MAX_STANDARD = 0x7FFU;
+
+    static_assert(MAX_EXTENDED <= EXTENDED_ID_MASK, "Max extended id value is wrong");
+    static_assert(MAX_STANDARD <= STANDARD_ID_MASK, "Max standed id value is wrong");
+    const auto max_id = is_extended() ? MAX_EXTENDED : MAX_STANDARD;
+    if (max_id < id) {
+      throw std::domain_error{"CanId would be truncated!"};
+    }
+    m_id = m_id & (~EXTENDED_ID_MASK);
+    m_id = m_id | id;
+    return *this;
+  }
+
+  IdT identifier() const noexcept
+  {
+    const auto mask = is_extended() ? EXTENDED_ID_MASK : STANDARD_ID_MASK;
+    return m_id & mask;
+  }
+
+  IdT get() const noexcept { return m_id; }
+
+  bool is_extended() const noexcept { return (m_id & EXTENDED_MASK) == EXTENDED_MASK; }
+
+  FrameType frame_type() const
+  {
+    const auto is_error = (m_id & ERROR_MASK) == ERROR_MASK;
+    const auto is_remote = (m_id & REMOTE_MASK) == REMOTE_MASK;
+    if (is_error && is_remote) {
+      throw std::domain_error{"CanId has both bit 29 and 30 set! Inconsistent"};
+    }
+    if (is_error) {
+      return FrameType::ERROR;
+    }
+    if (is_remote) {
+      return FrameType::REMOTE;
+    }
+    return FrameType::DATA;
+  }
+
+  LengthT length() const noexcept { return m_data_length; }
+  IdT m_id{};
+
+private:
+  SOCKETCAN_LOCAL CanId(const IdT id, FrameType type, bool is_extended)
+  {
+    if (is_extended) {
+      (void)extended();
+    }
+    (void)frame_type(type);
+    (void)identifier(id);
+  }
+
+  LengthT m_data_length{};
+};  // class CanId
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // RL_SAR_TITATI_HW_PROTOCOL_SOCKET_CAN_ID_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/include/titati_hw/protocol/socket_can_receiver.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/include/titati_hw/protocol/socket_can_receiver.hpp
@@ -1,0 +1,145 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RL_SAR_TITATI_HW_PROTOCOL_SOCKET_CAN_RECEIVER_HPP_
+#define RL_SAR_TITATI_HW_PROTOCOL_SOCKET_CAN_RECEIVER_HPP_
+#include <linux/can.h>
+#include <linux/can/raw.h>
+#include <sys/socket.h>
+#include <unistd.h>  // for close()
+
+#include <chrono>
+#include <cstring>
+#include <memory>
+#include <string>
+
+#include "socket_can_common.hpp"
+#include "socket_can_id.hpp"
+#include "visibility_control.hpp"
+
+namespace can_device
+{
+namespace socket_can
+{
+// using target_can_device = static_cast<std::string>(TARGET_CAN_DEVICE);
+
+class SOCKETCAN_PUBLIC SocketCanReceiver
+{
+public:
+  explicit SocketCanReceiver(
+    const std::string & interface = "can0", bool canfd_on = false)
+  {
+    if (!bind_can_socket(fd_, interface, canfd_on)) {
+      printf("bind_can_socket failed!\r\n");
+      return;
+    }
+  }
+
+  ~SocketCanReceiver() noexcept { (void)close(fd_); }
+
+  bool receive(
+    std::shared_ptr<struct can_frame> rx_frame,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero())
+  {
+    wait(timeout);
+
+    struct canfd_frame frame;
+    memset(&frame, 0, sizeof(frame));
+    const auto nbytes = read(fd_, &frame, sizeof(frame));
+
+    if (nbytes < 0) {
+      throw std::runtime_error{strerror(errno)};
+    }
+    if (static_cast<std::size_t>(nbytes) < CAN_MTU) {
+      throw std::logic_error{"read: incomplete CAN frame"};
+    }
+    if (static_cast<std::size_t>(nbytes) != CAN_MTU) {
+      throw std::logic_error{"Message was wrong size"};
+    }
+
+    auto receive_id = CanId{frame.can_id, frame.len};
+    if (receive_id.frame_type() == can_device::socket_can::FrameType::DATA) {
+      rx_frame->can_id = receive_id.standard().get();
+      rx_frame->can_id = receive_id.length();
+      std::memcpy(rx_frame->data, frame.data, sizeof(rx_frame->data));
+      return true;
+    }
+    return false;
+  }
+
+  bool receive(
+    std::shared_ptr<struct canfd_frame> rx_frame,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero())
+  {
+    wait(timeout);
+
+    struct canfd_frame frame;
+    const auto nbytes = read(fd_, &frame, sizeof(frame));
+
+    uint8_t except_len = CAN_MTU - 8 + frame.len;
+    if (nbytes < 0) {
+      throw std::runtime_error{strerror(errno)};
+    }
+    if (static_cast<std::size_t>(nbytes) < except_len) {
+      throw std::runtime_error{"read: incomplete CAN frame"};
+    }
+
+    auto receive_id = CanId{frame.can_id, frame.len};
+    if (receive_id.frame_type() == can_device::socket_can::FrameType::DATA) {
+      rx_frame->can_id = receive_id.standard().get();
+      rx_frame->len = receive_id.length();
+      std::memcpy(rx_frame->data, frame.data, sizeof(rx_frame->data));
+      return true;
+    }
+    return false;
+  }
+
+  void set_filter(const struct can_filter filter[], size_t s)
+  {
+    setsockopt(fd_, SOL_CAN_RAW, CAN_RAW_FILTER, filter, s);
+  }
+
+private:
+  SOCKETCAN_LOCAL void wait(const std::chrono::nanoseconds timeout) const
+  {
+    if (decltype(timeout)::zero() < timeout) {
+      auto c_timeout = to_timeval(timeout);
+      auto read_set = single_set(fd_);
+
+      if (0 == select(fd_ + 1, &read_set, NULL, NULL, &c_timeout)) {
+        throw SocketCanTimeout{"$CAN Receive Timeout 1"};
+      }
+
+      if (!FD_ISSET(fd_, &read_set)) {
+        throw SocketCanTimeout{"$CAN Receive Timeout 2"};
+      }
+    } else {
+      auto read_set = single_set(fd_);
+
+      if (0 == select(fd_ + 1, &read_set, NULL, NULL, NULL)) {
+        throw SocketCanTimeout{"$CAN Receive Timeout 1"};
+      }
+
+      if (!FD_ISSET(fd_, &read_set)) {
+        throw SocketCanTimeout{"CAN Receive Timeout 2"};
+      }
+    }
+  }
+
+  int32_t fd_;
+};  // class SocketCanReceiver
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // RL_SAR_TITATI_HW_PROTOCOL_SOCKET_CAN_RECEIVER_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/include/titati_hw/protocol/socket_can_sender.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/include/titati_hw/protocol/socket_can_sender.hpp
@@ -1,0 +1,168 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RL_SAR_TITATI_HW_PROTOCOL_SOCKET_CAN_SENDER_HPP_
+#define RL_SAR_TITATI_HW_PROTOCOL_SOCKET_CAN_SENDER_HPP_
+
+#include <linux/can.h>
+#include <linux/can/raw.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <stdexcept>
+#include <string>
+
+#include "socket_can_common.hpp"
+#include "socket_can_id.hpp"
+#include "visibility_control.hpp"
+
+namespace can_device
+{
+namespace socket_can
+{
+class SOCKETCAN_PUBLIC SocketCanSender
+{
+public:
+  explicit SocketCanSender(
+    const std::string & interface = "can0", bool canfd_on = false,
+    const CanId & default_id = CanId{})
+  : m_default_id{default_id}
+  {
+    if (!bind_can_socket(fd_, interface, canfd_on)) {
+      printf("bind_can_socket failed\r\n");
+      return;
+    }
+  }
+  ~SocketCanSender() noexcept
+  {
+    (void)close(fd_);
+    // I'm destructing--there's not much else I can do on an error
+    // seem not good
+  }
+
+  void send(
+    const void * const data, const std::size_t Length,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    send(data, Length, m_default_id, timeout);
+  }
+
+  void send(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    if (length > MAX_DATA_LENGTH) {
+      throw std::domain_error{"Size is too large to send via CAN"};
+    }
+    send_impl(data, length, id, timeout);
+  }
+
+  template <typename T, typename = std::enable_if_t<!std::is_pointer<T>::value>>
+  void send(
+    const T & data, const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    send(data, m_default_id, timeout);
+  }
+
+  template <typename T, typename = std::enable_if<!std::is_pointer<T>::value>>
+  void send(
+    const T & data, const CanId id,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    static_assert(sizeof(data) <= MAX_DATA_LENGTH, "Data type too large for CAN");
+    send_impl(reinterpret_cast<const char *>(&data), sizeof(data), id, timeout);
+  }
+
+  void send_fd(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    if (length > MAX_DATA_LENGTH) {
+      throw std::domain_error{"Size is too large to send via CAN"};
+    }
+    send_fd_impl(data, length, id, timeout);
+  }
+
+  CanId default_id() const noexcept { return m_default_id; }
+
+private:
+  void send_impl(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout) const
+  {
+    // (void)data;
+    // (void)length;
+    // (void)id;
+    (void)timeout;
+
+    struct can_frame data_frame;
+    data_frame.can_id = id.get();
+
+    data_frame.can_dlc = static_cast<decltype(data_frame.can_dlc)>(length);
+
+    (void)std::memcpy(static_cast<void *>(&data_frame.data[0U]), data, length);
+
+    if (write(fd_, &data_frame, static_cast<int>(CAN_MTU)) != static_cast<int>(CAN_MTU)) {
+      throw std::runtime_error{strerror(errno)};
+    }
+  }
+
+  void send_fd_impl(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout) const
+  {
+    // (void)data;
+    // (void)length;
+    // (void)id;
+    (void)timeout;
+
+    struct canfd_frame data_frame;
+    memset(&data_frame, 0, sizeof(data_frame));
+    data_frame.can_id = id.get();
+    data_frame.flags = CANFD_FDF | CANFD_BRS;
+    data_frame.len = static_cast<decltype(data_frame.len)>(length);
+    std::memcpy(static_cast<void *>(&data_frame.data[0U]), data, length);
+    if (write(fd_, &data_frame, CANFD_MTU) != CANFD_MTU) {
+      throw std::runtime_error{strerror(errno)};
+    }
+  }
+
+  SOCKETCAN_LOCAL void wait(const std::chrono::nanoseconds timeout) const
+  {
+    if (decltype(timeout)::zero() < timeout) {
+      auto c_timeout = to_timeval(timeout);
+      auto write_set = single_set(fd_);
+
+      // wait
+      if (0 == select(fd_ + 1, NULL, &write_set, NULL, &c_timeout)) {
+        throw SocketCanTimeout{"$CAN Send Timeout [1]"};
+      }
+
+      if (!FD_ISSET(fd_, &write_set)) {
+        throw SocketCanTimeout{"$CAN Send Timeout [2]"};
+      }
+    } else {
+      // do nothing
+      // auto write_set = single_set(fd_);
+    }
+  }
+
+  int32_t fd_;
+  CanId m_default_id;
+};
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // RL_SAR_TITATI_HW_PROTOCOL_SOCKET_CAN_SENDER_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/include/titati_hw/protocol/visibility_control.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/include/titati_hw/protocol/visibility_control.hpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RL_SAR_TITATI_HW_PROTOCOL_VISIBILITY_CONTROL_HPP_
+#define RL_SAR_TITATI_HW_PROTOCOL_VISIBILITY_CONTROL_HPP_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+#ifdef __GNUC__
+#define SOCKETCAN_EXPORT __attribute__((dllexport))
+#define SOCKETCAN_IMPORT __attribute__((dllimport))
+#else
+#define SOCKETCAN_EXPORT __declspec(dllexport)
+#define SOCKETCAN_IMPORT __declspec(dllimport)
+#endif
+#ifdef SOCKETCAN_BUILDING_LIBRARY
+#define SOCKETCAN_PUBLIC SOCKETCAN_EXPORT
+#else
+#define SOCKETCAN_PUBLIC SOCKETCAN_IMPORT
+#endif
+#define SOCKETCAN_PUBLIC_TYPE SOCKETCAN_PUBLIC
+#define SOCKETCAN_LOCAL
+#else
+#define SOCKETCAN_EXPORT __attribute__((visibility("default")))
+#define SOCKETCAN_IMPORT
+#if __GNUC__ >= 4
+#define SOCKETCAN_PUBLIC __attribute__((visibility("default")))
+#define SOCKETCAN_LOCAL __attribute__((visibility("hidden")))
+#else
+#define SOCKETCAN_PUBLIC
+#define SOCKETCAN_LOCAL
+#endif
+#define SOCKETCAN_PUBLIC_TYPE
+#endif
+
+#endif  // RL_SAR_TITATI_HW_PROTOCOL_VISIBILITY_CONTROL_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/include/titati_hw/tita_robot.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/include/titati_hw/tita_robot.hpp
@@ -1,0 +1,171 @@
+#ifndef RL_SAR_TITATI_HW_TITA_ROBOT_HPP_
+#define RL_SAR_TITATI_HW_TITA_ROBOT_HPP_
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "titati_hw/can_receiver.hpp"
+#include "titati_hw/can_sender.hpp"
+
+namespace titati
+{
+namespace hardware
+{
+
+class TitatiRobot
+{
+public:
+    enum ReadyNext
+    {
+        READY_WAITING = 0x00U,
+        AUTO_LOCOMOTION = 0x01U,
+        FORCE_LOCOMOTION = 0x02U,
+        FORCE_DIRECT = 0x03U,
+        MOTOR_ZERO_CAL = 0x04U,
+        BOOT_RECOVERY_MODE = 0x05U,
+        ESTOP_MODE = 0x06U,
+    };
+    struct ChannelInput
+    {
+        uint32_t timestamp;
+        float forward;
+        float yaw;
+        float pitch;
+        float roll;
+        float height;
+        float split;
+        float tilt;
+        float forward_accel;
+        float yaw_accel;
+    };
+    explicit TitatiRobot(size_t num_motors)
+    {
+        // Initialize the CAN receiver
+        can_receiver_ = std::make_unique<can_device::MotorsImuCanReceiveApi>(num_motors);
+        can_sender_ = std::make_unique<can_device::MotorsCanSendApi>(num_motors);
+        motor_num_ = num_motors;
+    }
+
+    /**
+     * @brief Get the current joint positions in joint space.
+     * @return std::vector<double>: current joint positions in radians.
+     */
+    std::vector<double> get_joint_q() const;
+
+    /**
+     * @brief Get the current joint velocities in joint space.
+     * @return std::vector<double>: current joint velocities in radians per second.
+     */
+    std::vector<double> get_joint_v() const;
+
+    /**
+     * @brief Get the current joint torques in joint space.
+     * @return std::vector<double>: current joint torques in Newton meters.
+     */
+    std::vector<double> get_joint_t() const;
+
+    /**
+     * @brief Get the current joint status.
+     * @note Joints status now is in bool value, true means the joint is online(TODO).
+     * @return std::vector<uint8_t>: current joint status.
+     */
+    std::vector<uint8_t> get_joint_status() const;
+
+    /**
+     * @brief Get the current imu quaternion of mcu.
+     * @note Quaternion sequence is x y z w.
+     * @return std::array<double, 4>: current quaternion.
+     */
+    std::array<double, 4> get_imu_quaternion() const;  // x y z w
+
+    /**
+     * @brief Get the current imu acceleration of mcu.
+     * @return std::array<double, 3>: current acceleration.
+     */
+    std::array<double, 3> get_imu_acceleration() const;
+
+    /**
+     * @brief Get the current imu angular velocity of mcu.
+     * @return std::array<double, 3>: current angular velocity.
+     */
+    std::array<double, 3> get_imu_angular_velocity() const;
+
+    /**
+     * @brief Set the target joint feed-forward torques.
+     * @param t the target joint feed-forward torques.
+     * @return return true if the target is set successfully.
+     */
+    bool set_target_joint_t(const std::vector<double> &t);
+
+    /**
+     * @brief MIT control method. Set the target joint positions, velocities, kp, kd and feed-forward torques of the
+     motors.
+     * @param q the target joint positions in radians.
+     * @param v the target joint velocities in radians per second.
+     * @param kp the target joint proportional gains.
+     * @param kd the target joint derivative gains.
+     * @param t the target joint feed-forward torques.
+     *
+     * @return return true if the target is set successfully
+     */
+    bool set_target_joint_mit(const std::vector<double> &q, const std::vector<double> &v, const std::vector<double> &kp, const std::vector<double> &kd, const std::vector<double> &t);
+
+    // /**
+    //  * @brief Set mcu board control mode, maybe remove in the future.
+    //  * @param mode the target mcu mode, option: READY_WAITING AUTO_LOCOMOTION FORCE_DIRECT.
+    //  *
+    //  * @return return true if the target is set successfully
+    //  */
+    // bool set_board_mode(ReadyNext mode);
+    /**
+     * @brief Set mcu board can direct drive motors, default is auto_locomotion(use mcu control).
+     * @param if_sdk true means use control motors sdk, false means use mcu control.
+     *
+     * @return return true if the target is set successfully
+     */
+    bool set_motors_sdk(bool if_sdk);
+    /**
+     * @brief Set rc input to mcu. Only used in board mode is AUTO_LOCOMOTION.
+     * @param forward the target forward.
+     * @param yaw the target yaw.
+     * @param pitch the target pitch.
+     * @param roll the target roll.
+     * @param height the target height.
+     * @param split the target split.
+     * @param tilt the target tilt.
+     * @param forward_accel the target forward acceleration.
+     * @param yaw_accel the target yaw acceleration.
+     * @return return true if the target is set successfully
+     */
+    bool set_rc_input(ChannelInput input);    
+    /**
+     * @brief Set rc input to mcu. Only used in board mode is AUTO_LOCOMOTION.
+     * @param stand true if stand.
+     * @return return true if the target is set successfully
+     */
+    bool set_robot_stand(bool stand);
+
+    /**
+     * @brief Set rc input to mcu. Only used in board mode is AUTO_LOCOMOTION.
+     * @param jump true to start robot charge, then false change to start jump.
+     * @return return true if the target is set successfully
+     */
+    bool set_robot_jump(bool jump);
+    /**
+     * @brief Set rc input to mcu. Only used in board mode is AUTO_LOCOMOTION.
+     * @return return true if the target is set successfully
+     */
+    bool set_robot_stop();
+private:
+    std::unique_ptr<can_device::MotorsImuCanReceiveApi> can_receiver_;
+    std::unique_ptr<can_device::MotorsCanSendApi> can_sender_;
+    size_t motor_num_;
+};
+
+}  // namespace hardware
+}  // namespace titati
+
+#endif  // RL_SAR_TITATI_HW_TITA_ROBOT_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/src/can_receiver.cpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/src/can_receiver.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "titati_hw/can_receiver.hpp"
+
+namespace can_device
+{
+
+void MotorsImuCanReceiveApi::register_motors_device_can_filter()
+{
+  // if (!this->is_running.load()) {
+  //   throw std::runtime_error("MotorsImuCanReceiveApi is not running");
+  // }
+  struct can_filter motors_device_rx_filter;
+  motors_device_rx_filter.can_id = CAN_ID_MOTOR_IN;
+  motors_device_rx_filter.can_mask = CAN_MASK_AS_MOTORS_INFO;
+  this->motors_can_receive_api->set_filter(&motors_device_rx_filter, sizeof(struct can_filter));
+}
+
+void MotorsImuCanReceiveApi::board_can_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  if (recv_frame->can_id >= CAN_ID_MOTOR_IN && recv_frame->can_id < CAN_ID_MOTOR_IN + leg_num_) {
+    motors_data_callback(recv_frame);
+  } else if (recv_frame->can_id == CAN_ID_IMU1) {
+    imu_data_callback(recv_frame);
+  } else {
+    return;
+  }
+}
+void MotorsImuCanReceiveApi::motors_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  std::unique_lock<std::shared_mutex> lock(motors_in_mutex_);
+  for (size_t i = 0; i < leg_dof_; i++) {
+    api_motor_in_t motor;
+    std::memcpy(&motor, recv_frame->data + 16 * i, sizeof(api_motor_in_t));
+    auto it = recv_frame->can_id - CAN_ID_MOTOR_IN;
+    motors_in_[i + leg_dof_ * it] = motor;
+  }
+}
+void MotorsImuCanReceiveApi::imu_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  std::unique_lock<std::shared_mutex> lock(imu_mutex_);
+  std::memcpy(&imu_data_, recv_frame->data, sizeof(api_imu_data_t));
+  for (size_t i(0); i < 3; ++i) {
+    imu_data_.accl[i] *= GRAVITY;
+  }
+  return;
+}
+void MotorsImuCanReceiveApi::motors_status_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  std::memcpy(&motors_status_, recv_frame->data, sizeof(api_motor_status_t));
+}
+
+}  // namespace can_device

--- a/rl_sar/src/rl_sar/library/hardware/titati/src/can_sender.cpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/src/can_sender.cpp
@@ -1,0 +1,90 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "titati_hw/can_sender.hpp"
+
+namespace can_device
+{
+bool MotorsCanSendApi::send_command_can_channel_input(ChannelInput data)
+{
+  data.timestamp = get_current_time();
+  struct canfd_frame frame;
+  frame.can_id = CAN_ID_CHANNEL_INPUT;
+  frame.len = 40u;
+  memset(frame.data, 0x00U, sizeof(frame.data));
+  
+  std::memcpy(frame.data, &data, sizeof(data));
+
+  return can_send_api_->send_can_message(frame);
+}
+
+bool MotorsCanSendApi::send_command_can_rpc_request(RpcRequest data){
+  data.timestamp = get_current_time();
+
+  struct canfd_frame frame;
+  frame.can_id = CAN_ID_RPC_REQUEST;
+  frame.len = 10U;
+
+  memset(frame.data, 0x00U, sizeof(frame.data));
+
+  std::memcpy(frame.data, &data.timestamp, sizeof(data.timestamp));
+  std::memcpy(frame.data + 4, &data.key, sizeof(data.key));
+  std::memcpy(frame.data + 6, &data.value, sizeof(data.value));
+
+  return can_send_api_->send_can_message(frame);
+}
+
+bool MotorsCanSendApi::send_motors_can(std::vector<motor_out> motors)
+{
+  if (motors.size() != leg_dof_ * leg_num_) {
+    std::cerr << "[MOTORS_CAN_SEND] motors size not equal to robot dof" << std::endl;
+    return false;
+  }
+  if(leg_dof_ == 3){
+    motor_out motor = {};
+    auto it = motors.begin() + 3;
+    motors.insert(it, motor);
+    motors.push_back(motor);
+  }
+  bool send_success = true;
+  struct canfd_frame frame;
+  frame.len = 48U;
+  auto now = get_current_time();
+  for (size_t id(0); id < motors.size()/2; id++) {
+    frame.can_id = CAN_ID_SEND_MOTORS + id;
+    memset(frame.data, 0x00U, sizeof(frame.data));
+    auto motor = motors[2 * id];
+    motor.timestamp = now;
+    std::memcpy(frame.data, &motor.timestamp, sizeof(motor.timestamp));
+    std::memcpy(frame.data + 4, &motor.position, sizeof(motor.position));
+    std::memcpy(frame.data + 8, &motor.kp, sizeof(motor.kp));
+    std::memcpy(frame.data + 12, &motor.velocity, sizeof(motor.velocity));
+    std::memcpy(frame.data + 16, &motor.kd, sizeof(motor.kd));
+    std::memcpy(frame.data + 20, &motor.torque, sizeof(motor.torque));
+
+    motor = motors[2 * id + 1];
+    motor.timestamp = now;
+    std::memcpy(frame.data + 24, &motor.timestamp, sizeof(motor.timestamp));
+    std::memcpy(frame.data + 28, &motor.position, sizeof(motor.position));
+    std::memcpy(frame.data + 32, &motor.kp, sizeof(motor.kp));
+    std::memcpy(frame.data + 36, &motor.velocity, sizeof(motor.velocity));
+    std::memcpy(frame.data + 40, &motor.kd, sizeof(motor.kd));
+    std::memcpy(frame.data + 44, &motor.torque, sizeof(motor.torque));
+    send_success &= can_send_api_->send_can_message(frame);
+    std::this_thread::sleep_for(std::chrono::microseconds(150)); // 等待 100 微秒
+  }
+  return send_success;
+}
+
+}  // namespace can_device

--- a/rl_sar/src/rl_sar/library/hardware/titati/src/tita_robot.cpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/src/tita_robot.cpp
@@ -1,0 +1,171 @@
+#include "titati_hw/tita_robot.hpp"
+
+std::vector<double> titati::hardware::TitatiRobot::get_joint_q() const
+{
+  auto infos = can_receiver_->get_motors_in();
+  std::vector<double> joint;
+  for (const auto & info : *infos) {
+    joint.push_back(info.position);
+  }
+  return joint;
+}
+
+std::vector<double> titati::hardware::TitatiRobot::get_joint_v() const
+{
+  auto infos = can_receiver_->get_motors_in();
+  std::vector<double> joint;
+  for (const auto & info : *infos) {
+    joint.push_back(info.velocity);
+  }
+  return joint;
+}
+
+std::vector<double> titati::hardware::TitatiRobot::get_joint_t() const
+{
+  auto infos = can_receiver_->get_motors_in();
+  std::vector<double> joint;
+  for (const auto & info : *infos) {
+    joint.push_back(info.torque);
+  }
+  return joint;
+}
+
+std::vector<uint8_t> titati::hardware::TitatiRobot::get_joint_status() const  // TODO: why 8
+{
+  auto infos = can_receiver_->get_motors_status();
+  std::vector<uint8_t> joint;
+  for (size_t id = 0; id < 8; id++) {
+    joint.push_back(infos->value[id]);
+  }
+  return joint;
+}
+
+std::array<double, 4> titati::hardware::TitatiRobot::get_imu_quaternion() const
+{
+  auto infos = can_receiver_->get_imu_data();
+  std::array<double, 4> data;
+  for (size_t i = 0; i < 4; i++) {
+    data[i] = infos->quaternion[i];
+  }
+  return data;
+}
+
+std::array<double, 3> titati::hardware::TitatiRobot::get_imu_acceleration() const
+{
+  auto infos = can_receiver_->get_imu_data();
+  std::array<double, 3> data;
+  for (size_t i = 0; i < 3; i++) {
+    data[i] = infos->accl[i];
+  }
+  return data;
+}
+
+std::array<double, 3> titati::hardware::TitatiRobot::get_imu_angular_velocity() const
+{
+  auto infos = can_receiver_->get_imu_data();
+  std::array<double, 3> data;
+  for (size_t i = 0; i < 3; i++) {
+    data[i] = infos->gyro[i];
+  }
+  return data;
+}
+
+bool titati::hardware::TitatiRobot::set_target_joint_t(const std::vector<double> & t)
+{
+  std::vector<can_device::motor_out> motors;
+  for (size_t id = 0; id < motor_num_; id++) {
+    can_device::motor_out motor;
+    motor.torque = t[id];
+    motor.kp = 0.0f;
+    motor.kd = 0.0f;
+    motor.velocity = 0.0f;
+    motor.position = 0.0f;
+    motors.push_back(motor);
+  }
+  return can_sender_->send_motors_can(motors);
+}
+
+bool titati::hardware::TitatiRobot::set_target_joint_mit(
+  const std::vector<double> & q, const std::vector<double> & v, const std::vector<double> & kp,
+  const std::vector<double> & kd, const std::vector<double> & t)
+{
+  std::vector<can_device::motor_out> motors;
+  for (size_t id = 0; id < motor_num_; id++) {
+    can_device::motor_out motor;
+    motor.torque = t[id];
+    motor.kp = kp[id];
+    motor.kd = kd[id];
+    motor.velocity = v[id];
+    motor.position = q[id];
+    motors.push_back(motor);
+  }
+  return can_sender_->send_motors_can(motors);
+}
+
+// bool titati::hardware::TitatiRobot::set_board_mode(ReadyNext mode)
+// {
+//   can_device::RpcRequest rpc_request;
+//   rpc_request.key = can_device::SET_READY_NEXT;
+//   rpc_request.value = mode;
+//   return can_sender_->send_command_can_rpc_request(rpc_request);
+// }
+
+bool titati::hardware::TitatiRobot::set_motors_sdk(bool if_sdk)
+{
+  can_device::RpcRequest rpc_request;
+  rpc_request.key = can_device::SET_READY_NEXT;
+  rpc_request.value = READY_WAITING;
+  bool return_ok = can_sender_->send_command_can_rpc_request(rpc_request);
+  std::this_thread::sleep_for(std::chrono::microseconds(100));
+  if (if_sdk) {
+    rpc_request.value = FORCE_DIRECT;
+  } else {
+    rpc_request.value = AUTO_LOCOMOTION;
+  }
+  return_ok &= can_sender_->send_command_can_rpc_request(rpc_request);
+  return return_ok;
+}
+
+bool titati::hardware::TitatiRobot::set_rc_input(ChannelInput input)
+{
+  can_device::ChannelInput can_input;
+  can_input.forward = input.forward;
+  can_input.yaw = input.yaw;
+  can_input.pitch = input.pitch;
+  can_input.roll = input.roll;
+  can_input.height = input.height;
+  can_input.split = input.split;
+  can_input.tilt = input.tilt;
+  can_input.forward_accel = input.forward_accel;
+  can_input.yaw_accel = input.yaw_accel;
+  return can_sender_->send_command_can_channel_input(can_input);
+}
+
+bool titati::hardware::TitatiRobot::set_robot_stand(bool stand)
+{
+  can_device::RpcRequest rpc_request;
+  rpc_request.key = can_device::SET_STAND_MODE;
+  rpc_request.value = !stand ? 0x01U : 0x02U;
+  return can_sender_->send_command_can_rpc_request(rpc_request);
+}
+
+bool titati::hardware::TitatiRobot::set_robot_jump(bool jump)
+{
+  can_device::RpcRequest rpc_request;
+  rpc_request.key = can_device::SET_JUMP;
+  rpc_request.value = !jump ? 0x01U : 0x02U;
+  return can_sender_->send_command_can_rpc_request(rpc_request);
+}
+
+bool titati::hardware::TitatiRobot::set_robot_stop()
+{
+  can_device::RpcRequest rpc_request;
+  rpc_request.value = 0x01U;
+  rpc_request.key = can_device::SET_STAND_MODE;
+  bool return_ok = can_sender_->send_command_can_rpc_request(rpc_request);
+  std::this_thread::sleep_for(std::chrono::microseconds(200));
+  rpc_request.value = 0x02U;
+  rpc_request.key = can_device::SET_JUMP;
+  return_ok &= can_sender_->send_command_can_rpc_request(rpc_request);
+  return true;
+}

--- a/rl_sar/src/rl_sar/src/rl_real_titati.cpp
+++ b/rl_sar/src/rl_sar/src/rl_real_titati.cpp
@@ -1,0 +1,298 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "rl_real_titati.hpp"
+
+#include "policy/titati/fsm.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <csignal>
+#include <iostream>
+#include <thread>
+
+namespace
+{
+constexpr double kPi = 3.14159265358979323846;
+}
+
+RL_Real::RL_Real(bool wheel_torque_mode)
+    : wheel_torque_mode_(wheel_torque_mode)
+{
+    this->ang_vel_type = "ang_vel_body";
+    this->robot_name = "titati";
+    this->ReadYamlBase(this->robot_name);
+
+    if (FSMManager::GetInstance().IsTypeSupported(this->robot_name))
+    {
+        auto fsm_ptr = FSMManager::GetInstance().CreateFSM(this->robot_name, this);
+        if (fsm_ptr)
+        {
+            this->fsm = *fsm_ptr;
+        }
+    }
+    else
+    {
+        std::cout << LOGGER::ERROR << "No FSM registered for robot: " << this->robot_name << std::endl;
+    }
+
+    torch::autograd::GradMode::set_enabled(false);
+    torch::set_num_threads(4);
+
+    robot_ = std::make_unique<titati::hardware::TitatiRobot>(this->params.num_of_dofs);
+    robot_->set_motors_sdk(true);
+
+    joint_command_pos_.assign(this->params.num_of_dofs, 0.0);
+    joint_command_vel_.assign(this->params.num_of_dofs, 0.0);
+    joint_command_tau_.assign(this->params.num_of_dofs, 0.0);
+
+    this->InitOutputs();
+    this->InitControl();
+
+    loop_keyboard = std::make_shared<LoopFunc>("loop_keyboard", 0.05, std::bind(&RL_Real::KeyboardInterface, this));
+    loop_control = std::make_shared<LoopFunc>("loop_control", this->params.dt, std::bind(&RL_Real::RobotControl, this));
+    loop_rl = std::make_shared<LoopFunc>("loop_rl", this->params.dt * this->params.decimation, std::bind(&RL_Real::RunModel, this));
+    loop_keyboard->start();
+    loop_control->start();
+    loop_rl->start();
+
+    last_print_time_ = std::chrono::steady_clock::now();
+}
+
+RL_Real::~RL_Real()
+{
+    loop_keyboard->shutdown();
+    loop_control->shutdown();
+    loop_rl->shutdown();
+    std::cout << LOGGER::INFO << "RL_Real titati exit" << std::endl;
+}
+
+void RL_Real::GetState(RobotState<double> *state)
+{
+    auto q = robot_->get_joint_q();
+    auto v = robot_->get_joint_v();
+    auto tau = robot_->get_joint_t();
+
+    if (q.size() >= static_cast<std::size_t>(this->params.num_of_dofs))
+    {
+        for (int i = 0; i < this->params.num_of_dofs; ++i)
+        {
+            int idx = this->params.joint_mapping[i];
+            double pos = q[idx];
+            if (i == 1 || i == (1 + this->params.num_of_dofs / 2))
+            {
+                if (pos < -2.5)
+                {
+                    pos += 2.0 * kPi;
+                }
+            }
+            state->motor_state.q[i] = pos;
+            state->motor_state.dq[i] = v[idx];
+            state->motor_state.tau_est[i] = tau[idx];
+        }
+    }
+
+    auto quat = robot_->get_imu_quaternion();
+    state->imu.quaternion[0] = quat[3];
+    state->imu.quaternion[1] = quat[0];
+    state->imu.quaternion[2] = quat[1];
+    state->imu.quaternion[3] = quat[2];
+
+    auto accel = robot_->get_imu_acceleration();
+    auto gyro = robot_->get_imu_angular_velocity();
+    for (int i = 0; i < 3; ++i)
+    {
+        state->imu.accelerometer[i] = accel[i];
+        state->imu.gyroscope[i] = gyro[i];
+    }
+}
+
+void RL_Real::SetCommand(const RobotCommand<double> *command)
+{
+    std::vector<double> q_hw(this->params.num_of_dofs, 0.0);
+    std::vector<double> dq_hw(this->params.num_of_dofs, 0.0);
+    std::vector<double> kp_hw(this->params.num_of_dofs, 0.0);
+    std::vector<double> kd_hw(this->params.num_of_dofs, 0.0);
+    std::vector<double> tau_hw(this->params.num_of_dofs, 0.0);
+
+    for (int i = 0; i < this->params.num_of_dofs; ++i)
+    {
+        int idx = this->params.joint_mapping[i];
+        bool is_wheel = std::find(this->params.wheel_indices.begin(), this->params.wheel_indices.end(), i) != this->params.wheel_indices.end();
+
+        if (is_wheel && wheel_torque_mode_)
+        {
+            q_hw[idx] = 0.0;
+            dq_hw[idx] = 0.0;
+            kp_hw[idx] = 0.0;
+            kd_hw[idx] = 0.0;
+            tau_hw[idx] = command->motor_command.tau[i];
+        }
+        else
+        {
+            q_hw[idx] = command->motor_command.q[i];
+            dq_hw[idx] = command->motor_command.dq[i];
+            kp_hw[idx] = command->motor_command.kp[i];
+            kd_hw[idx] = command->motor_command.kd[i];
+            tau_hw[idx] = command->motor_command.tau[i];
+        }
+    }
+
+    joint_command_pos_ = q_hw;
+    joint_command_vel_ = dq_hw;
+    joint_command_tau_ = tau_hw;
+
+    robot_->set_target_joint_mit(joint_command_pos_, joint_command_vel_, kp_hw, kd_hw, joint_command_tau_);
+}
+
+void RL_Real::RobotControl()
+{
+    motiontime_++;
+
+    if (this->control.current_keyboard == Input::Keyboard::W)
+    {
+        this->control.x += 0.05;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::S)
+    {
+        this->control.x -= 0.05;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::A)
+    {
+        this->control.y += 0.05;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::D)
+    {
+        this->control.y -= 0.05;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::Q)
+    {
+        this->control.yaw += 0.05;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::E)
+    {
+        this->control.yaw -= 0.05;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::Space)
+    {
+        this->control.x = 0;
+        this->control.y = 0;
+        this->control.yaw = 0;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::N)
+    {
+        this->control.navigation_mode = !this->control.navigation_mode;
+        std::cout << std::endl << LOGGER::INFO << "Navigation mode: " << (this->control.navigation_mode ? "ON" : "OFF") << std::endl;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+
+    this->GetState(&this->robot_state);
+    this->StateController(&this->robot_state, &this->robot_command);
+    this->SetCommand(&this->robot_command);
+
+    auto now = std::chrono::steady_clock::now();
+    if (now - last_print_time_ > std::chrono::seconds(1))
+    {
+        last_print_time_ = now;
+        std::cout << "\r\033[K" << LOGGER::INFO
+                  << "cmd x:" << this->control.x
+                  << " y:" << this->control.y
+                  << " yaw:" << this->control.yaw
+                  << std::flush;
+    }
+}
+
+void RL_Real::RunModel()
+{
+    if (this->rl_init_done)
+    {
+        this->episode_length_buf += 1;
+        this->obs.ang_vel = torch::tensor(this->robot_state.imu.gyroscope).unsqueeze(0);
+        if (this->control.navigation_mode)
+        {
+            this->obs.commands = torch::tensor({{this->control.x, this->control.y, this->control.yaw}});
+        }
+        else
+        {
+            this->obs.commands = torch::tensor({{this->control.x, this->control.y, this->control.yaw}});
+        }
+        this->obs.base_quat = torch::tensor(this->robot_state.imu.quaternion).unsqueeze(0);
+        this->obs.dof_pos = torch::tensor(this->robot_state.motor_state.q).narrow(0, 0, this->params.num_of_dofs).unsqueeze(0);
+        this->obs.dof_vel = torch::tensor(this->robot_state.motor_state.dq).narrow(0, 0, this->params.num_of_dofs).unsqueeze(0);
+
+        this->obs.actions = this->Forward();
+        this->ComputeOutput(this->obs.actions, this->output_dof_pos, this->output_dof_vel, this->output_dof_tau);
+
+        if (this->output_dof_pos.defined() && this->output_dof_pos.numel() > 0)
+        {
+            output_dof_pos_queue.push(this->output_dof_pos);
+        }
+        if (this->output_dof_vel.defined() && this->output_dof_vel.numel() > 0)
+        {
+            output_dof_vel_queue.push(this->output_dof_vel);
+        }
+        if (this->output_dof_tau.defined() && this->output_dof_tau.numel() > 0)
+        {
+            output_dof_tau_queue.push(this->output_dof_tau);
+        }
+
+        this->TorqueProtect(this->output_dof_tau);
+
+#ifdef CSV_LOGGER
+        torch::Tensor tau_est = torch::tensor(this->robot_state.motor_state.tau_est).unsqueeze(0);
+        this->CSVLogger(this->output_dof_tau, tau_est, this->obs.dof_pos, this->output_dof_pos, this->obs.dof_vel);
+#endif
+    }
+}
+
+torch::Tensor RL_Real::Forward()
+{
+    torch::autograd::GradMode::set_enabled(false);
+
+    torch::Tensor clamped_obs = this->ComputeObservation();
+
+    torch::Tensor actions;
+    if (!this->params.observations_history.empty())
+    {
+        this->history_obs_buf.insert(clamped_obs);
+        this->history_obs = this->history_obs_buf.get_obs_vec(this->params.observations_history);
+        actions = this->model.forward({this->history_obs}).toTensor();
+    }
+    else
+    {
+        actions = this->model.forward({clamped_obs}).toTensor();
+    }
+
+    if (this->params.clip_actions_upper.numel() != 0 && this->params.clip_actions_lower.numel() != 0)
+    {
+        return torch::clamp(actions, this->params.clip_actions_lower, this->params.clip_actions_upper);
+    }
+    return actions;
+}
+
+static void signalHandler(int signum)
+{
+    (void)signum;
+    std::exit(0);
+}
+
+int main(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    signal(SIGINT, signalHandler);
+    RL_Real rl(true);
+    while (true)
+    {
+        std::this_thread::sleep_for(std::chrono::seconds(10));
+    }
+    return 0;
+}

--- a/rl_sar/src/rl_sar/src/rl_real_titati.cpp
+++ b/rl_sar/src/rl_sar/src/rl_real_titati.cpp
@@ -4,7 +4,7 @@
 
 #include "rl_real_titati.hpp"
 
-#include "policy/titati/fsm.hpp"
+#include "titati/fsm.hpp"
 
 #include <algorithm>
 #include <cmath>

--- a/rl_sar/src/rl_sar/src/titati_motor_test.cpp
+++ b/rl_sar/src/rl_sar/src/titati_motor_test.cpp
@@ -1,0 +1,196 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "titati_hw/tita_robot.hpp"
+#include "rl_sdk.hpp"
+
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+struct Options
+{
+    std::string mode = "torque";  // torque, mit, direct
+    int motor_count = 16;
+    double amplitude = 2.0;        // Nm for torque, rad for mit offset
+    double duration = 1.0;         // seconds per joint
+    double kp_leg = 70.0;
+    double kd_leg = 5.0;
+    double kp_wheel = 0.0;
+    double kd_wheel = 0.5;
+    bool enable_sdk = true;
+};
+
+void PrintUsage()
+{
+    std::cout << "titati_motor_test --mode <torque|mit|direct> [--motors N] [--amplitude A] [--duration D]" << std::endl;
+    std::cout << "  torque : apply sequential torque pulses to each motor" << std::endl;
+    std::cout << "  mit    : command MIT position offsets for each motor" << std::endl;
+    std::cout << "  direct : switch MCU control mode (use --amplitude 0 to switch back to MCU)" << std::endl;
+}
+
+Options ParseOptions(int argc, char **argv)
+{
+    Options opts;
+    for (int i = 1; i < argc; ++i)
+    {
+        std::string arg = argv[i];
+        if ((arg == "--mode" || arg == "-m") && i + 1 < argc)
+        {
+            opts.mode = argv[++i];
+        }
+        else if (arg == "--motors" && i + 1 < argc)
+        {
+            opts.motor_count = std::stoi(argv[++i]);
+        }
+        else if (arg == "--amplitude" && i + 1 < argc)
+        {
+            opts.amplitude = std::stod(argv[++i]);
+        }
+        else if (arg == "--duration" && i + 1 < argc)
+        {
+            opts.duration = std::stod(argv[++i]);
+        }
+        else if (arg == "--disable-sdk")
+        {
+            opts.enable_sdk = false;
+        }
+        else if (arg == "--help" || arg == "-h")
+        {
+            PrintUsage();
+            std::exit(0);
+        }
+    }
+    return opts;
+}
+
+std::vector<double> DefaultPose(int motor_count)
+{
+    std::vector<double> base = {
+        0.00, 0.40, -0.917,
+        0.00, 0.40, -0.917,
+        0.00, -0.40, 0.917,
+        0.00, -0.40, 0.917,
+        0.00, 0.00, 0.00, 0.00
+    };
+    if (motor_count <= static_cast<int>(base.size()))
+    {
+        base.resize(motor_count);
+    }
+    else
+    {
+        base.resize(motor_count, 0.0);
+    }
+    return base;
+}
+
+std::vector<double> DefaultGain(double leg_gain, double wheel_gain, int motor_count)
+{
+    std::vector<double> gains(motor_count, leg_gain);
+    if (motor_count >= 16)
+    {
+        for (int i = 12; i < motor_count; ++i)
+        {
+            gains[i] = wheel_gain;
+        }
+    }
+    return gains;
+}
+
+void RunTorqueTest(titati::hardware::TitatiRobot &robot, const Options &opts)
+{
+    std::vector<double> tau(opts.motor_count, 0.0);
+    auto rest = tau;
+    const auto period = std::chrono::milliseconds(5);
+
+    for (int i = 0; i < opts.motor_count; ++i)
+    {
+        std::cout << LOGGER::INFO << "Torque test joint " << i << " -> " << opts.amplitude << " Nm" << std::endl;
+        auto start = std::chrono::steady_clock::now();
+        while (std::chrono::steady_clock::now() - start < std::chrono::duration<double>(opts.duration))
+        {
+            std::fill(tau.begin(), tau.end(), 0.0);
+            tau[i] = opts.amplitude;
+            robot.set_target_joint_t(tau);
+            std::this_thread::sleep_for(period);
+        }
+        robot.set_target_joint_t(rest);
+        std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    }
+
+    robot.set_target_joint_t(rest);
+}
+
+void RunMitTest(titati::hardware::TitatiRobot &robot, const Options &opts)
+{
+    const auto base_pos = DefaultPose(opts.motor_count);
+    const auto base_kp = DefaultGain(opts.kp_leg, opts.kp_wheel, opts.motor_count);
+    const auto base_kd = DefaultGain(opts.kd_leg, opts.kd_wheel, opts.motor_count);
+    std::vector<double> command_pos = base_pos;
+    std::vector<double> command_vel(opts.motor_count, 0.0);
+    std::vector<double> command_tau(opts.motor_count, 0.0);
+
+    const auto period = std::chrono::milliseconds(5);
+
+    for (int i = 0; i < opts.motor_count; ++i)
+    {
+        std::cout << LOGGER::INFO << "MIT test joint " << i << " -> offset " << opts.amplitude << " rad" << std::endl;
+        command_pos = base_pos;
+        command_pos[i] += opts.amplitude;
+        auto start = std::chrono::steady_clock::now();
+        while (std::chrono::steady_clock::now() - start < std::chrono::duration<double>(opts.duration))
+        {
+            robot.set_target_joint_mit(command_pos, command_vel, base_kp, base_kd, command_tau);
+            std::this_thread::sleep_for(period);
+        }
+        robot.set_target_joint_mit(base_pos, command_vel, base_kp, base_kd, command_tau);
+        std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    }
+
+    robot.set_target_joint_mit(base_pos, command_vel, base_kp, base_kd, command_tau);
+}
+
+}  // namespace
+
+int main(int argc, char **argv)
+{
+    auto opts = ParseOptions(argc, argv);
+
+    if (opts.mode != "torque" && opts.mode != "mit" && opts.mode != "direct")
+    {
+        std::cerr << LOGGER::ERROR << "Unknown mode: " << opts.mode << std::endl;
+        PrintUsage();
+        return 1;
+    }
+
+    titati::hardware::TitatiRobot robot(opts.motor_count);
+
+    if (opts.mode == "direct")
+    {
+        bool ok = robot.set_motors_sdk(opts.enable_sdk);
+        std::cout << LOGGER::INFO << (opts.enable_sdk ? "Enable" : "Disable") << " direct SDK: " << (ok ? "OK" : "FAILED") << std::endl;
+        return ok ? 0 : 1;
+    }
+
+    robot.set_motors_sdk(true);
+
+    if (opts.mode == "torque")
+    {
+        RunTorqueTest(robot, opts);
+    }
+    else if (opts.mode == "mit")
+    {
+        RunMitTest(robot, opts);
+    }
+
+    robot.set_target_joint_t(std::vector<double>(opts.motor_count, 0.0));
+    std::cout << std::endl << LOGGER::INFO << "Test finished." << std::endl;
+    return 0;
+}

--- a/rl_sar/src/rl_sar/src/titati_motor_test.cpp
+++ b/rl_sar/src/rl_sar/src/titati_motor_test.cpp
@@ -3,7 +3,6 @@
  */
 
 #include "titati_hw/tita_robot.hpp"
-#include "rl_sdk.hpp"
 
 #include <chrono>
 #include <cstdlib>
@@ -12,6 +11,15 @@
 #include <string>
 #include <thread>
 #include <vector>
+
+namespace LOGGER
+{
+    constexpr const char *INFO = "\033[0;37m[INFO]\033[0m ";
+    constexpr const char *WARNING = "\033[0;33m[WARNING]\033[0m ";
+    constexpr const char *ERROR = "\033[0;31m[ERROR]\033[0m ";
+    constexpr const char *DEBUG = "\033[0;32m[DEBUG]\033[0m ";
+    constexpr const char *NOTE = "\033[0;34m[NOTE]\033[0m ";
+}
 
 namespace
 {


### PR DESCRIPTION
## Summary
- port the Titati CAN hardware interface into rl_sar and expose it as the titati_hw library
- add a rl_real_titati controller and CMake wiring so the quadruped can run without ROS using the existing FSM
- provide a titati_motor_test utility and update the README with master/slave setup and usage instructions

## Testing
- ./build.sh -m rl_real_titati titati_motor_test *(fails: TorchConfig.cmake not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4fd990400832186d7ffdc8b7e321d