### PR TITLE
Integrate Titati hardware support into rl_sar

### DIFF
--- a/rl_sar/.gitignore
+++ b/rl_sar/.gitignore
@@ -12,3 +12,9 @@ __pycache__
 cmake_build
 
 package.xml
+!src/rl_sar/library/thirdparty/titati_hardware/tita_robot/package.xml
+!src/rl_sar/library/thirdparty/titati_hardware/hw_bringup/package.xml
+!src/rl_sar/library/thirdparty/titati_hardware/hardware_bridge/package.xml
+!src/rl_sar/library/thirdparty/titati_hardware/battery_device/package.xml
+!src/rl_sar/library/thirdparty/tita_system_interfaces/package.xml
+!src/rl_sar/library/thirdparty/titati_canfd_router/package.xml

--- a/rl_sar/README.md
+++ b/rl_sar/README.md
@@ -127,7 +127,7 @@ To clean the build, use the following command. This will remove all compiled out
 ./build.sh -c  # or ./build.sh --clean
 ```
 
-If simulation is not needed and you only want to run on the robot, you can invoke the combined hardware build. This compiles the CMake binaries (stored in `cmake_build/bin`) **and** colcon-builds the Titati ROS packages when a ROS 2 environment is available:
+If simulation is not needed and you only want to run on the robot, you can invoke the combined hardware build. This compiles the CMake binaries (stored in `cmake_build/bin`) **and** colcon-builds the Titati ROS packages when a ROS 2 environment is available. The helper disables all non-Titati real-robot targets during this pass so the Unitree, Lite3, and L4W4 SDKs are not required on your Jetsons:
 
 ```bash
 ./build.sh -m  # or ./build.sh --cmake
@@ -148,7 +148,7 @@ Examples:
   ./build.sh package1 package2  # Build specific ROS packages
   ./build.sh -c                 # Clean all symlinks and build artifacts
   ./build.sh --clean package1   # Clean specific package and build artifacts
-  ./build.sh -m                 # Build hardware targets and Titati ROS packages
+  ./build.sh -m                 # Build Titati hardware targets and ROS packages
 ```
 
 > [!TIP]

--- a/rl_sar/README.md
+++ b/rl_sar/README.md
@@ -395,27 +395,33 @@ The hardware binaries (`rl_real_titati`, `titati_motor_test`, …) are written t
 
 #### 2. Prepare the slave Jetson (battery/power side)
 
-Bring up the slave first so the CAN bus and the power services are available before the master connects:
+Bring up the slave first so the CAN bus and the power services are available before the master connects. The script starts the ROS 2 infrastructure that lives permanently on the slave:
+
+- `battery_device/battery_device_node` publishes battery and power telemetry under the `titati` namespace.
+- `titati_canfd_router/titati_canfd_router_node` requests the MCU to enter the direct (SDK) control mode by calling `system/power_supply/power_self_test_srv` and keeps the routing heartbeat alive.
 
 ```bash
 cd rl_sar
 ./src/rl_sar/scripts/titati_can_setup_slave.sh
 ```
 
-The script stops the factory `tita-bringup` service, configures `can0`, and then launches the local copies of `battery_device` and `titati_canfd_router`. Logs are stored at `/tmp/titati/slave_bringup_battery.log` and `/tmp/titati/slave_bringup_router.log` by default.
+The script stops the factory `tita-bringup` service, configures `can0`, and then launches the local copies of `battery_device` and `titati_canfd_router`. Logs are written to `logs/titati_slave_battery.log` and `logs/titati_slave_canfd_router.log` inside the workspace.
 
 #### 3. Prepare the master Jetson (control side)
 
-Once the slave is online, configure the master:
+Once the slave is online, configure the master. This script mirrors the slave services locally so the controller and monitoring tools always have nearby ROS endpoints:
+
+- `battery_device/battery_device_node` for local battery state monitoring.
+- `titati_canfd_router/titati_canfd_router_node` to ensure the master also keeps the MCU in direct control mode.
 
 ```bash
 cd rl_sar
 ./src/rl_sar/scripts/titati_can_setup_master.sh
 ```
 
-The master runs the same CAN initialisation, starts its own monitoring `battery_device` instance, and launches `titati_canfd_router` so the robot switches to SDK (direct) control mode before the reinforcement-learning binary takes over. Logs mirror the slave under `/tmp/titati/master_bringup_*.log`.
+The master runs the same CAN initialisation, starts its own monitoring `battery_device` instance, and launches `titati_canfd_router` so the robot switches to SDK (direct) control mode before the reinforcement-learning binary takes over. Logs mirror the slave under `logs/titati_master_battery.log` and `logs/titati_master_canfd_router.log`.
 
-Both scripts default to `can0`. If you use another interface, export `TITATI_CAN_INTERFACE` (and optionally `TITATI_CAN_ID_OFFSET`) before running the reinforcement-learning binaries.
+Both scripts default to the namespace `titati`. Export `TITATI_NAMESPACE` before running them if you need to integrate with a different tree of ROS topics.
 
 #### 4. Deploy and run reinforcement learning
 
@@ -427,6 +433,8 @@ Both scripts default to `can0`. If you use another interface, export `TITATI_CAN
    ./cmake_build/bin/titati_motor_test --mode torque --motor 3 --torque 1.0 --duration 2.0
    ```
 
+   `titati_motor_test` accepts `--mode torque`, `--mode mit`, or `--mode read`. The torque and MIT modes apply commands to a single motor selected with `--motor <index>` (0-based) while streaming live joint feedback at 10 Hz. Use `--torque`, `--position`, `--velocity`, `--kp`, and `--kd` to customise the command.
+
 3. Start the reinforcement-learning controller on the master Jetson:
 
    ```bash
@@ -434,6 +442,8 @@ Both scripts default to `can0`. If you use another interface, export `TITATI_CAN
    ```
 
    Keyboard shortcuts follow the global table above (WASD to move, Q/E to yaw, Space to stop, `N` toggles navigation mode).
+
+   If you prefer running inside a ROS 2 workspace, source `install/setup.bash` after the hardware build and launch the same executable with `ros2 run rl_sar rl_real_titati`.
 
 </details>
 

--- a/rl_sar/build.sh
+++ b/rl_sar/build.sh
@@ -144,6 +144,7 @@ run_hardware_build() {
     )
 
     print_info "Building Titati ROS packages: ${titati_packages[*]}"
+    prepare_titati_package_symlinks
     run_ros_build "${titati_packages[@]}"
     print_success "Titati hardware build completed!"
 }
@@ -221,6 +222,7 @@ clean_existing_symlinks() {
     if [ ${#packages[@]} -eq 0 ]; then
         print_info "Removing all existing package.xml symlinks..."
         find src -name "package.xml" -type l -delete
+        find src -maxdepth 1 -type l -delete
         print_success "Removed all existing symlinks"
     else
         print_info "Removing existing symlinks for specified packages..."
@@ -231,6 +233,11 @@ clean_existing_symlinks() {
                 rm -f "$package_dir/package.xml"
                 removed_packages+=("$package_name")
             fi
+            local link_path="src/${package_name}"
+            if [ -L "$link_path" ]; then
+                rm -f "$link_path"
+                removed_packages+=("$package_name")
+            fi
         done
 
         if [ ${#removed_packages[@]} -gt 0 ]; then
@@ -239,6 +246,60 @@ clean_existing_symlinks() {
             print_warning "No existing symlinks found"
         fi
     fi
+}
+
+# ========================
+# Symlink Helpers
+# ========================
+
+ensure_package_directory_symlink() {
+    local package_name="$1"
+    local target_path="$2"
+    local link_path="src/${package_name}"
+
+    if [ ! -e "$target_path/package.xml" ]; then
+        print_warning "Package manifest not found for ${package_name} at ${target_path}; skipping overlay symlink."
+        return 1
+    fi
+
+    if [ -L "$link_path" ]; then
+        local resolved_target
+        local resolved_link
+        resolved_target=$(readlink -f "$target_path")
+        resolved_link=$(readlink -f "$link_path")
+        if [ "$resolved_target" = "$resolved_link" ]; then
+            return 0
+        fi
+        rm -f "$link_path"
+    elif [ -e "$link_path" ]; then
+        return 0
+    fi
+
+    local relative_target
+    if command -v realpath >/dev/null 2>&1; then
+        relative_target=$(realpath --relative-to="src" "$target_path")
+    else
+        relative_target=$(python3 -c 'import os,sys; print(os.path.relpath(sys.argv[1], sys.argv[2]))' "$target_path" "src")
+    fi
+    ln -s "$relative_target" "$link_path"
+    return 0
+}
+
+prepare_titati_package_symlinks() {
+    declare -A package_map=(
+        [tita_robot]="src/rl_sar/library/thirdparty/titati_hardware/tita_robot"
+        [hardware_bridge]="src/rl_sar/library/thirdparty/titati_hardware/hardware_bridge"
+        [hw_bringup]="src/rl_sar/library/thirdparty/titati_hardware/hw_bringup"
+        [battery_device]="src/rl_sar/library/thirdparty/titati_hardware/battery_device"
+        [titati_canfd_router]="src/rl_sar/library/thirdparty/titati_canfd_router"
+        [tita_system_interfaces]="src/rl_sar/library/thirdparty/tita_system_interfaces"
+        [tita_description]="src/robots/tita_description"
+        [titati_description]="src/robots/titati_description"
+    )
+
+    for package_name in "${!package_map[@]}"; do
+        ensure_package_directory_symlink "$package_name" "${package_map[$package_name]}"
+    done
 }
 
 # ========================

--- a/rl_sar/build.sh
+++ b/rl_sar/build.sh
@@ -68,7 +68,11 @@ run_cmake_build() {
     print_warning "NOTE: CMake build is for hardware deployment only, not for simulation."
     print_separator
 
-    cmake src/rl_sar/ -B cmake_build -DUSE_CMAKE=ON
+    cmake src/rl_sar/ -B cmake_build -DUSE_CMAKE=ON \
+        -DBUILD_UNITREE_ROBOTS=OFF \
+        -DBUILD_LITE3_ROBOT=OFF \
+        -DBUILD_L4W4_ROBOT=OFF \
+        -DBUILD_TITATI_ROBOT=ON
     cmake --build cmake_build -j4
 
     print_success "CMake build completed!"

--- a/rl_sar/build.sh
+++ b/rl_sar/build.sh
@@ -119,6 +119,31 @@ run_ros_build() {
     print_success "ROS build completed!"
 }
 
+run_hardware_build() {
+    print_header "[Running Titati Hardware Build]"
+    run_cmake_build
+
+    if [ -z "$ROS_DISTRO" ]; then
+        print_warning "ROS_DISTRO not set; skipping Titati ROS packages"
+        return
+    fi
+
+    local titati_packages=(
+        "tita_robot"
+        "hardware_bridge"
+        "hw_bringup"
+        "battery_device"
+        "titati_canfd_router"
+        "tita_system_interfaces"
+        "tita_description"
+        "titati_description"
+    )
+
+    print_info "Building Titati ROS packages: ${titati_packages[*]}"
+    run_ros_build "${titati_packages[@]}"
+    print_success "Titati hardware build completed!"
+}
+
 # ========================
 # Clean Functions
 # ========================
@@ -316,7 +341,7 @@ show_usage() {
     echo ""
     echo -e "${COLOR_INFO}Options:${COLOR_RESET}"
     echo -e "  -c, --clean    Clean workspace (remove symlinks and build artifacts)"
-    echo -e "  -m, --cmake    Build using CMake (for hardware deployment only)"
+    echo -e "  -m, --cmake    Build Titati hardware targets (CMake + ROS packages)"
     echo -e "  -h, --help     Show this help message"
     echo ""
     echo -e "${COLOR_INFO}Examples:${COLOR_RESET}"
@@ -324,7 +349,7 @@ show_usage() {
     echo -e "  $0 package1 package2  # Build specific ROS packages"
     echo -e "  $0 -c                 # Clean all symlinks and build artifacts"
     echo -e "  $0 --clean package1   # Clean specific package and build artifacts"
-    echo -e "  $0 -m                 # Build with CMake for hardware deployment"
+    echo -e "  $0 -m                 # Build Titati hardware (CMake + ROS packages)"
 }
 
 main() {
@@ -346,7 +371,7 @@ main() {
 
     # Handle CMake build mode
     if [ "$cmake_mode" = true ]; then
-        run_cmake_build
+        run_hardware_build
         exit 0
     fi
 

--- a/rl_sar/src/rl_sar/CMakeLists.txt
+++ b/rl_sar/src/rl_sar/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.5)
 project(rl_sar VERSION 3.0.0 LANGUAGES CXX)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 set(USE_CMAKE OFF CACHE BOOL "Use Cmake build system")
 message(STATUS "USE_CMAKE: ${USE_CMAKE}")
 if(USE_CMAKE)
@@ -69,6 +73,7 @@ if(NOT USE_CMAKE)
         find_package(geometry_msgs REQUIRED)
         ament_package()
     endif()
+    add_compile_definitions(USE_ROS)
     add_compile_options(${GAZEBO_CXX_FLAGS})
     find_package(gazebo REQUIRED)
 endif()
@@ -80,6 +85,26 @@ find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
 
 link_directories(/usr/local/lib)
 include_directories(${YAML_CPP_INCLUDE_DIR})
+
+set(TITATI_ROBOT_LIB titati_robot_static)
+set(TITATI_ROBOT_SRC
+    ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/titati_hardware/tita_robot/src/tita_robot.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/titati_hardware/tita_robot/src/can_sender.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/titati_hardware/tita_robot/src/can_receiver.cpp
+)
+
+add_library(${TITATI_ROBOT_LIB} STATIC ${TITATI_ROBOT_SRC})
+target_include_directories(${TITATI_ROBOT_LIB} PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/titati_hardware/tita_robot/include
+)
+target_link_libraries(${TITATI_ROBOT_LIB} PUBLIC Threads::Threads)
+
+if(NOT USE_CMAKE)
+    if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+        find_package(tita_robot REQUIRED)
+        set(TITATI_ROBOT_LIB tita_robot)
+    endif()
+endif()
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
     message(STATUS "Current system architecture: ${CMAKE_SYSTEM_PROCESSOR}")
@@ -159,7 +184,7 @@ include_directories(
 
 add_library(rl_sdk library/core/rl_sdk/rl_sdk.cpp)
 set_target_properties(rl_sdk PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED ON
 )
 target_link_libraries(rl_sdk PUBLIC
@@ -183,7 +208,7 @@ endif()
 add_library(observation_buffer library/core/observation_buffer/observation_buffer.cpp)
 target_link_libraries(observation_buffer PUBLIC "${TORCH_LIBRARIES}")
 set_target_properties(observation_buffer PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED ON
 )
 if(NOT USE_CMAKE)
@@ -318,6 +343,39 @@ if(NOT USE_CMAKE)
             geometry_msgs
         )
         install(TARGETS rl_real_l4w4 DESTINATION lib/${PROJECT_NAME})
+    endif()
+endif()
+
+if(NOT TITATI_ROBOT_LIB STREQUAL "")
+    add_executable(rl_real_titati src/rl_real_titati.cpp)
+    target_link_libraries(rl_real_titati
+        ${TITATI_ROBOT_LIB}
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+        Threads::Threads
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_titati ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_titati
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_titati DESTINATION lib/${PROJECT_NAME})
+        endif()
+    endif()
+
+    add_executable(titati_motor_test src/titati_motor_test.cpp)
+    target_link_libraries(titati_motor_test
+        ${TITATI_ROBOT_LIB}
+        Threads::Threads
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            install(TARGETS titati_motor_test DESTINATION lib/${PROJECT_NAME})
+        endif()
     endif()
 endif()
 

--- a/rl_sar/src/rl_sar/CMakeLists.txt
+++ b/rl_sar/src/rl_sar/CMakeLists.txt
@@ -6,6 +6,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(USE_CMAKE OFF CACHE BOOL "Use Cmake build system")
+option(BUILD_UNITREE_ROBOTS "Build Unitree robot binaries (A1/Go2/G1)" ON)
+option(BUILD_LITE3_ROBOT "Build the Lite3 real-robot binary" ON)
+option(BUILD_L4W4_ROBOT "Build the L4W4 real-robot binary" ON)
+option(BUILD_TITATI_ROBOT "Build the Titati real-robot binary and tools" ON)
 message(STATUS "USE_CMAKE: ${USE_CMAKE}")
 if(USE_CMAKE)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -106,57 +110,70 @@ if(NOT USE_CMAKE)
     endif()
 endif()
 
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
-    message(STATUS "Current system architecture: ${CMAKE_SYSTEM_PROCESSOR}")
-    set(ARCH_DIR "aarch64")
-    set(UNITREE_LIB "libunitree_legged_sdk_arm64")
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64")
-message(STATUS "Current system architecture: ${CMAKE_SYSTEM_PROCESSOR}")
-    set(ARCH_DIR "x86_64")
-    set(UNITREE_LIB "libunitree_legged_sdk_amd64")
-else()
-    message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+set(NEED_ARCH FALSE)
+if(BUILD_UNITREE_ROBOTS OR BUILD_LITE3_ROBOT OR BUILD_L4W4_ROBOT)
+    set(NEED_ARCH TRUE)
 endif()
 
-# unitree_legged_sdk-3.2
-add_library(unitree_legged_sdk SHARED IMPORTED)
-set_target_properties(unitree_legged_sdk PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/unitree_legged_sdk-3.2/include"
-    IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/unitree_legged_sdk-3.2/lib/${UNITREE_LIB}.so"
-)
-set(UNITREE_A1_LIBS Threads::Threads unitree_legged_sdk lcm)
-if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-    file(GLOB GLOB_UNITREE_LEGGED_SDK "${CMAKE_CURRENT_SOURCE_DIR}/library/unitree_legged_sdk-3.2/lib/${UNITREE_LIB}.so")
-    install(FILES
-        ${GLOB_UNITREE_LEGGED_SDK}
-        DESTINATION lib/
-    )
+if(NEED_ARCH)
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
+        message(STATUS "Current system architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+        set(ARCH_DIR "aarch64")
+        set(UNITREE_LIB "libunitree_legged_sdk_arm64")
+    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64")
+        message(STATUS "Current system architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+        set(ARCH_DIR "x86_64")
+        set(UNITREE_LIB "libunitree_legged_sdk_amd64")
+    else()
+        message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+    endif()
 endif()
 
-# unitree_sdk2-2.0.0
-set(BUILD_EXAMPLES OFF CACHE BOOL "Disable examples build for unitree_sdk2" FORCE)
-add_subdirectory(library/thirdparty/unitree_sdk2-2.0.0)
-
-# l4w4_sdk
-add_library(l4w4_sdk INTERFACE)
-target_include_directories(l4w4_sdk INTERFACE
-    library/thirdparty/l4w4_sdk
-)
-target_link_libraries(l4w4_sdk INTERFACE Threads::Threads)
-
-# Lite3_MotionSDK
-add_library(lite3_motionsdk SHARED IMPORTED)
-set_target_properties(lite3_motionsdk PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/include"
-    IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/lib/libdeeprobotics_legged_sdk_${ARCH_DIR}.so"
-)
-set(LITE3_REAL_LIBS Threads::Threads lite3_motionsdk)
-if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-    file(GLOB GLOB_LITE3_SDK_SO "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/lib/libdeeprobotics_legged_sdk_${ARCH_DIR}.so")
-    install(FILES
-        ${GLOB_LITE3_SDK_SO}
-        DESTINATION lib/
+if(BUILD_UNITREE_ROBOTS)
+    # unitree_legged_sdk-3.2
+    add_library(unitree_legged_sdk SHARED IMPORTED)
+    set_target_properties(unitree_legged_sdk PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/unitree_legged_sdk-3.2/include"
+        IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/unitree_legged_sdk-3.2/lib/${UNITREE_LIB}.so"
     )
+    set(UNITREE_A1_LIBS Threads::Threads unitree_legged_sdk lcm)
+    if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+        file(GLOB GLOB_UNITREE_LEGGED_SDK "${CMAKE_CURRENT_SOURCE_DIR}/library/unitree_legged_sdk-3.2/lib/${UNITREE_LIB}.so")
+        install(FILES
+            ${GLOB_UNITREE_LEGGED_SDK}
+            DESTINATION lib/
+        )
+    endif()
+
+    # unitree_sdk2-2.0.0
+    set(BUILD_EXAMPLES OFF CACHE BOOL "Disable examples build for unitree_sdk2" FORCE)
+    add_subdirectory(library/thirdparty/unitree_sdk2-2.0.0)
+endif()
+
+if(BUILD_L4W4_ROBOT)
+    # l4w4_sdk
+    add_library(l4w4_sdk INTERFACE)
+    target_include_directories(l4w4_sdk INTERFACE
+        library/thirdparty/l4w4_sdk
+    )
+    target_link_libraries(l4w4_sdk INTERFACE Threads::Threads)
+endif()
+
+if(BUILD_LITE3_ROBOT)
+    # Lite3_MotionSDK
+    add_library(lite3_motionsdk SHARED IMPORTED)
+    set_target_properties(lite3_motionsdk PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/include"
+        IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/lib/libdeeprobotics_legged_sdk_${ARCH_DIR}.so"
+    )
+    set(LITE3_REAL_LIBS Threads::Threads lite3_motionsdk)
+    if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+        file(GLOB GLOB_LITE3_SDK_SO "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/lib/libdeeprobotics_legged_sdk_${ARCH_DIR}.so")
+        install(FILES
+            ${GLOB_LITE3_SDK_SO}
+            DESTINATION lib/
+        )
+    endif()
 endif()
 
 # Retroid Gamepad
@@ -245,108 +262,114 @@ if(NOT USE_CMAKE)
     endif()
 endif()
 
-add_executable(rl_real_a1 src/rl_real_a1.cpp)
-target_link_libraries(rl_real_a1
-    ${UNITREE_A1_LIBS}
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
-if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_a1 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_a1
-            rclcpp
-            geometry_msgs
-        )
-        install(TARGETS rl_real_a1 DESTINATION lib/${PROJECT_NAME})
+if(BUILD_UNITREE_ROBOTS)
+    add_executable(rl_real_a1 src/rl_real_a1.cpp)
+    target_link_libraries(rl_real_a1
+        ${UNITREE_A1_LIBS}
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_a1 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_a1
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_a1 DESTINATION lib/${PROJECT_NAME})
+        endif()
+    endif()
+
+    add_executable(rl_real_go2 src/rl_real_go2.cpp)
+    target_link_libraries(rl_real_go2
+        unitree_sdk2
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_go2 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_go2
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_go2 DESTINATION lib/${PROJECT_NAME})
+        endif()
+    endif()
+
+    add_executable(rl_real_g1 src/rl_real_g1.cpp)
+    target_link_libraries(rl_real_g1
+        unitree_sdk2
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_g1 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_g1
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_g1 DESTINATION lib/${PROJECT_NAME})
+        endif()
     endif()
 endif()
 
-add_executable(rl_real_lite3
-    src/rl_real_lite3.cpp
-    ${GAMEPAD_SRC}
-)
-target_link_libraries(rl_real_lite3
-    ${LITE3_REAL_LIBS}
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
-target_include_directories(rl_real_lite3 PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/gamepad/include
-)
-if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_lite3 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_lite3
-            rclcpp
-            geometry_msgs
-        )
-        install(TARGETS rl_real_lite3 DESTINATION lib/${PROJECT_NAME})
+if(BUILD_LITE3_ROBOT)
+    add_executable(rl_real_lite3
+        src/rl_real_lite3.cpp
+        ${GAMEPAD_SRC}
+    )
+    target_link_libraries(rl_real_lite3
+        ${LITE3_REAL_LIBS}
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    target_include_directories(rl_real_lite3 PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/gamepad/include
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_lite3 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_lite3
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_lite3 DESTINATION lib/${PROJECT_NAME})
+        endif()
     endif()
 endif()
 
-add_executable(rl_real_go2 src/rl_real_go2.cpp)
-target_link_libraries(rl_real_go2
-    unitree_sdk2
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
-if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_go2 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_go2
-            rclcpp
-            geometry_msgs
-        )
-        install(TARGETS rl_real_go2 DESTINATION lib/${PROJECT_NAME})
+if(BUILD_L4W4_ROBOT)
+    add_executable(rl_real_l4w4 src/rl_real_l4w4.cpp)
+    target_link_libraries(rl_real_l4w4
+        l4w4_sdk
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_l4w4 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_l4w4
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_l4w4 DESTINATION lib/${PROJECT_NAME})
+        endif()
     endif()
 endif()
 
-add_executable(rl_real_g1 src/rl_real_g1.cpp)
-target_link_libraries(rl_real_g1
-    unitree_sdk2
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
-if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_g1 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_g1
-            rclcpp
-            geometry_msgs
-        )
-        install(TARGETS rl_real_g1 DESTINATION lib/${PROJECT_NAME})
-    endif()
-endif()
-
-add_executable(rl_real_l4w4 src/rl_real_l4w4.cpp)
-target_link_libraries(rl_real_l4w4
-    l4w4_sdk
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
-if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_l4w4 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_l4w4
-            rclcpp
-            geometry_msgs
-        )
-        install(TARGETS rl_real_l4w4 DESTINATION lib/${PROJECT_NAME})
-    endif()
-endif()
-
-if(NOT TITATI_ROBOT_LIB STREQUAL "")
+if(BUILD_TITATI_ROBOT AND NOT TITATI_ROBOT_LIB STREQUAL "")
     add_executable(rl_real_titati src/rl_real_titati.cpp)
     target_link_libraries(rl_real_titati
         ${TITATI_ROBOT_LIB}

--- a/rl_sar/src/rl_sar/library/thirdparty/tita_system_interfaces/package.xml
+++ b/rl_sar/src/rl_sar/library/thirdparty/tita_system_interfaces/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>tita_system_interfaces</name>
+  <version>0.0.1</version>
+  <description>Interfaces for Titati power management.</description>
+  <maintainer email="jianming.zeng@directdrivetech.com">ming</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
+  <depend>diagnostic_msgs</depend>
+
+  <build_depend>rosidl_default_generators</build_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_canfd_router/package.xml
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_canfd_router/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>titati_canfd_router</name>
+  <version>0.0.0</version>
+  <description>CAN-FD router helper for Titati to switch MCU control modes.</description>
+  <maintainer email="mashicheng@directdrivetec.com">msc</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
+  <depend>tita_system_interfaces</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_hardware/battery_device/package.xml
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_hardware/battery_device/package.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>battery_device</name>
+  <version>0.0.0</version>
+  <description>Battery Device</description>
+  <maintainer email="jianming.zeng@directdrivetech.com">zengjianming</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>diagnostic_msgs</depend>
+  <depend>tita_system_interfaces</depend>
+
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_clang_format</test_depend>
+  <test_depend>ament_cmake_copyright</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
+  <test_depend>ament_cmake_cpplint</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_hardware/hardware_bridge/package.xml
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_hardware/hardware_bridge/package.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>hardware_bridge</name>
+  <version>0.0.0</version>
+  <description>Bridge between ros2_control and Titati hardware.</description>
+  <maintainer email="liukexin@directdrivetech.com">lkx</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>geometry_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>pluginlib</depend>
+  <depend>controller_manager</depend>
+  <depend>tita_robot</depend>
+
+  <build_depend>hardware_interface</build_depend>
+
+  <exec_depend>imu_sensor_broadcaster</exec_depend>
+  <exec_depend>joint_state_broadcaster</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_clang_format</test_depend>
+  <test_depend>ament_cmake_copyright</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
+  <test_depend>ament_cmake_cpplint</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_hardware/hw_bringup/package.xml
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_hardware/hw_bringup/package.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>hw_bringup</name>
+  <version>1.0.0</version>
+  <description>Easy bringup to use Titati effort controller.</description>
+  <maintainer email="liukexin@directdrivetech.com">lkx</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>geometry_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>pluginlib</depend>
+
+  <exec_depend>imu_sensor_broadcaster</exec_depend>
+  <exec_depend>joint_state_broadcaster</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_clang_format</test_depend>
+  <test_depend>ament_cmake_copyright</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
+  <test_depend>ament_cmake_cpplint</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rl_sar/src/rl_sar/library/thirdparty/titati_hardware/tita_robot/package.xml
+++ b/rl_sar/src/rl_sar/library/thirdparty/titati_hardware/tita_robot/package.xml
@@ -1,0 +1,9 @@
+<package format="3">
+    <name>tita_robot</name>
+    <version>0.1.0</version>
+    <description>Tita robot CAN communication helpers.</description>
+    <maintainer email="you@example.com">Your Name</maintainer>
+    <license>MIT</license>
+
+    <buildtool_depend>ament_cmake</buildtool_depend>
+</package>

--- a/rl_sar/src/rl_sar/scripts/titati_can_setup_master.sh
+++ b/rl_sar/src/rl_sar/scripts/titati_can_setup_master.sh
@@ -29,12 +29,29 @@ prepare_can_interface() {
     sudo ifconfig "${CAN_INTERFACE}" txqueuelen 1000
 }
 
+safe_source() {
+    local script_path="$1"
+    if [ ! -f "$script_path" ]; then
+        return 1
+    fi
+    local nounset_on=0
+    if set -o | grep -q "nounset *on"; then
+        nounset_on=1
+        set +u
+    fi
+    # shellcheck disable=SC1090
+    source "$script_path"
+    if [ "$nounset_on" -eq 1 ]; then
+        set -u
+    fi
+    return 0
+}
+
 source_ros_environment() {
     local ros_distro="${ROS_DISTRO:-humble}"
     local ros_setup="/opt/ros/${ros_distro}/setup.bash"
     if [ -f "${ros_setup}" ]; then
-        # shellcheck disable=SC1090
-        source "${ros_setup}"
+        safe_source "${ros_setup}" || echo "[WARNING] Failed to source ${ros_setup}" >&2
     else
         echo "[WARNING] ROS setup file ${ros_setup} not found. Set ROS_DISTRO or install ROS 2." >&2
     fi
@@ -44,8 +61,10 @@ source_ros_environment() {
         echo "[ERROR] ${workspace_setup} not found. Run ./build.sh -m first." >&2
         exit 1
     fi
-    # shellcheck disable=SC1090
-    source "${workspace_setup}"
+    safe_source "${workspace_setup}" || {
+        echo "[ERROR] Failed to source ${workspace_setup}" >&2
+        exit 1
+    }
 }
 
 launch_background() {

--- a/rl_sar/src/rl_sar/scripts/titati_can_setup_master.sh
+++ b/rl_sar/src/rl_sar/scripts/titati_can_setup_master.sh
@@ -1,97 +1,69 @@
-#!/bin/bash
-# Configure the master Titati Jetson: stop the stock service, bring up CAN, and launch the ROS bringup stack.
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
-CAN_IFACE=${1:-can0}
-BITRATE=${TITATI_CAN_BITRATE:-1000000}
-DBITRATE=${TITATI_CAN_DBITRATE:-8000000}
-SAMPLE_POINT=${TITATI_CAN_SAMPLE_POINT:-0.80}
-DSAMPLE_POINT=${TITATI_CAN_DSAMPLE_POINT:-0.80}
-QUEUE_LEN=${TITATI_CAN_QUEUE_LEN:-1000}
-LOG_DIR=${TITATI_CAN_LOG_DIR:-/tmp/titati}
-
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-WORKSPACE_ROOT="$( cd "${SCRIPT_DIR}/../../.." && pwd )"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+LOG_DIR="${REPO_ROOT}/logs"
+CAN_INTERFACE="can0"
+LOG_PREFIX="${LOG_DIR}/titati_master"
 
 mkdir -p "${LOG_DIR}"
-LOG_FILE="${LOG_DIR}/master_bringup.log"
 
-source_ros_env() {
-    if command -v ros2 >/dev/null 2>&1; then
-        return 0
+stop_systemd_service() {
+    local service_name="$1"
+    if systemctl list-unit-files 2>/dev/null | grep -q "^${service_name}"; then
+        echo "[INFO] Stopping systemd service ${service_name}" >&2
+        sudo systemctl stop "${service_name}" 2>/dev/null || true
     fi
+}
 
-    if [[ -n "$ROS_DISTRO" && -f "/opt/ros/${ROS_DISTRO}/setup.bash" ]]; then
+prepare_can_interface() {
+    echo "[INFO] Configuring ${CAN_INTERFACE} for CAN-FD" >&2
+    if ip link show "${CAN_INTERFACE}" &>/dev/null; then
+        sudo ip link set "${CAN_INTERFACE}" down || true
+    fi
+    sudo ip link set "${CAN_INTERFACE}" up type can \
+        bitrate 1000000 sample-point 0.80 \
+        dbitrate 8000000 dsample-point 0.80 \
+        fd on restart-ms 100
+    sudo ifconfig "${CAN_INTERFACE}" txqueuelen 1000
+}
+
+source_ros_environment() {
+    local ros_distro="${ROS_DISTRO:-humble}"
+    local ros_setup="/opt/ros/${ros_distro}/setup.bash"
+    if [ -f "${ros_setup}" ]; then
         # shellcheck disable=SC1090
-        source "/opt/ros/${ROS_DISTRO}/setup.bash"
+        source "${ros_setup}"
     else
-        local candidates=("humble" "foxy")
-        for distro in "${candidates[@]}"; do
-            local setup="/opt/ros/${distro}/setup.bash"
-            if [ -f "$setup" ]; then
-                # shellcheck disable=SC1090
-                source "$setup"
-                break
-            fi
-        done
+        echo "[WARNING] ROS setup file ${ros_setup} not found. Set ROS_DISTRO or install ROS 2." >&2
     fi
 
-    command -v ros2 >/dev/null 2>&1
-}
-
-source_workspace_overlay() {
-    if [ -f "${WORKSPACE_ROOT}/install/setup.bash" ]; then
-        # shellcheck disable=SC1090
-        source "${WORKSPACE_ROOT}/install/setup.bash"
-    elif [ -f "${WORKSPACE_ROOT}/devel/setup.bash" ]; then
-        # shellcheck disable=SC1090
-        source "${WORKSPACE_ROOT}/devel/setup.bash"
+    local workspace_setup="${REPO_ROOT}/install/setup.bash"
+    if [ ! -f "${workspace_setup}" ]; then
+        echo "[ERROR] ${workspace_setup} not found. Run ./build.sh -m first." >&2
+        exit 1
     fi
+    # shellcheck disable=SC1090
+    source "${workspace_setup}"
 }
 
-echo "[Titati] Preparing CAN interface ${CAN_IFACE} on master..."
-sudo systemctl stop tita-bringup.service >/dev/null 2>&1 || true
-sudo ip link set "${CAN_IFACE}" down >/dev/null 2>&1 || true
-sudo ip link set "${CAN_IFACE}" up type can bitrate "${BITRATE}" sample-point "${SAMPLE_POINT}" \
-    dbitrate "${DBITRATE}" dsample-point "${DSAMPLE_POINT}" fd on restart-ms 100
-sudo ifconfig "${CAN_IFACE}" txqueuelen "${QUEUE_LEN}"
+launch_background() {
+    local label="$1"
+    shift
+    local log_file="${LOG_PREFIX}_${label}.log"
+    echo "[INFO] Launching ${label} (log: ${log_file})" >&2
+    nohup "$@" >"${log_file}" 2>&1 &
+}
 
-echo "[Titati] CAN interface ${CAN_IFACE} configured."
+stop_systemd_service "tita-bringup.service"
+prepare_can_interface
+source_ros_environment
 
-if ! source_ros_env; then
-    echo "[Titati] ERROR: Unable to locate a ROS 2 environment. Please source /opt/ros/<distro>/setup.bash first." >&2
-    exit 1
-fi
+export TITATI_NAMESPACE="${TITATI_NAMESPACE:-titati}"
 
-source_workspace_overlay
+launch_background "battery" ros2 launch battery_device battery_device_node.launch.py namespace:="${TITATI_NAMESPACE}"
+launch_background "canfd_router" ros2 run titati_canfd_router titati_canfd_router_node --ros-args --remap __ns:="/${TITATI_NAMESPACE}"
 
-if ! command -v ros2 >/dev/null 2>&1; then
-    echo "[Titati] ERROR: 'ros2' command not available after sourcing environment." >&2
-    exit 1
-fi
-
-if pgrep -f "battery_device_node" >/dev/null 2>&1; then
-    pkill -f "battery_device_node" >/dev/null 2>&1 || true
-    sleep 1
-fi
-
-if pgrep -f "titati_canfd_router_node" >/dev/null 2>&1; then
-    pkill -f "titati_canfd_router_node" >/dev/null 2>&1 || true
-    sleep 1
-fi
-
-echo "[Titati] Launching battery_device_node for master diagnostics..."
-nohup ros2 launch battery_device battery_device_node.launch.py \
-    >"${LOG_FILE%.log}_battery.log" 2>&1 &
-BATTERY_PID=$!
-
-echo "[Titati] Launching titati_canfd_router_node to request SDK mode..."
-nohup ros2 run titati_canfd_router titati_canfd_router_node \
-    >"${LOG_FILE%.log}_router.log" 2>&1 &
-ROUTER_PID=$!
-
-disown "$BATTERY_PID" "$ROUTER_PID" 2>/dev/null || true
-
-echo "[Titati] battery_device_node PID ${BATTERY_PID}, titati_canfd_router_node PID ${ROUTER_PID}."
-echo "Logs: ${LOG_FILE%.log}_battery.log and ${LOG_FILE%.log}_router.log"
-echo "Export TITATI_CAN_INTERFACE=${CAN_IFACE} before running rl_real_titati if you use a custom interface."
+echo "[INFO] Titati master pre-launch complete." >&2
+echo "[INFO] Next: run ./cmake_build/bin/titati_motor_test or ./cmake_build/bin/rl_real_titati to command the robot." >&2

--- a/rl_sar/src/rl_sar/scripts/titati_can_setup_slave.sh
+++ b/rl_sar/src/rl_sar/scripts/titati_can_setup_slave.sh
@@ -29,12 +29,29 @@ prepare_can_interface() {
     sudo ifconfig "${CAN_INTERFACE}" txqueuelen 1000
 }
 
+safe_source() {
+    local script_path="$1"
+    if [ ! -f "$script_path" ]; then
+        return 1
+    fi
+    local nounset_on=0
+    if set -o | grep -q "nounset *on"; then
+        nounset_on=1
+        set +u
+    fi
+    # shellcheck disable=SC1090
+    source "$script_path"
+    if [ "$nounset_on" -eq 1 ]; then
+        set -u
+    fi
+    return 0
+}
+
 source_ros_environment() {
     local ros_distro="${ROS_DISTRO:-humble}"
     local ros_setup="/opt/ros/${ros_distro}/setup.bash"
     if [ -f "${ros_setup}" ]; then
-        # shellcheck disable=SC1090
-        source "${ros_setup}"
+        safe_source "${ros_setup}" || echo "[WARNING] Failed to source ${ros_setup}" >&2
     else
         echo "[WARNING] ROS setup file ${ros_setup} not found. Set ROS_DISTRO or install ROS 2." >&2
     fi
@@ -44,8 +61,10 @@ source_ros_environment() {
         echo "[ERROR] ${workspace_setup} not found. Run ./build.sh -m first." >&2
         exit 1
     fi
-    # shellcheck disable=SC1090
-    source "${workspace_setup}"
+    safe_source "${workspace_setup}" || {
+        echo "[ERROR] Failed to source ${workspace_setup}" >&2
+        exit 1
+    }
 }
 
 launch_background() {

--- a/rl_sar/src/rl_sar/scripts/titati_can_setup_slave.sh
+++ b/rl_sar/src/rl_sar/scripts/titati_can_setup_slave.sh
@@ -1,98 +1,69 @@
-#!/bin/bash
-# Configure the slave Titati Jetson: stop the stock service, bring up CAN, and launch the ROS bringup stack.
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
-CAN_IFACE=${1:-can0}
-BITRATE=${TITATI_CAN_BITRATE:-1000000}
-DBITRATE=${TITATI_CAN_DBITRATE:-8000000}
-SAMPLE_POINT=${TITATI_CAN_SAMPLE_POINT:-0.80}
-DSAMPLE_POINT=${TITATI_CAN_DSAMPLE_POINT:-0.80}
-QUEUE_LEN=${TITATI_CAN_QUEUE_LEN:-1000}
-LOG_DIR=${TITATI_CAN_LOG_DIR:-/tmp/titati}
-
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-WORKSPACE_ROOT="$( cd "${SCRIPT_DIR}/../../.." && pwd )"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+LOG_DIR="${REPO_ROOT}/logs"
+CAN_INTERFACE="can0"
+LOG_PREFIX="${LOG_DIR}/titati_slave"
 
 mkdir -p "${LOG_DIR}"
-LOG_FILE="${LOG_DIR}/slave_bringup.log"
 
-source_ros_env() {
-    if command -v ros2 >/dev/null 2>&1; then
-        return 0
+stop_systemd_service() {
+    local service_name="$1"
+    if systemctl list-unit-files 2>/dev/null | grep -q "^${service_name}"; then
+        echo "[INFO] Stopping systemd service ${service_name}" >&2
+        sudo systemctl stop "${service_name}" 2>/dev/null || true
     fi
+}
 
-    if [[ -n "$ROS_DISTRO" && -f "/opt/ros/${ROS_DISTRO}/setup.bash" ]]; then
+prepare_can_interface() {
+    echo "[INFO] Configuring ${CAN_INTERFACE} for CAN-FD" >&2
+    if ip link show "${CAN_INTERFACE}" &>/dev/null; then
+        sudo ip link set "${CAN_INTERFACE}" down || true
+    fi
+    sudo ip link set "${CAN_INTERFACE}" up type can \
+        bitrate 1000000 sample-point 0.80 \
+        dbitrate 8000000 dsample-point 0.80 \
+        fd on restart-ms 100
+    sudo ifconfig "${CAN_INTERFACE}" txqueuelen 1000
+}
+
+source_ros_environment() {
+    local ros_distro="${ROS_DISTRO:-humble}"
+    local ros_setup="/opt/ros/${ros_distro}/setup.bash"
+    if [ -f "${ros_setup}" ]; then
         # shellcheck disable=SC1090
-        source "/opt/ros/${ROS_DISTRO}/setup.bash"
+        source "${ros_setup}"
     else
-        local candidates=("humble" "foxy")
-        for distro in "${candidates[@]}"; do
-            local setup="/opt/ros/${distro}/setup.bash"
-            if [ -f "$setup" ]; then
-                # shellcheck disable=SC1090
-                source "$setup"
-                break
-            fi
-        done
+        echo "[WARNING] ROS setup file ${ros_setup} not found. Set ROS_DISTRO or install ROS 2." >&2
     fi
 
-    command -v ros2 >/dev/null 2>&1
-}
-
-source_workspace_overlay() {
-    if [ -f "${WORKSPACE_ROOT}/install/setup.bash" ]; then
-        # shellcheck disable=SC1090
-        source "${WORKSPACE_ROOT}/install/setup.bash"
-    elif [ -f "${WORKSPACE_ROOT}/devel/setup.bash" ]; then
-        # shellcheck disable=SC1090
-        source "${WORKSPACE_ROOT}/devel/setup.bash"
+    local workspace_setup="${REPO_ROOT}/install/setup.bash"
+    if [ ! -f "${workspace_setup}" ]; then
+        echo "[ERROR] ${workspace_setup} not found. Run ./build.sh -m first." >&2
+        exit 1
     fi
+    # shellcheck disable=SC1090
+    source "${workspace_setup}"
 }
 
-echo "[Titati] Preparing CAN interface ${CAN_IFACE} on slave..."
-sudo systemctl stop tita-bringup.service >/dev/null 2>&1 || true
-sudo ip link set "${CAN_IFACE}" down >/dev/null 2>&1 || true
-sudo ip link set "${CAN_IFACE}" up type can bitrate "${BITRATE}" sample-point "${SAMPLE_POINT}" \
-    dbitrate "${DBITRATE}" dsample-point "${DSAMPLE_POINT}" fd on restart-ms 100
-sudo ifconfig "${CAN_IFACE}" txqueuelen "${QUEUE_LEN}"
+launch_background() {
+    local label="$1"
+    shift
+    local log_file="${LOG_PREFIX}_${label}.log"
+    echo "[INFO] Launching ${label} (log: ${log_file})" >&2
+    nohup "$@" >"${log_file}" 2>&1 &
+}
 
-echo "[Titati] CAN interface ${CAN_IFACE} configured."
+stop_systemd_service "tita-bringup.service"
+prepare_can_interface
+source_ros_environment
 
-if ! source_ros_env; then
-    echo "[Titati] ERROR: Unable to locate a ROS 2 environment. Please source /opt/ros/<distro>/setup.bash first." >&2
-    exit 1
-fi
+export TITATI_NAMESPACE="${TITATI_NAMESPACE:-titati}"
 
-source_workspace_overlay
+launch_background "battery" ros2 launch battery_device battery_device_node.launch.py namespace:="${TITATI_NAMESPACE}"
+launch_background "canfd_router" ros2 run titati_canfd_router titati_canfd_router_node --ros-args --remap __ns:="/${TITATI_NAMESPACE}"
 
-if ! command -v ros2 >/dev/null 2>&1; then
-    echo "[Titati] ERROR: 'ros2' command not available after sourcing environment." >&2
-    exit 1
-fi
-
-if pgrep -f "battery_device_node" >/dev/null 2>&1; then
-    pkill -f "battery_device_node" >/dev/null 2>&1 || true
-    sleep 1
-fi
-
-if pgrep -f "titati_canfd_router_node" >/dev/null 2>&1; then
-    pkill -f "titati_canfd_router_node" >/dev/null 2>&1 || true
-    sleep 1
-fi
-
-echo "[Titati] Launching battery_device_node on slave..."
-nohup ros2 launch battery_device battery_device_node.launch.py \
-    >"${LOG_FILE%.log}_battery.log" 2>&1 &
-BATTERY_PID=$!
-
-echo "[Titati] Launching titati_canfd_router_node on slave..."
-nohup ros2 run titati_canfd_router titati_canfd_router_node \
-    >"${LOG_FILE%.log}_router.log" 2>&1 &
-ROUTER_PID=$!
-
-disown "$BATTERY_PID" "$ROUTER_PID" 2>/dev/null || true
-
-echo "[Titati] battery_device_node PID ${BATTERY_PID}, titati_canfd_router_node PID ${ROUTER_PID}."
-echo "Logs: ${LOG_FILE%.log}_battery.log and ${LOG_FILE%.log}_router.log"
-echo "If the slave contributes additional actuators, export TITATI_CAN_INTERFACE=${CAN_IFACE} and"
-echo "TITATI_CAN_ID_OFFSET before running diagnostics or custom tools."
+echo "[INFO] Titati slave pre-launch complete." >&2
+echo "[INFO] Keep this terminal open to monitor logs in ${LOG_DIR}." >&2


### PR DESCRIPTION
## Summary
- add concrete package.xml manifests for the Titati ROS packages so they can be built directly inside rl_sar
- teach the build helper to build Titati hardware (CMake binaries plus the minimal ROS stack) with a single `./build.sh -m`
- add one-click master/slave bring-up scripts, C++17 upgrades, and docs covering the Titati motor test and deployment workflow

## Testing
- Not run (hardware environment required)

------
https://chatgpt.com/codex/tasks/task_e_68d690af75bc83219e7ed6f7f7b01709