### PR TITLE
Keep Titati force-direct mode in sync

### DIFF
--- a/rl_sar/src/rl_sar/library/hardware/titati/include/titati/canfd_router.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/include/titati/canfd_router.hpp
@@ -35,6 +35,8 @@ public:
 
   /// @brief Request the MCU to switch into ForceDirect (SDK) mode.
   void RequestForceDirectMode();
+  /// @brief Stop requesting ForceDirect mode and disable monitoring.
+  void CancelForceDirectMode();
 
 private:
   void RegisterFilter();
@@ -42,6 +44,7 @@ private:
   void SendForceDirectCommand(uint32_t value);
   uint32_t GetCurrentTime() const;
 
+  std::atomic<bool> monitor_force_direct_{false};
   std::atomic<bool> request_force_direct_{false};
 
   std::string router_interface_{"can0"};
@@ -63,6 +66,7 @@ private:
 
   uint32_t mode_{0U};
   uint32_t heart_cnt_{0U};
+  uint32_t last_mode_{0U};
 };
 
 }  // namespace titati

--- a/rl_sar/src/rl_sar/library/hardware/titati/src/canfd_router.cpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/src/canfd_router.cpp
@@ -56,7 +56,14 @@ void CanfdRouter::RegisterFilter()
 
 void CanfdRouter::RequestForceDirectMode()
 {
+  monitor_force_direct_.store(true);
   request_force_direct_.store(true);
+}
+
+void CanfdRouter::CancelForceDirectMode()
+{
+  monitor_force_direct_.store(false);
+  request_force_direct_.store(false);
 }
 
 void CanfdRouter::HandleBoardFrame(std::shared_ptr<struct canfd_frame> recv_frame)
@@ -69,8 +76,24 @@ void CanfdRouter::HandleBoardFrame(std::shared_ptr<struct canfd_frame> recv_fram
   std::memcpy(&mode_, recv_frame->data + 4, sizeof(mode_));
   std::memcpy(&heart_cnt_, recv_frame->data + 8, sizeof(heart_cnt_));
 
+  if (!monitor_force_direct_.load())
+  {
+    last_mode_ = mode_;
+    return;
+  }
+
+  if (mode_ == kForceDirect)
+  {
+    request_force_direct_.store(false);
+  }
+  else if (last_mode_ == kForceDirect)
+  {
+    request_force_direct_.store(true);
+  }
+
   if (!request_force_direct_.load())
   {
+    last_mode_ = mode_;
     return;
   }
 
@@ -81,6 +104,8 @@ void CanfdRouter::HandleBoardFrame(std::shared_ptr<struct canfd_frame> recv_fram
     SendForceDirectCommand(kForceDirect);
     request_force_direct_.store(false);
   }
+
+  last_mode_ = mode_;
 }
 
 void CanfdRouter::SendForceDirectCommand(uint32_t value)

--- a/rl_sar/src/rl_sar/library/hardware/titati/src/titati_hardware.cpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/src/titati_hardware.cpp
@@ -24,6 +24,10 @@ bool TitatiHardware::EnableDirectControl()
     router_->RequestForceDirectMode();
   }
   direct_control_enabled_ = robot_->set_motors_sdk(true);
+  if (!direct_control_enabled_ && router_)
+  {
+    router_->CancelForceDirectMode();
+  }
   return direct_control_enabled_;
 }
 
@@ -32,6 +36,10 @@ bool TitatiHardware::DisableDirectControl()
   if (!direct_control_enabled_)
   {
     return true;
+  }
+  if (router_)
+  {
+    router_->CancelForceDirectMode();
   }
   direct_control_enabled_ = !robot_->set_motors_sdk(false);
   return !direct_control_enabled_;


### PR DESCRIPTION
## Summary
- keep the CAN-FD router actively monitoring force-direct state and re-requesting control when the MCU drops out of SDK mode
- allow the Titati hardware wrapper to disable monitoring when direct control is not active

## Testing
- cmake rl_sar/src/rl_sar -B rl_sar/cmake_build -DUSE_CMAKE=ON *(fails: missing Torch development package)*

------
https://chatgpt.com/codex/tasks/task_e_68d5723039ec83219f609bbdc11fca19