### PR TITLE
Add Titati battery service bridge for CAN handshake

### DIFF
--- a/rl_sar/README.md
+++ b/rl_sar/README.md
@@ -160,6 +160,93 @@ In the following text, **\<ROBOT\>/\<CONFIG\>** is used to represent different e
 
 Before running, copy the trained pt model file to `rl_sar/src/rl_sar/policy/<ROBOT>/<CONFIG>`, and configure the parameters in `<ROBOT>/<CONFIG>/config.yaml` and `<ROBOT>/base.yaml`.
 
+### Titati hardware deployment (real robot)
+
+> The Titati deployment targets the dual-Tita quadruped described in the task (two wheeled legs bridged through the connection box). Only the Titati binaries are built when you use `./build.sh -m`.
+
+#### 1. Build (one-time on each Jetson)
+
+```bash
+cd rl_sar
+./build.sh -m
+```
+
+This uses CMake with C++17 and generates binaries in `cmake_build/bin/`.
+
+#### 2. Prepare CAN-FD on both controllers
+
+On **both** Jetson Orin NX boards (master and slave) configure `can0` to 1 Mbps arbitration / 8 Mbps data:
+
+```bash
+cd rl_sar/src/rl_sar/scripts
+sudo ./can_setup_8m_master.sh    # on the master Jetson
+sudo ./can_setup_8m_slave.sh     # on the slave Jetson
+```
+
+The scripts are identical to those in `titati_control` and bring up CAN-FD, set the bit timings, and start the `titati_canfd` interface.
+
+#### 3. Start the Titati battery service bridge (ROS 2)
+
+The CAN-FD router expects the `battery_device` ROS 2 services to be present. This lightweight node answers the `power_self_test` request and streams the required heartbeats so the MCU grants force-direct control to the host.
+
+On **each** Jetson (master and slave) open a ROS 2 terminal and run:
+
+```bash
+source /opt/ros/humble/setup.bash
+source install/setup.bash
+ros2 run rl_sar titati_battery_device_node
+```
+
+Leave the node running; it is idle until the router requests a self-test and publishes a heartbeat every second.
+
+#### 4. Start the CAN-FD router watchdog (keeps the MCU in FORCE_DIRECT)
+
+The watchdog listens to broadcast frame `0x09F` and replays the `READY_WAITING -> FORCE_DIRECT` RPC pair (`0x170`) whenever the MCU falls back to auto mode.
+
+On **both** master and slave Jetsons run:
+
+```bash
+cd rl_sar/cmake_build/bin
+./titati_router_watchdog
+```
+
+You can keep this process in the background (Ctrl+C to exit). The RL controller and the motor test tool also embed the same handshake logic, so the watchdog is mostly a safety net for unexpected resets.
+
+#### 5. Master-side quick diagnostics
+
+Before loading a policy you can verify motor connectivity and state feedback with the standalone motor exerciser:
+
+```bash
+cd rl_sar/cmake_build/bin
+./titati_motor_test --joint 3 --mode torque --value 5.0 --duration 3
+```
+
+Options:
+
+* `--joint <id>`: select joint `[0-15]`.
+* `--mode torque|mit`: pure torque command (Nm) or MIT mode with position/PD gains.
+* `--value`: torque (Nm) in torque mode, position (rad) in MIT mode.
+* `--kp/--kd`: PD gains for MIT mode (defaults to zero).
+* `--duration`: hold time in seconds.
+
+The tool streams the current position/velocity/torque of the chosen joint every 200 ms so you can confirm feedback from all actuators.
+
+#### 6. Run the Titati RL controller on the master
+
+```bash
+cd rl_sar/cmake_build/bin
+./rl_real_titati
+```
+
+Key notes:
+
+* The controller reads the policies in `policy/titati/*` and matches the joint ordering defined in `policy/titati/base.yaml`.
+* Force-direct CAN handshake is handled internally (no extra ROS2 nodes required).
+* Keyboard teleop matches other RL deployments: `W/S` for forward/backward, `A/D` lateral, `Q/E` yaw, `Space` to zero the command, `N` to toggle navigation mode (`/cmd_vel` takeover if ROS2 teleop is running).
+* On exit the node sends zero torques and hands control back to the MCU.
+
+If you prefer ROS2 command inputs, compile with ROS enabled (`source /opt/ros/humble/setup.bash` before calling `./build.sh -m`) and publish `geometry_msgs/Twist` on `/cmd_vel`.
+
 ### Simulation
 
 Open a terminal, launch the gazebo simulation environment

--- a/rl_sar/build.sh
+++ b/rl_sar/build.sh
@@ -68,7 +68,7 @@ run_cmake_build() {
     print_warning "NOTE: CMake build is for hardware deployment only, not for simulation."
     print_separator
 
-    cmake src/rl_sar/ -B cmake_build -DUSE_CMAKE=ON
+    cmake src/rl_sar/ -B cmake_build -DUSE_CMAKE=ON -DBUILD_TITATI_ONLY=ON
     cmake --build cmake_build -j4
 
     print_success "CMake build completed!"

--- a/rl_sar/src/rl_sar/CMakeLists.txt
+++ b/rl_sar/src/rl_sar/CMakeLists.txt
@@ -1,8 +1,17 @@
 cmake_minimum_required(VERSION 3.5)
 project(rl_sar VERSION 3.0.0 LANGUAGES CXX)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 set(USE_CMAKE OFF CACHE BOOL "Use Cmake build system")
 message(STATUS "USE_CMAKE: ${USE_CMAKE}")
+set(BUILD_TITATI_ONLY_DEFAULT OFF)
+if(USE_CMAKE)
+    set(BUILD_TITATI_ONLY_DEFAULT ON)
+endif()
+option(BUILD_TITATI_ONLY "Build only Titati hardware deployment targets" ${BUILD_TITATI_ONLY_DEFAULT})
 if(USE_CMAKE)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
     set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -67,6 +76,8 @@ if(NOT USE_CMAKE)
         find_package(gazebo_msgs REQUIRED)
         find_package(std_srvs REQUIRED)
         find_package(geometry_msgs REQUIRED)
+        find_package(diagnostic_msgs REQUIRED)
+        find_package(tita_system_interfaces REQUIRED)
         ament_package()
     endif()
     add_compile_options(${GAZEBO_CXX_FLAGS})
@@ -93,53 +104,55 @@ else()
     message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
 endif()
 
-# unitree_legged_sdk-3.2
-add_library(unitree_legged_sdk SHARED IMPORTED)
-set_target_properties(unitree_legged_sdk PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/unitree_legged_sdk-3.2/include"
-    IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/unitree_legged_sdk-3.2/lib/${UNITREE_LIB}.so"
-)
-set(UNITREE_A1_LIBS Threads::Threads unitree_legged_sdk lcm)
-if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-    file(GLOB GLOB_UNITREE_LEGGED_SDK "${CMAKE_CURRENT_SOURCE_DIR}/library/unitree_legged_sdk-3.2/lib/${UNITREE_LIB}.so")
-    install(FILES
-        ${GLOB_UNITREE_LEGGED_SDK}
-        DESTINATION lib/
+if(NOT BUILD_TITATI_ONLY)
+    # unitree_legged_sdk-3.2
+    add_library(unitree_legged_sdk SHARED IMPORTED)
+    set_target_properties(unitree_legged_sdk PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/unitree_legged_sdk-3.2/include"
+        IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/unitree_legged_sdk-3.2/lib/${UNITREE_LIB}.so"
+    )
+    set(UNITREE_A1_LIBS Threads::Threads unitree_legged_sdk lcm)
+    if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+        file(GLOB GLOB_UNITREE_LEGGED_SDK "${CMAKE_CURRENT_SOURCE_DIR}/library/unitree_legged_sdk-3.2/lib/${UNITREE_LIB}.so")
+        install(FILES
+            ${GLOB_UNITREE_LEGGED_SDK}
+            DESTINATION lib/
+        )
+    endif()
+
+    # unitree_sdk2-2.0.0
+    set(BUILD_EXAMPLES OFF CACHE BOOL "Disable examples build for unitree_sdk2" FORCE)
+    add_subdirectory(library/thirdparty/unitree_sdk2-2.0.0)
+
+    # l4w4_sdk
+    add_library(l4w4_sdk INTERFACE)
+    target_include_directories(l4w4_sdk INTERFACE
+        library/thirdparty/l4w4_sdk
+    )
+    target_link_libraries(l4w4_sdk INTERFACE Threads::Threads)
+
+    # Lite3_MotionSDK
+    add_library(lite3_motionsdk SHARED IMPORTED)
+    set_target_properties(lite3_motionsdk PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/include"
+        IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/lib/libdeeprobotics_legged_sdk_${ARCH_DIR}.so"
+    )
+    set(LITE3_REAL_LIBS Threads::Threads lite3_motionsdk)
+    if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+        file(GLOB GLOB_LITE3_SDK_SO "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/lib/libdeeprobotics_legged_sdk_${ARCH_DIR}.so")
+        install(FILES
+            ${GLOB_LITE3_SDK_SO}
+            DESTINATION lib/
+        )
+    endif()
+
+    # Retroid Gamepad
+    set(GAMEPAD_SRC
+        ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/gamepad/src/gamepad.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/gamepad/src/retroid_gamepad.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/gamepad/src/udp_receiver.cpp
     )
 endif()
-
-# unitree_sdk2-2.0.0
-set(BUILD_EXAMPLES OFF CACHE BOOL "Disable examples build for unitree_sdk2" FORCE)
-add_subdirectory(library/thirdparty/unitree_sdk2-2.0.0)
-
-# l4w4_sdk
-add_library(l4w4_sdk INTERFACE)
-target_include_directories(l4w4_sdk INTERFACE
-    library/thirdparty/l4w4_sdk
-)
-target_link_libraries(l4w4_sdk INTERFACE Threads::Threads)
-
-# Lite3_MotionSDK
-add_library(lite3_motionsdk SHARED IMPORTED)
-set_target_properties(lite3_motionsdk PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/include"
-    IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/lib/libdeeprobotics_legged_sdk_${ARCH_DIR}.so"
-)
-set(LITE3_REAL_LIBS Threads::Threads lite3_motionsdk)
-if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-    file(GLOB GLOB_LITE3_SDK_SO "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/lib/libdeeprobotics_legged_sdk_${ARCH_DIR}.so")
-    install(FILES
-        ${GLOB_LITE3_SDK_SO}
-        DESTINATION lib/
-    )
-endif()
-
-# Retroid Gamepad
-set(GAMEPAD_SRC
-    ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/gamepad/src/gamepad.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/gamepad/src/retroid_gamepad.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/gamepad/src/udp_receiver.cpp
-)
 
 if(NOT USE_CMAKE)
     if($ENV{ROS_DISTRO} MATCHES "noetic")
@@ -155,13 +168,25 @@ include_directories(
     library/core/loop
     library/core/fsm
     policy
+    library/hardware/titati/include
 )
 
-add_library(rl_sdk library/core/rl_sdk/rl_sdk.cpp)
-set_target_properties(rl_sdk PROPERTIES
-    CXX_STANDARD 14
-    CXX_STANDARD_REQUIRED ON
+set(TITATI_HARDWARE_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/library/hardware/titati/src/can_receiver.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/library/hardware/titati/src/can_sender.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/library/hardware/titati/src/tita_robot.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/library/hardware/titati/src/force_direct_manager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/library/hardware/titati/src/power_management_sender.cpp
 )
+add_library(titati_hardware ${TITATI_HARDWARE_SOURCES})
+target_link_libraries(titati_hardware PUBLIC Threads::Threads)
+target_include_directories(titati_hardware PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/library/hardware/titati/include
+)
+target_compile_features(titati_hardware PUBLIC cxx_std_17)
+
+add_library(rl_sdk library/core/rl_sdk/rl_sdk.cpp)
+target_compile_features(rl_sdk PUBLIC cxx_std_17)
 target_link_libraries(rl_sdk PUBLIC
     "${TORCH_LIBRARIES}"
     Python3::Python
@@ -182,10 +207,7 @@ endif()
 
 add_library(observation_buffer library/core/observation_buffer/observation_buffer.cpp)
 target_link_libraries(observation_buffer PUBLIC "${TORCH_LIBRARIES}")
-set_target_properties(observation_buffer PROPERTIES
-    CXX_STANDARD 14
-    CXX_STANDARD_REQUIRED ON
-)
+target_compile_features(observation_buffer PUBLIC cxx_std_17)
 if(NOT USE_CMAKE)
     if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
         install(TARGETS observation_buffer DESTINATION lib/${PROJECT_NAME})
@@ -220,104 +242,144 @@ if(NOT USE_CMAKE)
     endif()
 endif()
 
-add_executable(rl_real_a1 src/rl_real_a1.cpp)
-target_link_libraries(rl_real_a1
-    ${UNITREE_A1_LIBS}
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
-if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_a1 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_a1
-            rclcpp
-            geometry_msgs
-        )
-        install(TARGETS rl_real_a1 DESTINATION lib/${PROJECT_NAME})
+if(NOT BUILD_TITATI_ONLY)
+    add_executable(rl_real_a1 src/rl_real_a1.cpp)
+    target_link_libraries(rl_real_a1
+        ${UNITREE_A1_LIBS}
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_a1 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_a1
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_a1 DESTINATION lib/${PROJECT_NAME})
+        endif()
+    endif()
+
+    add_executable(rl_real_lite3
+        src/rl_real_lite3.cpp
+        ${GAMEPAD_SRC}
+    )
+    target_link_libraries(rl_real_lite3
+        ${LITE3_REAL_LIBS}
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    target_include_directories(rl_real_lite3 PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/gamepad/include
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_lite3 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_lite3
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_lite3 DESTINATION lib/${PROJECT_NAME})
+        endif()
+    endif()
+
+    add_executable(rl_real_go2 src/rl_real_go2.cpp)
+    target_link_libraries(rl_real_go2
+        unitree_sdk2
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_go2 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_go2
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_go2 DESTINATION lib/${PROJECT_NAME})
+        endif()
+    endif()
+
+    add_executable(rl_real_g1 src/rl_real_g1.cpp)
+    target_link_libraries(rl_real_g1
+        unitree_sdk2
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_g1 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_g1
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_g1 DESTINATION lib/${PROJECT_NAME})
+        endif()
+    endif()
+
+    add_executable(rl_real_l4w4 src/rl_real_l4w4.cpp)
+    target_link_libraries(rl_real_l4w4
+        l4w4_sdk
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_l4w4 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_l4w4
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_l4w4 DESTINATION lib/${PROJECT_NAME})
+        endif()
     endif()
 endif()
 
-add_executable(rl_real_lite3
-    src/rl_real_lite3.cpp
-    ${GAMEPAD_SRC}
-)
-target_link_libraries(rl_real_lite3
-    ${LITE3_REAL_LIBS}
+add_executable(rl_real_titati src/rl_real_titati.cpp)
+target_link_libraries(rl_real_titati
+    titati_hardware
     rl_sdk
     observation_buffer
     yaml-cpp
 )
-target_include_directories(rl_real_lite3 PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/gamepad/include
-)
 if(NOT USE_CMAKE)
     if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_lite3 ${catkin_LIBRARIES})
+        target_link_libraries(rl_real_titati ${catkin_LIBRARIES})
     elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_lite3
+        ament_target_dependencies(rl_real_titati
             rclcpp
             geometry_msgs
         )
-        install(TARGETS rl_real_lite3 DESTINATION lib/${PROJECT_NAME})
+        install(TARGETS rl_real_titati DESTINATION lib/${PROJECT_NAME})
     endif()
 endif()
 
-add_executable(rl_real_go2 src/rl_real_go2.cpp)
-target_link_libraries(rl_real_go2
-    unitree_sdk2
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
-if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_go2 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_go2
-            rclcpp
-            geometry_msgs
-        )
-        install(TARGETS rl_real_go2 DESTINATION lib/${PROJECT_NAME})
-    endif()
-endif()
+add_executable(titati_motor_test src/titati_motor_test.cpp)
+target_link_libraries(titati_motor_test titati_hardware)
 
-add_executable(rl_real_g1 src/rl_real_g1.cpp)
-target_link_libraries(rl_real_g1
-    unitree_sdk2
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
-if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_g1 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_g1
-            rclcpp
-            geometry_msgs
-        )
-        install(TARGETS rl_real_g1 DESTINATION lib/${PROJECT_NAME})
-    endif()
-endif()
+add_executable(titati_router_watchdog src/titati_router_watchdog.cpp)
+target_link_libraries(titati_router_watchdog titati_hardware)
 
-add_executable(rl_real_l4w4 src/rl_real_l4w4.cpp)
-target_link_libraries(rl_real_l4w4
-    l4w4_sdk
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
 if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_l4w4 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_l4w4
+    if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+        add_executable(titati_battery_device_node src/titati_battery_device.cpp)
+        target_link_libraries(titati_battery_device_node titati_hardware)
+        ament_target_dependencies(titati_battery_device_node
             rclcpp
-            geometry_msgs
+            diagnostic_msgs
+            tita_system_interfaces
         )
-        install(TARGETS rl_real_l4w4 DESTINATION lib/${PROJECT_NAME})
+        install(TARGETS titati_battery_device_node DESTINATION lib/${PROJECT_NAME})
     endif()
 endif()
 

--- a/rl_sar/src/rl_sar/include/rl_real_titati.hpp
+++ b/rl_sar/src/rl_sar/include/rl_real_titati.hpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024-2025 Ziqi Fan
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef RL_REAL_TITATI_HPP
+#define RL_REAL_TITATI_HPP
+
+// #define USE_ROS
+
+#include "rl_sdk.hpp"
+#include "observation_buffer.hpp"
+#include "loop.hpp"
+#include "fsm.hpp"
+
+#include "titati/tita_robot/tita_robot.hpp"
+#include "titati/force_direct_manager.hpp"
+
+#if defined(USE_ROS1) && defined(USE_ROS)
+#include <ros/ros.h>
+#include <geometry_msgs/Twist.h>
+#elif defined(USE_ROS2) && defined(USE_ROS)
+#include <rclcpp/rclcpp.hpp>
+#include <geometry_msgs/msg/twist.hpp>
+#endif
+
+class RL_Real : public RL
+#if defined(USE_ROS2) && defined(USE_ROS)
+    , public rclcpp::Node
+#endif
+{
+public:
+    RL_Real();
+    ~RL_Real();
+
+private:
+    // rl functions
+    torch::Tensor Forward() override;
+    void GetState(RobotState<double> *state) override;
+    void SetCommand(const RobotCommand<double> *command) override;
+    void RunModel();
+    void RobotControl();
+
+    // loop
+    std::shared_ptr<LoopFunc> loop_keyboard;
+    std::shared_ptr<LoopFunc> loop_control;
+    std::shared_ptr<LoopFunc> loop_rl;
+
+    // hardware
+    std::unique_ptr<tita_robot> robot_;
+    titati::ForceDirectManager force_direct_manager_;
+
+    // others
+    int motiontime = 0;
+
+#if defined(USE_ROS1) && defined(USE_ROS)
+    geometry_msgs::Twist cmd_vel;
+    ros::Subscriber cmd_vel_subscriber;
+    void CmdvelCallback(const geometry_msgs::Twist::ConstPtr &msg);
+#elif defined(USE_ROS2) && defined(USE_ROS)
+    geometry_msgs::msg::Twist cmd_vel;
+    rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_subscriber;
+    void CmdvelCallback(const geometry_msgs::msg::Twist::SharedPtr msg);
+#endif
+};
+
+#endif // RL_REAL_TITATI_HPP

--- a/rl_sar/src/rl_sar/library/hardware/titati/include/titati/battery_device/power_management_sender.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/include/titati/battery_device/power_management_sender.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <memory>
+
+#include "titati/battery_device/power_management_types.hpp"
+#include "titati/protocol/can_utils.hpp"
+
+namespace titati
+{
+namespace battery
+{
+
+class PowerManagementSender
+{
+public:
+  PowerManagementSender();
+
+  void send_state(const PowerStateCommand & command);
+  void send_self_test(const PowerSelfTestReport & report);
+  void send_heartbeat(const PowerHeartbeat & heartbeat);
+
+private:
+  std::shared_ptr<can_device::socket_can::CanDev> can_dev_;
+};
+
+}  // namespace battery
+}  // namespace titati

--- a/rl_sar/src/rl_sar/library/hardware/titati/include/titati/battery_device/power_management_types.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/include/titati/battery_device/power_management_types.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <cstdint>
+
+namespace titati
+{
+namespace battery
+{
+
+constexpr uint32_t kCanIdPowerStateSet = 0x86U;
+constexpr uint32_t kCanIdPowerSelfTest = 0x87U;
+constexpr uint32_t kCanIdPowerHeartbeat = 0x90U;
+
+constexpr std::size_t kDlcPowerStateSet = 20U;
+constexpr std::size_t kDlcPowerSelfTest = 32U;
+constexpr std::size_t kDlcPowerHeartbeat = 10U;
+
+struct PowerStateCommand
+{
+  int8_t power_5v{0};
+  int8_t power_12v{0};
+  int8_t power_24v{0};
+  int8_t power_motor_48v{0};
+  int8_t power_extern_48v{0};
+
+  uint16_t power_5v_delay_ms{0};
+  uint16_t power_12v_delay_ms{0};
+  uint16_t power_24v_delay_ms{0};
+  uint16_t power_motor_48v_delay_ms{0};
+  uint16_t power_extern_48v_delay_ms{0};
+
+  uint8_t fixed{0x55U};
+};
+
+struct PowerSelfTestReport
+{
+  uint64_t rst{0};
+  uint32_t app_version{0};
+  uint32_t build_timestamp{0};
+  uint32_t uuid_0{0};
+  uint32_t uuid_1{0};
+  uint32_t uuid_2{0};
+};
+
+struct PowerHeartbeat
+{
+  uint32_t cur_mode{0};
+  uint8_t right_history{0};
+  uint8_t left_history{0};
+};
+
+}  // namespace battery
+}  // namespace titati

--- a/rl_sar/src/rl_sar/library/hardware/titati/include/titati/force_direct_manager.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/include/titati/force_direct_manager.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <thread>
+
+#include "titati/protocol/can_utils.hpp"
+
+namespace titati
+{
+
+class ForceDirectManager
+{
+public:
+  ForceDirectManager();
+  ~ForceDirectManager();
+
+  void start();
+  void stop();
+
+private:
+  void handle_frame(std::shared_ptr<struct canfd_frame> frame);
+  void send_force_direct_sequence();
+  uint32_t current_time_us() const;
+  void initial_wakeup();
+
+  std::atomic<bool> running_{false};
+  std::atomic<bool> pending_sequence_{false};
+  std::shared_ptr<can_device::socket_can::CanDev> router_receiver_;
+  std::shared_ptr<can_device::socket_can::CanDev> rpc_sender_;
+  std::thread wake_thread_;
+};
+
+}  // namespace titati

--- a/rl_sar/src/rl_sar/library/hardware/titati/include/titati/protocol/can_utils.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/include/titati/protocol/can_utils.hpp
@@ -1,0 +1,468 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__CAN_UTILS_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__CAN_UTILS_HPP_
+
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "linux/can.h"
+#include "linux/can/error.h"
+#include "linux/can/raw.h"
+#include "titati/protocol/socket_can_receiver.hpp"
+#include "titati/protocol/socket_can_sender.hpp"
+
+#define C_END "\033[m"
+// #define C_RED "\033[0;32;31m"
+#define C_RED "\033[0;31m"
+#define C_YELLOW "\033[1;33m"
+
+#ifdef GCC_OPTIMIZE_03
+#pragma GCC optimize("O3")
+#else
+#pragma GCC optimize("O0")
+#endif
+namespace can_device
+{
+namespace socket_can
+{
+using can_std_callback = std::function<void(std::shared_ptr<struct can_frame> recv_frame)>;
+using can_fd_callback = std::function<void(std::shared_ptr<struct canfd_frame> recv_frame)>;
+class CanRxDev
+{
+public:
+  explicit CanRxDev(
+    const std::string & interface, const std::string & name, can_std_callback recv_callback,
+    bool is_block, int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    init(interface, name, false, recv_callback, nullptr, is_block, nano_timeout);
+  }
+  explicit CanRxDev(
+    const std::string & interface, const std::string & name, can_fd_callback recv_callback,
+    bool is_block, int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    init(interface, name, true, nullptr, recv_callback, is_block, nano_timeout);
+  }
+
+  ~CanRxDev()
+  {
+    ready_ = false;
+    isthreadrunning_ = false;
+    if (main_T_ != nullptr) {
+      main_T_->join();
+    }
+    main_T_ = nullptr;
+    receiver_ = nullptr;
+  }
+
+  bool is_ready() { return ready_; }
+  bool is_timeout() { return is_timeout_; }
+  void set_filter(const struct can_filter filter[], size_t s)
+  {
+    if (receiver_ != nullptr) {
+      receiver_->set_filter(filter, s);
+    }
+  }
+
+  std::shared_ptr<canfd_frame> wait_for_can_data_block()
+  {
+    can_device::socket_can::CanId receive_id{};
+    std::string can_type;
+    if (canfd_) {
+      can_type = "FD";
+      rx_fd_frame_ = std::make_shared<struct canfd_frame>();
+    } else {
+      can_type = "STD";
+      rx_std_frame_ = std::make_shared<struct can_frame>();
+    }
+    if (receiver_ != nullptr) {
+      try {
+        bool result =
+          canfd_ ? receiver_->receive(rx_fd_frame_, std::chrono::nanoseconds(nano_timeout_))
+                 : receiver_->receive(rx_std_frame_, std::chrono::nanoseconds(nano_timeout_));
+        if (result) {
+          is_timeout_ = false;
+          return rx_fd_frame_;
+        } else {
+          return nullptr;
+        }
+      } catch (const std::exception & ex) {
+        if (ex.what()[0] == '$') {
+          is_timeout_ = true;
+          return nullptr;
+        }
+      }
+    } else {
+      isthreadrunning_ = false;
+      printf(
+        C_RED
+        "[CAN_RX %s][ERROR][%s] Error receiving CAN %s message: %s, "
+        "no receiver init\r\n" C_END,
+        can_type.c_str(), name_.c_str(), can_type.c_str(), interface_.c_str());
+    }
+    return nullptr;
+  }
+
+#ifdef COMMON_PROTOCOL_TEST
+  bool testing_setcandata(can_frame frame)
+  {
+    if (can_std_callback_ != nullptr) {
+      can_std_callback_(std::make_shared<struct can_frame>(frame));
+      return true;
+    }
+    return false;
+  }
+  bool testing_setcandata(canfd_frame frame)
+  {
+    if (can_fd_callback_ != nullptr) {
+      can_fd_callback_(std::make_shared<struct canfd_frame>(frame));
+      return true;
+    }
+    return false;
+  }
+#endif  // COMMON_PROTOCOL_TEST
+
+private:
+  bool ready_;
+  bool canfd_;
+  bool is_timeout_;
+  bool extended_frame_;
+  bool isthreadrunning_;
+  int64_t nano_timeout_;
+  std::string name_;
+  std::string interface_;
+  can_std_callback can_std_callback_;
+  can_fd_callback can_fd_callback_;
+  std::unique_ptr<std::thread> main_T_;
+  std::shared_ptr<struct can_frame> rx_std_frame_;
+  std::shared_ptr<struct canfd_frame> rx_fd_frame_;
+  std::unique_ptr<can_device::socket_can::SocketCanReceiver> receiver_;
+  uint8_t can_id_offset_ = 0;
+  void init(
+    const std::string & interface, const std::string & name, bool canfd_on,
+    can_std_callback std_callback, can_fd_callback fd_callback, bool is_block, int64_t nano_timeout)
+  {
+    name_ = name;
+    interface_ = interface;
+    canfd_ = canfd_on;
+    nano_timeout_ = nano_timeout;
+    is_timeout_ = false;
+    interface_ = interface;
+    can_std_callback_ = std_callback;
+    can_fd_callback_ = fd_callback;
+    try {
+      receiver_ = std::make_unique<can_device::socket_can::SocketCanReceiver>(interface_, canfd_);
+      if (!is_block) {
+        isthreadrunning_ = true;
+        ready_ = true;
+        main_T_ = std::make_unique<std::thread>(std::bind(&CanRxDev::main_recv_func, this));
+      }
+    } catch (const std::exception & ex) {
+      printf(
+        C_RED "[CAN_RX][ERROR][%s] %s receiver creat error! %s\r\n" C_END, name_.c_str(),
+        interface_.c_str(), ex.what());
+      return;
+    }
+  }
+
+  bool wait_for_can_data()
+  {
+    can_device::socket_can::CanId receive_id{};
+    std::string can_type;
+    if (canfd_) {
+      can_type = "FD";
+      rx_fd_frame_ = std::make_shared<struct canfd_frame>();
+    } else {
+      can_type = "STD";
+      rx_std_frame_ = std::make_shared<struct can_frame>();
+    }
+
+    if (receiver_ != nullptr) {
+      try {
+        bool result =
+          canfd_ ? receiver_->receive(rx_fd_frame_, std::chrono::nanoseconds(nano_timeout_))
+                 : receiver_->receive(rx_std_frame_, std::chrono::nanoseconds(nano_timeout_));
+        if (result) {
+          is_timeout_ = false;
+        }
+        return result;
+      } catch (const std::exception & ex) {
+        if (ex.what()[0] == '$') {
+          is_timeout_ = true;
+          return false;
+        }
+        printf(
+          C_RED "[CAN_RX %s][ERROR][%s] Error receiving CAN %s message: %s - %s\n" C_END,
+          can_type.c_str(), name_.c_str(), can_type.c_str(), interface_.c_str(), ex.what());
+      }
+    } else {
+      isthreadrunning_ = false;
+      printf(
+        C_RED
+        "[CAN_RX %s][ERROR][%s] Error receiving CAN %s message: %s, "
+        "no receiver init\r\n" C_END,
+        can_type.c_str(), name_.c_str(), can_type.c_str(), interface_.c_str());
+    }
+    return false;
+  }
+
+  void main_recv_func()
+  {
+#ifdef DEBUG_LOG
+    printf("[CAN_RX][INFO][%s] Start recv thread: %s\r\n", interface_.c_str(), name_.c_str());
+#endif  // DEBUG_LOG
+    while (isthreadrunning_ && ready_) {
+      if (wait_for_can_data()) {
+        if (!canfd_ && can_std_callback_ != nullptr) {
+          can_std_callback_(rx_std_frame_);
+        } else if (canfd_ && can_fd_callback_ != nullptr) {
+          can_fd_callback_(rx_fd_frame_);
+        }
+      }
+    }
+#ifdef DEBUG_LOG
+    printf("[CAN_RX][INFO][%s] Exit recv thread: %s\r\n", interface_.c_str(), name_.c_str());
+#endif  // DEBUG_LOG
+  }
+};
+
+class CanTxDev
+{
+public:
+  explicit CanTxDev(
+    const std::string & interface, const std::string & name, bool extended_frame, bool canfd_on,
+    int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    can_id_offset_ = can_id_offset;
+    ready_ = false;
+    name_ = name;
+    nano_timeout_ = nano_timeout;
+    is_timeout_ = false;
+    canfd_on_ = canfd_on;
+    interface_ = interface;
+    extended_frame_ = extended_frame;
+    try {
+      sender_ = std::make_unique<can_device::socket_can::SocketCanSender>(interface_, canfd_on_);
+    } catch (const std::exception & ex) {
+      printf(
+        C_RED "[CAN_TX][ERROR][%s] %s sender creat error! %s\r\n" C_END, name_.c_str(),
+        interface_.c_str(), ex.what());
+      return;
+    }
+    ready_ = true;
+  }
+
+  ~CanTxDev()
+  {
+    ready_ = false;
+    sender_ = nullptr;
+  }
+
+  bool send_can_message(struct can_frame & tx_frame)
+  {
+    return send_can_message(&tx_frame, nullptr);
+  }
+  bool send_can_message(struct canfd_frame & tx_frame)
+  {
+    return send_can_message(nullptr, &tx_frame);
+  }
+
+  bool is_ready() { return ready_; }
+  bool is_timeout() { return is_timeout_; }
+
+private:
+  bool ready_;
+  bool canfd_on_;
+  bool is_timeout_;
+  bool extended_frame_;
+  int64_t nano_timeout_;
+  std::string name_;
+  std::string interface_;
+  std::unique_ptr<can_device::socket_can::SocketCanSender> sender_;
+  uint8_t can_id_offset_;
+
+  bool send_can_message(struct can_frame * std_frame, struct canfd_frame * fd_frame)
+  {
+    bool self_fd = (fd_frame != nullptr);
+    std::string can_type = self_fd ? "FD" : "STD";
+    if (canfd_on_ != self_fd) {
+      printf(
+        C_RED
+        "[CAN_TX %s][ERROR][%s] Error sending CAN message: %s - "
+        "Not support can/canfd frame mixed\r\n" C_END,
+        can_type.c_str(), name_.c_str(), interface_.c_str());
+      return false;
+    }
+    canid_t * canid = self_fd ? &fd_frame->can_id : &std_frame->can_id;
+
+    bool result = true;
+    can_device::socket_can::CanId send_id =
+      extended_frame_
+        ? can_device::socket_can::CanId(
+            *canid, can_device::socket_can::FrameType::DATA, can_device::socket_can::ExtendedFrame)
+        : can_device::socket_can::CanId(
+            *canid, can_device::socket_can::FrameType::DATA, can_device::socket_can::StandardFrame);
+    if (sender_ != nullptr) {
+      try {
+        if (self_fd) {
+          sender_->send_fd(
+            fd_frame->data, (fd_frame->len == 0) ? 64 : fd_frame->len, send_id,
+            std::chrono::nanoseconds(nano_timeout_));
+          is_timeout_ = false;
+        } else {
+          sender_->send(
+            std_frame->data, (std_frame->can_dlc == 0) ? 8 : std_frame->can_dlc, send_id,
+            std::chrono::nanoseconds(nano_timeout_));
+          is_timeout_ = false;
+        }
+      } catch (const std::exception & ex) {
+        if (ex.what()[0] == '$') {
+          is_timeout_ = true;
+          return false;
+        }
+        result = false;
+        printf(
+          C_RED "[CAN_TX %s][ERROR][%s] Error sending CAN message: %s - %s\r\n" C_END,
+          can_type.c_str(), name_.c_str(), interface_.c_str(), ex.what());
+      }
+    } else {
+      result = false;
+      printf(
+        C_RED "[CAN_TX %s][ERROR][%s] Error sending CAN message: %s - No device\r\n" C_END,
+        can_type.c_str(), name_.c_str(), interface_.c_str());
+    }
+    return result;
+  }
+};
+
+class CanDev
+{
+public:
+  explicit CanDev(
+    const std::string & interface, const std::string & name, bool extended_frame,
+    can_std_callback recv_callback, bool is_block, int64_t nano_timeout = -1,
+    uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    name_ = name;
+    send_only_ = false;
+    tx_op_ = std::make_unique<CanTxDev>(
+      interface, name_, extended_frame, false, nano_timeout, can_id_offset_);
+    rx_op_ = std::make_unique<CanRxDev>(
+      interface, name_, recv_callback, is_block, nano_timeout, can_id_offset_);
+  }
+  explicit CanDev(
+    const std::string & interface, const std::string & name, bool extended_frame,
+    can_fd_callback recv_callback, bool is_block, int64_t nano_timeout = -1,
+    uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    name_ = name;
+    send_only_ = false;
+    tx_op_ = std::make_unique<CanTxDev>(
+      interface, name_, extended_frame, true, nano_timeout, can_id_offset_);
+    rx_op_ = std::make_unique<CanRxDev>(
+      interface, name_, recv_callback, is_block, nano_timeout, can_id_offset_);
+  }
+  explicit CanDev(
+    const std::string & interface, const std::string & name, bool extended_frame, bool canfd_on,
+    int64_t nano_timeout = -1, uint8_t can_id_offset = 0)
+  : can_id_offset_(can_id_offset)
+  {
+    name_ = name;
+    send_only_ = true;
+    tx_op_ = std::make_unique<CanTxDev>(
+      interface, name_, extended_frame, canfd_on, nano_timeout, can_id_offset_);
+  }
+
+  ~CanDev()
+  {
+    rx_op_ = nullptr;
+    tx_op_ = nullptr;
+  }
+
+  std::shared_ptr<canfd_frame> receive_can_message_block()
+  {
+    return rx_op_->wait_for_can_data_block();
+  }
+
+  bool send_can_message(struct can_frame & tx_frame)
+  {
+#ifdef COMMON_PROTOCOL_TEST
+    if (rx_op_ != nullptr) {
+      return rx_op_->testing_setcandata(tx_frame);
+    }
+    return false;
+#else
+    if (tx_op_ != nullptr) {
+      return tx_op_->send_can_message(tx_frame);
+    }
+    return false;
+#endif  // COMMON_PROTOCOL_TEST
+  }
+
+  bool send_can_message(struct canfd_frame & tx_frame)
+  {
+#ifdef COMMON_PROTOCOL_TEST
+    if (rx_op_ != nullptr) {
+      return rx_op_->testing_setcandata(tx_frame);
+    }
+    return false;
+#else
+    if (tx_op_ != nullptr) {
+      return tx_op_->send_can_message(tx_frame);
+    }
+    return false;
+#endif  // COMMON_PROTOCOL_TEST
+  }
+
+  void set_filter(const struct can_filter filter[], size_t s)
+  {
+    if (rx_op_ != nullptr) {
+      rx_op_->set_filter(filter, s);
+    }
+  }
+  bool is_send_only() { return send_only_; }
+  bool is_ready()
+  {
+    bool result = (tx_op_ == nullptr) ? false : tx_op_->is_ready();
+    if (send_only_) {
+      return result;
+    } else {
+      return result && ((rx_op_ == nullptr) ? false : rx_op_->is_ready());
+    }
+  }
+  bool is_rx_timeout() { return rx_op_->is_timeout(); }
+  bool is_tx_timeout() { return tx_op_->is_timeout(); }
+
+private:
+  bool send_only_;
+  std::string name_;
+  std::unique_ptr<CanRxDev> rx_op_;
+  std::unique_ptr<CanTxDev> tx_op_;
+  uint8_t can_id_offset_ = 0;
+};
+
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__CAN_UTILS_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/include/titati/protocol/socket_can_common.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/include/titati/protocol/socket_can_common.hpp
@@ -1,0 +1,122 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_COMMON_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_COMMON_HPP_
+
+#include <linux/can.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <sys/time.h>
+
+#include <chrono>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+
+#define GCC_OPTIMIZE_03
+
+#ifdef GCC_OPTIMIZE_03
+#pragma GCC optimize("O3")
+#else
+#pragma GCC optimize("O0")
+#endif
+
+namespace can_device
+{
+namespace socket_can
+{
+inline bool bind_can_socket(int & fd, const std::string & interface, const bool canfd_on = false)
+{
+  if (interface.length() >= static_cast<std::string::size_type>(IFNAMSIZ)) {
+    throw std::domain_error{"CAN interface name too long"};
+    return false;
+  }
+
+  fd = socket(PF_CAN, static_cast<int32_t>(SOCK_RAW), CAN_RAW);
+  if (0 > fd) {
+    throw std::runtime_error{"Failed to open CAN socket"};
+    return false;
+  }
+
+  // Make it non-blocking so we can use timeouts
+
+  struct ifreq ifr;
+  (void)strncpy(&ifr.ifr_name[0U], interface.c_str(), IFNAMSIZ - 1);
+  ifr.ifr_name[IFNAMSIZ - 1] = '\0';
+  ifr.ifr_ifindex = if_nametoindex(ifr.ifr_name);
+  if (!ifr.ifr_ifindex) {
+    perror("if_nametoindex");
+    return false;
+  }
+
+  struct sockaddr_can addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.can_family = AF_CAN;
+  addr.can_ifindex = ifr.ifr_ifindex;
+
+  if (canfd_on) {
+    if (ioctl(fd, SIOCGIFMTU, &ifr) < 0) {
+      throw std::runtime_error{"Failed to set CAN FD socket name via ioctl()"};
+      return false;
+    }
+    if (ifr.ifr_mtu != CANFD_MTU) {
+      throw std::runtime_error{"Interface does not support CAN FD"};
+      return false;
+    }
+    int _canfd_on = canfd_on ? 1 : 0;
+    auto ret = setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FD_FRAMES, &_canfd_on, sizeof(_canfd_on));
+    if (ret) {
+      throw std::runtime_error{"error whem enable canfd"};
+      return false;
+    }
+  }
+
+  /* disable default receive filter on this RAW socket */
+  /* This is obsolete as we do not read from the socket at all, but for */
+  /* this reason we can remove the receive list in the Kernel to save a */
+  /* little (really a very little!) CPU usage.                          */
+  setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FILTER, NULL, 0);
+
+  if (0 > bind(fd, (struct sockaddr *)&addr, sizeof(addr))) {
+    throw std::runtime_error{"Failed to bind CAN socket"};
+    return false;
+  }
+
+  return true;
+}
+
+inline struct timeval to_timeval(const std::chrono::nanoseconds timeout) noexcept
+{
+  const auto count = timeout.count();
+  constexpr auto BILLION = 1'000'000'000LL;
+  struct timeval c_timeout;
+  c_timeout.tv_sec = static_cast<decltype(c_timeout.tv_sec)>(count / BILLION);
+  c_timeout.tv_usec = static_cast<decltype(c_timeout.tv_usec)>((count % BILLION) * (0.001));
+
+  return c_timeout;
+}
+
+inline fd_set single_set(int32_t file_descriptor) noexcept
+{
+  fd_set descriptor_set;
+  FD_ZERO(&descriptor_set);
+  FD_SET(file_descriptor, &descriptor_set);
+
+  return descriptor_set;
+}
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_COMMON_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/include/titati/protocol/socket_can_id.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/include/titati/protocol/socket_can_id.hpp
@@ -1,0 +1,188 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_ID_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_ID_HPP_
+
+#include <linux/can.h>
+
+#include <stdexcept>
+#include <utility>
+
+#include "visibility_control.hpp"
+
+namespace can_device
+{
+namespace socket_can
+{
+using IdT = uint32_t;
+using LengthT = uint32_t;
+
+constexpr std::size_t MAX_DATA_LENGTH = 64U;
+
+static_assert(
+  MAX_DATA_LENGTH == sizeof(std::declval<struct canfd_frame>().data),
+  "Unexpected CAN frame data size");
+static_assert(std::is_same<IdT, canid_t>::value, "Underlying type of CanId is incorrect");
+constexpr IdT EXTENDED_MASK = CAN_EFF_FLAG;
+constexpr IdT REMOTE_MASK = CAN_RTR_FLAG;
+constexpr IdT ERROR_MASK = CAN_ERR_FLAG;
+constexpr IdT EXTENDED_ID_MASK = CAN_EFF_MASK;
+constexpr IdT STANDARD_ID_MASK = CAN_SFF_MASK;
+
+class SOCKETCAN_PUBLIC SocketCanTimeout : public std::runtime_error
+{
+public:
+  explicit SocketCanTimeout(const char * const what) : runtime_error{what} {};
+};  // class SocketCanTimeout
+
+enum class FrameType : uint32_t { DATA, ERROR, REMOTE };
+
+struct StandardFrame_
+{
+};
+
+constexpr StandardFrame_ StandardFrame;
+
+struct ExtendedFrame_
+{
+};
+
+constexpr ExtendedFrame_ ExtendedFrame;
+
+class SOCKETCAN_PUBLIC CanId
+{
+public:
+  CanId() = default;
+  explicit CanId(const IdT raw_id, const LengthT data_length = 0U)
+  : m_id{raw_id}, m_data_length{data_length}
+  {
+    (void)frame_type();
+  }
+
+  CanId(const IdT id, FrameType type, StandardFrame_) : CanId{id, type, false} {}
+  CanId(const IdT id, FrameType type, ExtendedFrame_) : CanId{id, type, true} {}
+
+  CanId & standard() noexcept
+  {
+    m_id = m_id & (~EXTENDED_MASK);
+    return *this;
+  }
+
+  CanId & extended() noexcept
+  {
+    m_id = m_id | EXTENDED_MASK;
+    return *this;
+  }
+
+  CanId & error_frame() noexcept
+  {
+    m_id = m_id & (~REMOTE_MASK);
+    m_id = m_id | ERROR_MASK;
+    return *this;
+  }
+
+  CanId & remote_frame() noexcept
+  {
+    m_id = m_id & (~ERROR_MASK);
+    m_id = m_id | REMOTE_MASK;
+    return *this;
+  }
+
+  CanId & data_frame() noexcept
+  {
+    m_id = m_id & (~ERROR_MASK);
+    m_id = m_id & (~REMOTE_MASK);
+    return *this;
+  }
+
+  CanId & frame_type(const FrameType type)
+  {
+    switch (type) {
+      case FrameType::DATA:
+        (void)data_frame();
+        break;
+      case FrameType::ERROR:
+        (void)error_frame();
+        break;
+      case FrameType::REMOTE:
+        (void)remote_frame();
+        break;
+      default:
+        throw std::logic_error{"CanId: No such type"};
+    }
+    return *this;
+  }
+
+  CanId & identifier(const IdT id)
+  {
+    constexpr auto MAX_EXTENDED = 0x1FBF'FFFFU;
+    constexpr auto MAX_STANDARD = 0x7FFU;
+
+    static_assert(MAX_EXTENDED <= EXTENDED_ID_MASK, "Max extended id value is wrong");
+    static_assert(MAX_STANDARD <= STANDARD_ID_MASK, "Max standed id value is wrong");
+    const auto max_id = is_extended() ? MAX_EXTENDED : MAX_STANDARD;
+    if (max_id < id) {
+      throw std::domain_error{"CanId would be truncated!"};
+    }
+    m_id = m_id & (~EXTENDED_ID_MASK);
+    m_id = m_id | id;
+    return *this;
+  }
+
+  IdT identifier() const noexcept
+  {
+    const auto mask = is_extended() ? EXTENDED_ID_MASK : STANDARD_ID_MASK;
+    return m_id & mask;
+  }
+
+  IdT get() const noexcept { return m_id; }
+
+  bool is_extended() const noexcept { return (m_id & EXTENDED_MASK) == EXTENDED_MASK; }
+
+  FrameType frame_type() const
+  {
+    const auto is_error = (m_id & ERROR_MASK) == ERROR_MASK;
+    const auto is_remote = (m_id & REMOTE_MASK) == REMOTE_MASK;
+    if (is_error && is_remote) {
+      throw std::domain_error{"CanId has both bit 29 and 30 set! Inconsistent"};
+    }
+    if (is_error) {
+      return FrameType::ERROR;
+    }
+    if (is_remote) {
+      return FrameType::REMOTE;
+    }
+    return FrameType::DATA;
+  }
+
+  LengthT length() const noexcept { return m_data_length; }
+  IdT m_id{};
+
+private:
+  SOCKETCAN_LOCAL CanId(const IdT id, FrameType type, bool is_extended)
+  {
+    if (is_extended) {
+      (void)extended();
+    }
+    (void)frame_type(type);
+    (void)identifier(id);
+  }
+
+  LengthT m_data_length{};
+};  // class CanId
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_ID_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/include/titati/protocol/socket_can_receiver.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/include/titati/protocol/socket_can_receiver.hpp
@@ -1,0 +1,145 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_RECEIVER_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_RECEIVER_HPP_
+#include <linux/can.h>
+#include <linux/can/raw.h>
+#include <sys/socket.h>
+#include <unistd.h>  // for close()
+
+#include <chrono>
+#include <cstring>
+#include <memory>
+#include <string>
+
+#include "titati/protocol/socket_can_common.hpp"
+#include "titati/protocol/socket_can_id.hpp"
+#include "titati/protocol/visibility_control.hpp"
+
+namespace can_device
+{
+namespace socket_can
+{
+// using target_can_device = static_cast<std::string>(TARGET_CAN_DEVICE);
+
+class SOCKETCAN_PUBLIC SocketCanReceiver
+{
+public:
+  explicit SocketCanReceiver(
+    const std::string & interface = "can0", bool canfd_on = false)
+  {
+    if (!bind_can_socket(fd_, interface, canfd_on)) {
+      printf("bind_can_socket failed!\r\n");
+      return;
+    }
+  }
+
+  ~SocketCanReceiver() noexcept { (void)close(fd_); }
+
+  bool receive(
+    std::shared_ptr<struct can_frame> rx_frame,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero())
+  {
+    wait(timeout);
+
+    struct canfd_frame frame;
+    memset(&frame, 0, sizeof(frame));
+    const auto nbytes = read(fd_, &frame, sizeof(frame));
+
+    if (nbytes < 0) {
+      throw std::runtime_error{strerror(errno)};
+    }
+    if (static_cast<std::size_t>(nbytes) < CAN_MTU) {
+      throw std::logic_error{"read: incomplete CAN frame"};
+    }
+    if (static_cast<std::size_t>(nbytes) != CAN_MTU) {
+      throw std::logic_error{"Message was wrong size"};
+    }
+
+    auto receive_id = CanId{frame.can_id, frame.len};
+    if (receive_id.frame_type() == can_device::socket_can::FrameType::DATA) {
+      rx_frame->can_id = receive_id.standard().get();
+      rx_frame->can_id = receive_id.length();
+      std::memcpy(rx_frame->data, frame.data, sizeof(rx_frame->data));
+      return true;
+    }
+    return false;
+  }
+
+  bool receive(
+    std::shared_ptr<struct canfd_frame> rx_frame,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero())
+  {
+    wait(timeout);
+
+    struct canfd_frame frame;
+    const auto nbytes = read(fd_, &frame, sizeof(frame));
+
+    uint8_t except_len = CAN_MTU - 8 + frame.len;
+    if (nbytes < 0) {
+      throw std::runtime_error{strerror(errno)};
+    }
+    if (static_cast<std::size_t>(nbytes) < except_len) {
+      throw std::runtime_error{"read: incomplete CAN frame"};
+    }
+
+    auto receive_id = CanId{frame.can_id, frame.len};
+    if (receive_id.frame_type() == can_device::socket_can::FrameType::DATA) {
+      rx_frame->can_id = receive_id.standard().get();
+      rx_frame->len = receive_id.length();
+      std::memcpy(rx_frame->data, frame.data, sizeof(rx_frame->data));
+      return true;
+    }
+    return false;
+  }
+
+  void set_filter(const struct can_filter filter[], size_t s)
+  {
+    setsockopt(fd_, SOL_CAN_RAW, CAN_RAW_FILTER, filter, s);
+  }
+
+private:
+  SOCKETCAN_LOCAL void wait(const std::chrono::nanoseconds timeout) const
+  {
+    if (decltype(timeout)::zero() < timeout) {
+      auto c_timeout = to_timeval(timeout);
+      auto read_set = single_set(fd_);
+
+      if (0 == select(fd_ + 1, &read_set, NULL, NULL, &c_timeout)) {
+        throw SocketCanTimeout{"$CAN Receive Timeout 1"};
+      }
+
+      if (!FD_ISSET(fd_, &read_set)) {
+        throw SocketCanTimeout{"$CAN Receive Timeout 2"};
+      }
+    } else {
+      auto read_set = single_set(fd_);
+
+      if (0 == select(fd_ + 1, &read_set, NULL, NULL, NULL)) {
+        throw SocketCanTimeout{"$CAN Receive Timeout 1"};
+      }
+
+      if (!FD_ISSET(fd_, &read_set)) {
+        throw SocketCanTimeout{"CAN Receive Timeout 2"};
+      }
+    }
+  }
+
+  int32_t fd_;
+};  // class SocketCanReceiver
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_RECEIVER_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/include/titati/protocol/socket_can_sender.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/include/titati/protocol/socket_can_sender.hpp
@@ -1,0 +1,168 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_SENDER_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_SENDER_HPP_
+
+#include <linux/can.h>
+#include <linux/can/raw.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <stdexcept>
+#include <string>
+
+#include "titati/protocol/socket_can_common.hpp"
+#include "titati/protocol/socket_can_id.hpp"
+#include "titati/protocol/visibility_control.hpp"
+
+namespace can_device
+{
+namespace socket_can
+{
+class SOCKETCAN_PUBLIC SocketCanSender
+{
+public:
+  explicit SocketCanSender(
+    const std::string & interface = "can0", bool canfd_on = false,
+    const CanId & default_id = CanId{})
+  : m_default_id{default_id}
+  {
+    if (!bind_can_socket(fd_, interface, canfd_on)) {
+      printf("bind_can_socket failed\r\n");
+      return;
+    }
+  }
+  ~SocketCanSender() noexcept
+  {
+    (void)close(fd_);
+    // I'm destructing--there's not much else I can do on an error
+    // seem not good
+  }
+
+  void send(
+    const void * const data, const std::size_t Length,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    send(data, Length, m_default_id, timeout);
+  }
+
+  void send(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    if (length > MAX_DATA_LENGTH) {
+      throw std::domain_error{"Size is too large to send via CAN"};
+    }
+    send_impl(data, length, id, timeout);
+  }
+
+  template <typename T, typename = std::enable_if_t<!std::is_pointer<T>::value>>
+  void send(
+    const T & data, const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    send(data, m_default_id, timeout);
+  }
+
+  template <typename T, typename = std::enable_if<!std::is_pointer<T>::value>>
+  void send(
+    const T & data, const CanId id,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    static_assert(sizeof(data) <= MAX_DATA_LENGTH, "Data type too large for CAN");
+    send_impl(reinterpret_cast<const char *>(&data), sizeof(data), id, timeout);
+  }
+
+  void send_fd(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::zero()) const
+  {
+    if (length > MAX_DATA_LENGTH) {
+      throw std::domain_error{"Size is too large to send via CAN"};
+    }
+    send_fd_impl(data, length, id, timeout);
+  }
+
+  CanId default_id() const noexcept { return m_default_id; }
+
+private:
+  void send_impl(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout) const
+  {
+    // (void)data;
+    // (void)length;
+    // (void)id;
+    (void)timeout;
+
+    struct can_frame data_frame;
+    data_frame.can_id = id.get();
+
+    data_frame.can_dlc = static_cast<decltype(data_frame.can_dlc)>(length);
+
+    (void)std::memcpy(static_cast<void *>(&data_frame.data[0U]), data, length);
+
+    if (write(fd_, &data_frame, static_cast<int>(CAN_MTU)) != static_cast<int>(CAN_MTU)) {
+      throw std::runtime_error{strerror(errno)};
+    }
+  }
+
+  void send_fd_impl(
+    const void * const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout) const
+  {
+    // (void)data;
+    // (void)length;
+    // (void)id;
+    (void)timeout;
+
+    struct canfd_frame data_frame;
+    memset(&data_frame, 0, sizeof(data_frame));
+    data_frame.can_id = id.get();
+    data_frame.flags = CANFD_FDF | CANFD_BRS;
+    data_frame.len = static_cast<decltype(data_frame.len)>(length);
+    std::memcpy(static_cast<void *>(&data_frame.data[0U]), data, length);
+    if (write(fd_, &data_frame, CANFD_MTU) != CANFD_MTU) {
+      throw std::runtime_error{strerror(errno)};
+    }
+  }
+
+  SOCKETCAN_LOCAL void wait(const std::chrono::nanoseconds timeout) const
+  {
+    if (decltype(timeout)::zero() < timeout) {
+      auto c_timeout = to_timeval(timeout);
+      auto write_set = single_set(fd_);
+
+      // wait
+      if (0 == select(fd_ + 1, NULL, &write_set, NULL, &c_timeout)) {
+        throw SocketCanTimeout{"$CAN Send Timeout [1]"};
+      }
+
+      if (!FD_ISSET(fd_, &write_set)) {
+        throw SocketCanTimeout{"$CAN Send Timeout [2]"};
+      }
+    } else {
+      // do nothing
+      // auto write_set = single_set(fd_);
+    }
+  }
+
+  int32_t fd_;
+  CanId m_default_id;
+};
+}  // namespace socket_can
+}  // namespace can_device
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__SOCKET_CAN_SENDER_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/include/titati/protocol/visibility_control.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/include/titati/protocol/visibility_control.hpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POWER_CONTROLLER__UTILS__PROTOCOL__VISIBILITY_CONTROL_HPP_
+#define POWER_CONTROLLER__UTILS__PROTOCOL__VISIBILITY_CONTROL_HPP_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+#ifdef __GNUC__
+#define SOCKETCAN_EXPORT __attribute__((dllexport))
+#define SOCKETCAN_IMPORT __attribute__((dllimport))
+#else
+#define SOCKETCAN_EXPORT __declspec(dllexport)
+#define SOCKETCAN_IMPORT __declspec(dllimport)
+#endif
+#ifdef SOCKETCAN_BUILDING_LIBRARY
+#define SOCKETCAN_PUBLIC SOCKETCAN_EXPORT
+#else
+#define SOCKETCAN_PUBLIC SOCKETCAN_IMPORT
+#endif
+#define SOCKETCAN_PUBLIC_TYPE SOCKETCAN_PUBLIC
+#define SOCKETCAN_LOCAL
+#else
+#define SOCKETCAN_EXPORT __attribute__((visibility("default")))
+#define SOCKETCAN_IMPORT
+#if __GNUC__ >= 4
+#define SOCKETCAN_PUBLIC __attribute__((visibility("default")))
+#define SOCKETCAN_LOCAL __attribute__((visibility("hidden")))
+#else
+#define SOCKETCAN_PUBLIC
+#define SOCKETCAN_LOCAL
+#endif
+#define SOCKETCAN_PUBLIC_TYPE
+#endif
+
+#endif  // POWER_CONTROLLER__UTILS__PROTOCOL__VISIBILITY_CONTROL_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/include/titati/tita_robot/can_receiver.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/include/titati/tita_robot/can_receiver.hpp
@@ -1,0 +1,116 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MOTORS_CAN__MOTORS_CAN_API_HPP_
+#define MOTORS_CAN__MOTORS_CAN_API_HPP_
+
+#include <algorithm>
+#include <atomic>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "titati/protocol/can_utils.hpp"
+namespace can_device
+{
+#define PACKED __attribute__((__packed__))
+#define GRAVITY 9.81f
+#define CAN_ID_MOTOR_IN 0x108
+#define CAN_ID_IMU1 0x118
+#define CAN_ID_STATE 0x102
+
+  struct api_motor_in_t
+  {
+    uint32_t timestamp;
+    float position;
+    float velocity;
+    float torque;
+  } PACKED;
+  /* 44 bytes */
+  struct api_imu_data_t
+  {
+    uint32_t timestamp;
+    float accl[3];
+    float gyro[3];
+    float quaternion[4]; // x y z w
+    float temperature;
+  } PACKED;
+  
+  struct api_motor_status_t
+  {
+    uint32_t timestamp;
+    uint16_t key;
+    uint8_t value[8];
+  } PACKED;
+
+  class MotorsImuCanReceiveApi
+  {
+  public:
+    MotorsImuCanReceiveApi(size_t size)
+    {
+      if(size % 8 == 0) leg_dof_ = 4;
+      else if(size % 6 == 0) leg_dof_ = 3;
+      leg_num_ = size / leg_dof_;
+      register_motors_device_can_filter();
+      api_motor_in_t default_motor_in;
+      std::memset(&default_motor_in, 0x00U, sizeof(api_motor_in_t));
+      motors_in_.resize(size, default_motor_in);
+      std::memset(&imu_data_, 0x00U, sizeof(api_imu_data_t));
+    }
+    ~MotorsImuCanReceiveApi() {}
+    const std::vector<api_motor_in_t> *get_motors_in() const { return &motors_in_; }
+    const api_imu_data_t *get_imu_data() const { return &imu_data_; }
+    const api_motor_status_t *get_motors_status() const { return &motors_status_; }
+
+  private:
+#define MIN_TIME_OUT_US 1'000L     // 1ms
+#define MAX_TIME_OUT_US 3'000'000L // 3s
+#define CAN_MASK_AS_MOTORS_INFO (0x7E0U)
+    std::string motors_can_interface = "can0";
+    std::string motors_can_name = "motors_can";
+    bool motors_can_extended_frame = false;
+    bool motors_can_rx_is_block = false;
+    int64_t motors_timeout_us = MAX_TIME_OUT_US;
+    uint8_t motors_can_id_offset = 0x00U;
+
+    void register_motors_device_can_filter();
+    can_device::socket_can::can_fd_callback motors_can_receive_callback =
+        std::bind(&MotorsImuCanReceiveApi::board_can_data_callback, this, std::placeholders::_1);
+
+    std::shared_ptr<can_device::socket_can::CanDev> motors_can_receive_api =
+        std::make_shared<can_device::socket_can::CanDev>(
+            motors_can_interface, motors_can_name, motors_can_extended_frame, motors_can_receive_callback,
+            motors_can_rx_is_block, motors_timeout_us, motors_can_id_offset);
+
+    void board_can_data_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+    void motors_data_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+    void imu_data_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+    void motors_status_callback(std::shared_ptr<struct canfd_frame> recv_frame);
+
+    std::vector<api_motor_in_t> motors_in_;
+    api_imu_data_t imu_data_;
+    api_motor_status_t motors_status_;
+
+    mutable std::shared_mutex motors_in_mutex_, imu_mutex_;
+    size_t leg_dof_{4}, leg_num_{2};
+  };
+} // namespace can_device
+
+#endif // MOTORS_CAN__MOTORS_CAN_API_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/include/titati/tita_robot/can_sender.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/include/titati/tita_robot/can_sender.hpp
@@ -1,0 +1,120 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MOTORS_CAN__MOTORS_CAN_SEND_API_HPP_
+#define MOTORS_CAN__MOTORS_CAN_SEND_API_HPP_
+
+#include <algorithm>
+#include <atomic>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "titati/protocol/can_utils.hpp"
+
+namespace can_device
+{
+
+#define CAN_ID_SEND_MOTORS (0x120U)
+#define CAN_ID_CHANNEL_INPUT (0x12DU)
+#define CAN_ID_RPC_REQUEST (0x170U)
+
+  enum ApiRpcKey
+  {
+    RPC_UNDEFINED = 0x000,
+    GET_MODEL_INFO = 0x100,
+    GET_SERIAL_NUMBER = 0x101,
+    SET_READY_NEXT = 0x200,
+    SET_BOARDCAST = 0x201,
+    SET_INPUT_MODE = 0x221,
+    SET_STAND_MODE = 0x222,
+    SET_HEAD_MODE = 0x223,
+    SET_JUMP = 0x231,
+    SET_MOTOR_ZERO = 0x280,
+  };
+  struct ChannelInput
+  {
+    uint32_t timestamp;
+    float forward;
+    float yaw;
+    float pitch;
+    float roll;
+    float height;
+    float split;
+    float tilt;
+    float forward_accel;
+    float yaw_accel;
+  };
+  struct RpcRequest
+  {
+    uint32_t timestamp;
+    uint16_t key;
+    uint32_t value;
+  };
+  struct motor_out
+  {
+    uint32_t timestamp;
+    float position;
+    float kp;
+    float velocity;
+    float kd;
+    float torque;
+  };
+
+  class MotorsCanSendApi
+  {
+  public:
+    MotorsCanSendApi(size_t size)
+    {
+      if (size % 8 == 0)
+        leg_dof_ = 4;
+      else if (size % 6 == 0)
+        leg_dof_ = 3;
+      leg_num_ = size / leg_dof_;
+    }
+    ~MotorsCanSendApi() = default;
+    bool send_motors_can(std::vector<motor_out> motors);
+    bool send_command_can_channel_input(ChannelInput data);
+    bool send_command_can_rpc_request(RpcRequest data);
+
+  private:
+#define MIN_TIME_OUT_US 1'000L     // 1ms
+#define MAX_TIME_OUT_US 3'000'000L // 3s
+    std::string can_interface = "can0";
+    std::string can_name = "motors_can_send";
+    int64_t timeout_us = MAX_TIME_OUT_US;
+    uint8_t can_id_offset = 0x00U;
+    bool can_extended_frame = false;
+    bool can_fd_mode = true;
+
+    std::shared_ptr<can_device::socket_can::CanDev> can_send_api_ =
+        std::make_shared<can_device::socket_can::CanDev>(
+            can_interface, can_name, can_extended_frame, can_fd_mode, timeout_us, can_id_offset);
+
+    inline uint32_t get_current_time()
+    {
+      struct timeval tv;
+      gettimeofday(&tv, NULL);
+      return std::move(tv.tv_sec * 1000000 + tv.tv_usec);
+    }
+    size_t leg_dof_{4}, leg_num_{2};
+  };
+} // namespace can_device
+
+#endif // MOTORS_CAN__MOTORS_CAN_SEND_API_HPP_

--- a/rl_sar/src/rl_sar/library/hardware/titati/include/titati/tita_robot/tita_robot.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/include/titati/tita_robot/tita_robot.hpp
@@ -1,0 +1,154 @@
+#include "titati/tita_robot/can_receiver.hpp"
+#include "titati/tita_robot/can_sender.hpp"
+
+class tita_robot
+{
+public:
+    enum ReadyNext
+    {
+        READY_WAITING = 0x00U,
+        AUTO_LOCOMOTION = 0x01U,
+        FORCE_LOCOMOTION = 0x02U,
+        FORCE_DIRECT = 0x03U,
+        MOTOR_ZERO_CAL = 0x04U,
+        BOOT_RECOVERY_MODE = 0x05U,
+        ESTOP_MODE = 0x06U,
+    };
+    struct ChannelInput
+    {
+        uint32_t timestamp;
+        float forward;
+        float yaw;
+        float pitch;
+        float roll;
+        float height;
+        float split;
+        float tilt;
+        float forward_accel;
+        float yaw_accel;
+    };
+    tita_robot(size_t num_motors)
+    {
+        // Initialize the CAN receiver
+        can_receiver_ = std::make_unique<can_device::MotorsImuCanReceiveApi>(num_motors);
+        can_sender_ = std::make_unique<can_device::MotorsCanSendApi>(num_motors);
+        motor_num_ = num_motors;
+    }
+
+    /**
+     * @brief Get the current joint positions in joint space.
+     * @return std::vector<double>: current joint positions in radians.
+     */
+    std::vector<double> get_joint_q() const;
+
+    /**
+     * @brief Get the current joint velocities in joint space.
+     * @return std::vector<double>: current joint velocities in radians per second.
+     */
+    std::vector<double> get_joint_v() const;
+
+    /**
+     * @brief Get the current joint torques in joint space.
+     * @return std::vector<double>: current joint torques in Newton meters.
+     */
+    std::vector<double> get_joint_t() const;
+
+    /**
+     * @brief Get the current joint status.
+     * @note Joints status now is in bool value, true means the joint is online(TODO).
+     * @return std::vector<uint8_t>: current joint status.
+     */
+    std::vector<uint8_t> get_joint_status() const;
+
+    /**
+     * @brief Get the current imu quaternion of mcu.
+     * @note Quaternion sequence is x y z w.
+     * @return std::array<double, 4>: current quaternion.
+     */
+    std::array<double, 4> get_imu_quaternion() const; // x y z w
+
+    /**
+     * @brief Get the current imu acceleration of mcu.
+     * @return std::array<double, 3>: current acceleration.
+     */
+    std::array<double, 3> get_imu_acceleration() const;
+
+    /**
+     * @brief Get the current imu angular velocity of mcu.
+     * @return std::array<double, 3>: current angular velocity.
+     */
+    std::array<double, 3> get_imu_angular_velocity() const;
+
+    /**
+     * @brief Set the target joint feed-forward torques.
+     * @param t the target joint feed-forward torques.
+     * @return return true if the target is set successfully.
+     */
+    bool set_target_joint_t(const std::vector<double> &t);
+
+    /**
+     * @brief MIT control method. Set the target joint positions, velocities, kp, kd and feed-forward torques of the
+     motors.
+     * @param q the target joint positions in radians.
+     * @param v the target joint velocities in radians per second.
+     * @param kp the target joint proportional gains.
+     * @param kd the target joint derivative gains.
+     * @param t the target joint feed-forward torques.
+     *
+     * @return return true if the target is set successfully
+     */
+    bool set_target_joint_mit(const std::vector<double> &q, const std::vector<double> &v, const std::vector<double> &kp, const std::vector<double> &kd, const std::vector<double> &t);
+
+    // /**
+    //  * @brief Set mcu board control mode, maybe remove in the future.
+    //  * @param mode the target mcu mode, option: READY_WAITING AUTO_LOCOMOTION FORCE_DIRECT.
+    //  *
+    //  * @return return true if the target is set successfully
+    //  */
+    // bool set_board_mode(ReadyNext mode);
+    /**
+     * @brief Set mcu board can direct drive motors, default is auto_locomotion(use mcu control).
+     * @param if_sdk true means use control motors sdk, false means use mcu control.
+     *
+     * @return return true if the target is set successfully
+     */
+    bool set_motors_sdk(bool if_sdk);
+    /**
+     * @brief Set rc input to mcu. Only used in board mode is AUTO_LOCOMOTION.
+     * @param forward the target forward.
+     * @param yaw the target yaw.
+     * @param pitch the target pitch.
+     * @param roll the target roll.
+     * @param height the target height.
+     * @param split the target split.
+     * @param tilt the target tilt.
+     * @param forward_accel the target forward acceleration.
+     * @param yaw_accel the target yaw acceleration.
+     * @return return true if the target is set successfully
+     */
+    bool set_rc_input(ChannelInput input);    
+    /**
+     * @brief Set rc input to mcu. Only used in board mode is AUTO_LOCOMOTION.
+     * @param stand true if stand.
+     * @return return true if the target is set successfully
+     */
+    bool set_robot_stand(bool stand);
+
+    /**
+     * @brief Set rc input to mcu. Only used in board mode is AUTO_LOCOMOTION.
+     * @param jump true to start robot charge, then false change to start jump.
+     * @return return true if the target is set successfully
+     */
+    bool set_robot_jump(bool jump);
+    /**
+     * @brief Set rc input to mcu. Only used in board mode is AUTO_LOCOMOTION.
+     * @return return true if the target is set successfully
+     */
+    bool set_robot_stop();
+private:
+    std::unique_ptr<can_device::MotorsImuCanReceiveApi> can_receiver_;
+    std::unique_ptr<can_device::MotorsCanSendApi> can_sender_;
+    size_t motor_num_;
+};
+
+// class tita_robot

--- a/rl_sar/src/rl_sar/library/hardware/titati/src/can_receiver.cpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/src/can_receiver.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "titati/tita_robot/can_receiver.hpp"
+
+namespace can_device
+{
+
+void MotorsImuCanReceiveApi::register_motors_device_can_filter()
+{
+  // if (!this->is_running.load()) {
+  //   throw std::runtime_error("MotorsImuCanReceiveApi is not running");
+  // }
+  struct can_filter motors_device_rx_filter;
+  motors_device_rx_filter.can_id = CAN_ID_MOTOR_IN;
+  motors_device_rx_filter.can_mask = CAN_MASK_AS_MOTORS_INFO;
+  this->motors_can_receive_api->set_filter(&motors_device_rx_filter, sizeof(struct can_filter));
+}
+
+void MotorsImuCanReceiveApi::board_can_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  if (recv_frame->can_id >= CAN_ID_MOTOR_IN && recv_frame->can_id < CAN_ID_MOTOR_IN + leg_num_) {
+    motors_data_callback(recv_frame);
+  } else if (recv_frame->can_id == CAN_ID_IMU1) {
+    imu_data_callback(recv_frame);
+  } else {
+    return;
+  }
+}
+void MotorsImuCanReceiveApi::motors_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  std::unique_lock<std::shared_mutex> lock(motors_in_mutex_);
+  for (size_t i = 0; i < leg_dof_; i++) {
+    api_motor_in_t motor;
+    std::memcpy(&motor, recv_frame->data + 16 * i, sizeof(api_motor_in_t));
+    auto it = recv_frame->can_id - CAN_ID_MOTOR_IN;
+    motors_in_[i + leg_dof_ * it] = motor;
+  }
+}
+void MotorsImuCanReceiveApi::imu_data_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  std::unique_lock<std::shared_mutex> lock(imu_mutex_);
+  std::memcpy(&imu_data_, recv_frame->data, sizeof(api_imu_data_t));
+  for (size_t i(0); i < 3; ++i) {
+    imu_data_.accl[i] *= GRAVITY;
+  }
+  return;
+}
+void MotorsImuCanReceiveApi::motors_status_callback(std::shared_ptr<struct canfd_frame> recv_frame)
+{
+  std::memcpy(&motors_status_, recv_frame->data, sizeof(api_motor_status_t));
+}
+
+}  // namespace can_device

--- a/rl_sar/src/rl_sar/library/hardware/titati/src/can_sender.cpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/src/can_sender.cpp
@@ -1,0 +1,90 @@
+// Copyright (c) 2023 Direct Drive Technology Co., Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "titati/tita_robot/can_sender.hpp"
+
+namespace can_device
+{
+bool MotorsCanSendApi::send_command_can_channel_input(ChannelInput data)
+{
+  data.timestamp = get_current_time();
+  struct canfd_frame frame;
+  frame.can_id = CAN_ID_CHANNEL_INPUT;
+  frame.len = 40u;
+  memset(frame.data, 0x00U, sizeof(frame.data));
+  
+  std::memcpy(frame.data, &data, sizeof(data));
+
+  return can_send_api_->send_can_message(frame);
+}
+
+bool MotorsCanSendApi::send_command_can_rpc_request(RpcRequest data){
+  data.timestamp = get_current_time();
+
+  struct canfd_frame frame;
+  frame.can_id = CAN_ID_RPC_REQUEST;
+  frame.len = 10U;
+
+  memset(frame.data, 0x00U, sizeof(frame.data));
+
+  std::memcpy(frame.data, &data.timestamp, sizeof(data.timestamp));
+  std::memcpy(frame.data + 4, &data.key, sizeof(data.key));
+  std::memcpy(frame.data + 6, &data.value, sizeof(data.value));
+
+  return can_send_api_->send_can_message(frame);
+}
+
+bool MotorsCanSendApi::send_motors_can(std::vector<motor_out> motors)
+{
+  if (motors.size() != leg_dof_ * leg_num_) {
+    std::cerr << "[MOTORS_CAN_SEND] motors size not equal to robot dof" << std::endl;
+    return false;
+  }
+  if(leg_dof_ == 3){
+    motor_out motor = {};
+    auto it = motors.begin() + 3;
+    motors.insert(it, motor);
+    motors.push_back(motor);
+  }
+  bool send_success = true;
+  struct canfd_frame frame;
+  frame.len = 48U;
+  auto now = get_current_time();
+  for (size_t id(0); id < motors.size()/2; id++) {
+    frame.can_id = CAN_ID_SEND_MOTORS + id;
+    memset(frame.data, 0x00U, sizeof(frame.data));
+    auto motor = motors[2 * id];
+    motor.timestamp = now;
+    std::memcpy(frame.data, &motor.timestamp, sizeof(motor.timestamp));
+    std::memcpy(frame.data + 4, &motor.position, sizeof(motor.position));
+    std::memcpy(frame.data + 8, &motor.kp, sizeof(motor.kp));
+    std::memcpy(frame.data + 12, &motor.velocity, sizeof(motor.velocity));
+    std::memcpy(frame.data + 16, &motor.kd, sizeof(motor.kd));
+    std::memcpy(frame.data + 20, &motor.torque, sizeof(motor.torque));
+
+    motor = motors[2 * id + 1];
+    motor.timestamp = now;
+    std::memcpy(frame.data + 24, &motor.timestamp, sizeof(motor.timestamp));
+    std::memcpy(frame.data + 28, &motor.position, sizeof(motor.position));
+    std::memcpy(frame.data + 32, &motor.kp, sizeof(motor.kp));
+    std::memcpy(frame.data + 36, &motor.velocity, sizeof(motor.velocity));
+    std::memcpy(frame.data + 40, &motor.kd, sizeof(motor.kd));
+    std::memcpy(frame.data + 44, &motor.torque, sizeof(motor.torque));
+    send_success &= can_send_api_->send_can_message(frame);
+    std::this_thread::sleep_for(std::chrono::microseconds(150)); // 等待 100 微秒
+  }
+  return send_success;
+}
+
+}  // namespace can_device

--- a/rl_sar/src/rl_sar/library/hardware/titati/src/force_direct_manager.cpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/src/force_direct_manager.cpp
@@ -1,0 +1,133 @@
+#include "titati/force_direct_manager.hpp"
+
+#include <chrono>
+#include <functional>
+#include <cstring>
+#include <sys/time.h>
+
+namespace titati
+{
+
+namespace
+{
+constexpr uint16_t kRpcKeyReadyNext = 0x200;
+constexpr uint32_t kRpcValueIdle = 0x00U;
+constexpr uint32_t kRpcValueForceDirect = 0x03U;
+constexpr uint32_t kCanIdRouter = 0x09FU;
+constexpr uint32_t kCanIdRpc = 0x170U;
+constexpr uint32_t kModeAuto = 0x01U;
+constexpr uint32_t kModeForce = 0x02U;
+constexpr int64_t kTimeoutUs = 3'000'000L;
+}  // namespace
+
+ForceDirectManager::ForceDirectManager()
+{
+  auto callback = std::bind(&ForceDirectManager::handle_frame, this, std::placeholders::_1);
+  router_receiver_ = std::make_shared<can_device::socket_can::CanDev>(
+    "can0", "titati_router_listener", false, callback, false, kTimeoutUs, 0x00U);
+
+  struct can_filter filter
+  {
+  };
+  filter.can_id = kCanIdRouter;
+  filter.can_mask = 0x0FFU;
+  router_receiver_->set_filter(&filter, sizeof(filter));
+
+  rpc_sender_ = std::make_shared<can_device::socket_can::CanDev>(
+    "can0", "titati_router_sender", false, true, kTimeoutUs, 0x00U);
+}
+
+ForceDirectManager::~ForceDirectManager()
+{
+  stop();
+}
+
+void ForceDirectManager::start()
+{
+  if (running_.exchange(true)) {
+    return;
+  }
+  pending_sequence_.store(true);
+  initial_wakeup();
+}
+
+void ForceDirectManager::stop()
+{
+  if (!running_.exchange(false)) {
+    return;
+  }
+  pending_sequence_.store(false);
+  if (wake_thread_.joinable()) {
+    wake_thread_.join();
+  }
+}
+
+void ForceDirectManager::initial_wakeup()
+{
+  wake_thread_ = std::thread([this]() {
+    for (int i = 0; i < 5 && running_.load(); ++i) {
+      send_force_direct_sequence();
+      std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    }
+  });
+}
+
+void ForceDirectManager::handle_frame(std::shared_ptr<struct canfd_frame> frame)
+{
+  if (!running_.load() || frame == nullptr) {
+    return;
+  }
+
+  if (frame->can_id != kCanIdRouter) {
+    return;
+  }
+
+  uint32_t mode = 0;
+  std::memcpy(&mode, frame->data + 4, sizeof(mode));
+  if (mode == kModeAuto || mode == kModeForce) {
+    pending_sequence_.store(true);
+    send_force_direct_sequence();
+  }
+}
+
+void ForceDirectManager::send_force_direct_sequence()
+{
+  if (!running_.load() || !pending_sequence_.exchange(false)) {
+    return;
+  }
+
+  struct canfd_frame frame
+  {
+  };
+  frame.can_id = kCanIdRpc;
+  frame.len = 10U;
+  std::memset(frame.data, 0x00, sizeof(frame.data));
+
+  uint32_t timestamp = current_time_us();
+  uint16_t key = kRpcKeyReadyNext;
+  uint32_t value = kRpcValueIdle;
+
+  std::memcpy(frame.data, &timestamp, sizeof(timestamp));
+  std::memcpy(frame.data + 4, &key, sizeof(key));
+  std::memcpy(frame.data + 6, &value, sizeof(value));
+  rpc_sender_->send_can_message(frame);
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  timestamp = current_time_us();
+  value = kRpcValueForceDirect;
+  std::memcpy(frame.data, &timestamp, sizeof(timestamp));
+  std::memcpy(frame.data + 6, &value, sizeof(value));
+  rpc_sender_->send_can_message(frame);
+}
+
+uint32_t ForceDirectManager::current_time_us() const
+{
+  struct timeval tv
+  {
+  };
+  gettimeofday(&tv, nullptr);
+  return static_cast<uint32_t>(tv.tv_sec * 1'000'000 + tv.tv_usec);
+}
+
+}  // namespace titati

--- a/rl_sar/src/rl_sar/library/hardware/titati/src/power_management_sender.cpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/src/power_management_sender.cpp
@@ -1,0 +1,118 @@
+#include "titati/battery_device/power_management_sender.hpp"
+
+#include <cstring>
+
+namespace titati
+{
+namespace battery
+{
+namespace
+{
+constexpr int64_t kTimeoutUs = 3'000'000L;
+
+inline void encode_u32(uint8_t * dst, uint32_t value)
+{
+  dst[0] = static_cast<uint8_t>((value >> 24) & 0xFFU);
+  dst[1] = static_cast<uint8_t>((value >> 16) & 0xFFU);
+  dst[2] = static_cast<uint8_t>((value >> 8) & 0xFFU);
+  dst[3] = static_cast<uint8_t>(value & 0xFFU);
+}
+
+inline void encode_u64(uint8_t * dst, uint64_t value)
+{
+  dst[0] = static_cast<uint8_t>((value >> 56) & 0xFFU);
+  dst[1] = static_cast<uint8_t>((value >> 48) & 0xFFU);
+  dst[2] = static_cast<uint8_t>((value >> 40) & 0xFFU);
+  dst[3] = static_cast<uint8_t>((value >> 32) & 0xFFU);
+  dst[4] = static_cast<uint8_t>((value >> 24) & 0xFFU);
+  dst[5] = static_cast<uint8_t>((value >> 16) & 0xFFU);
+  dst[6] = static_cast<uint8_t>((value >> 8) & 0xFFU);
+  dst[7] = static_cast<uint8_t>(value & 0xFFU);
+}
+}  // namespace
+
+PowerManagementSender::PowerManagementSender()
+{
+  can_dev_ = std::make_shared<can_device::socket_can::CanDev>(
+    "can0", "titati_power_sender", false, true, kTimeoutUs, 0x00U);
+}
+
+void PowerManagementSender::send_state(const PowerStateCommand & command)
+{
+  if (!can_dev_) {
+    return;
+  }
+
+  struct canfd_frame frame
+  {
+  };
+  frame.can_id = kCanIdPowerStateSet;
+  frame.len = static_cast<uint8_t>(kDlcPowerStateSet);
+  std::memset(frame.data, 0x00, sizeof(frame.data));
+
+  frame.data[4] = static_cast<uint8_t>(command.power_5v);
+  frame.data[5] = static_cast<uint8_t>(command.power_12v);
+  frame.data[6] = static_cast<uint8_t>(command.power_24v);
+  frame.data[7] = static_cast<uint8_t>(command.power_motor_48v);
+  frame.data[8] = static_cast<uint8_t>(command.power_extern_48v);
+
+  frame.data[9] = static_cast<uint8_t>(command.power_5v_delay_ms & 0xFFU);
+  frame.data[10] = static_cast<uint8_t>((command.power_5v_delay_ms >> 8) & 0xFFU);
+  frame.data[11] = static_cast<uint8_t>(command.power_12v_delay_ms & 0xFFU);
+  frame.data[12] = static_cast<uint8_t>((command.power_12v_delay_ms >> 8) & 0xFFU);
+  frame.data[13] = static_cast<uint8_t>(command.power_24v_delay_ms & 0xFFU);
+  frame.data[14] = static_cast<uint8_t>((command.power_24v_delay_ms >> 8) & 0xFFU);
+  frame.data[15] = static_cast<uint8_t>(command.power_motor_48v_delay_ms & 0xFFU);
+  frame.data[16] = static_cast<uint8_t>((command.power_motor_48v_delay_ms >> 8) & 0xFFU);
+  frame.data[17] = static_cast<uint8_t>(command.power_extern_48v_delay_ms & 0xFFU);
+  frame.data[18] = static_cast<uint8_t>((command.power_extern_48v_delay_ms >> 8) & 0xFFU);
+  frame.data[19] = command.fixed;
+
+  can_dev_->send_can_message(frame);
+}
+
+void PowerManagementSender::send_self_test(const PowerSelfTestReport & report)
+{
+  if (!can_dev_) {
+    return;
+  }
+
+  struct canfd_frame frame
+  {
+  };
+  frame.can_id = kCanIdPowerSelfTest;
+  frame.len = static_cast<uint8_t>(kDlcPowerSelfTest);
+  std::memset(frame.data, 0x00, sizeof(frame.data));
+
+  encode_u64(&frame.data[4], report.rst);
+  encode_u32(&frame.data[12], report.app_version);
+  encode_u32(&frame.data[16], report.build_timestamp);
+  encode_u32(&frame.data[20], report.uuid_0);
+  encode_u32(&frame.data[24], report.uuid_1);
+  encode_u32(&frame.data[28], report.uuid_2);
+
+  can_dev_->send_can_message(frame);
+}
+
+void PowerManagementSender::send_heartbeat(const PowerHeartbeat & heartbeat)
+{
+  if (!can_dev_) {
+    return;
+  }
+
+  struct canfd_frame frame
+  {
+  };
+  frame.can_id = kCanIdPowerHeartbeat;
+  frame.len = static_cast<uint8_t>(kDlcPowerHeartbeat);
+  std::memset(frame.data, 0x00, sizeof(frame.data));
+
+  encode_u32(&frame.data[4], heartbeat.cur_mode);
+  frame.data[8] = heartbeat.right_history;
+  frame.data[9] = heartbeat.left_history;
+
+  can_dev_->send_can_message(frame);
+}
+
+}  // namespace battery
+}  // namespace titati

--- a/rl_sar/src/rl_sar/library/hardware/titati/src/tita_robot.cpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/src/tita_robot.cpp
@@ -1,0 +1,171 @@
+#include "titati/tita_robot/tita_robot.hpp"
+
+std::vector<double> tita_robot::get_joint_q() const
+{
+  auto infos = can_receiver_->get_motors_in();
+  std::vector<double> joint;
+  for (const auto & info : *infos) {
+    joint.push_back(info.position);
+  }
+  return joint;
+}
+
+std::vector<double> tita_robot::get_joint_v() const
+{
+  auto infos = can_receiver_->get_motors_in();
+  std::vector<double> joint;
+  for (const auto & info : *infos) {
+    joint.push_back(info.velocity);
+  }
+  return joint;
+}
+
+std::vector<double> tita_robot::get_joint_t() const
+{
+  auto infos = can_receiver_->get_motors_in();
+  std::vector<double> joint;
+  for (const auto & info : *infos) {
+    joint.push_back(info.torque);
+  }
+  return joint;
+}
+
+std::vector<uint8_t> tita_robot::get_joint_status() const  // TODO: why 8
+{
+  auto infos = can_receiver_->get_motors_status();
+  std::vector<uint8_t> joint;
+  for (size_t id = 0; id < 8; id++) {
+    joint.push_back(infos->value[id]);
+  }
+  return joint;
+}
+
+std::array<double, 4> tita_robot::get_imu_quaternion() const
+{
+  auto infos = can_receiver_->get_imu_data();
+  std::array<double, 4> data;
+  for (size_t i = 0; i < 4; i++) {
+    data[i] = infos->quaternion[i];
+  }
+  return data;
+}
+
+std::array<double, 3> tita_robot::get_imu_acceleration() const
+{
+  auto infos = can_receiver_->get_imu_data();
+  std::array<double, 3> data;
+  for (size_t i = 0; i < 3; i++) {
+    data[i] = infos->accl[i];
+  }
+  return data;
+}
+
+std::array<double, 3> tita_robot::get_imu_angular_velocity() const
+{
+  auto infos = can_receiver_->get_imu_data();
+  std::array<double, 3> data;
+  for (size_t i = 0; i < 3; i++) {
+    data[i] = infos->gyro[i];
+  }
+  return data;
+}
+
+bool tita_robot::set_target_joint_t(const std::vector<double> & t)
+{
+  std::vector<can_device::motor_out> motors;
+  for (size_t id = 0; id < motor_num_; id++) {
+    can_device::motor_out motor;
+    motor.torque = t[id];
+    motor.kp = 0.0f;
+    motor.kd = 0.0f;
+    motor.velocity = 0.0f;
+    motor.position = 0.0f;
+    motors.push_back(motor);
+  }
+  return can_sender_->send_motors_can(motors);
+}
+
+bool tita_robot::set_target_joint_mit(
+  const std::vector<double> & q, const std::vector<double> & v, const std::vector<double> & kp,
+  const std::vector<double> & kd, const std::vector<double> & t)
+{
+  std::vector<can_device::motor_out> motors;
+  for (size_t id = 0; id < motor_num_; id++) {
+    can_device::motor_out motor;
+    motor.torque = t[id];
+    motor.kp = kp[id];
+    motor.kd = kd[id];
+    motor.velocity = v[id];
+    motor.position = q[id];
+    motors.push_back(motor);
+  }
+  return can_sender_->send_motors_can(motors);
+}
+
+// bool tita_robot::set_board_mode(ReadyNext mode)
+// {
+//   can_device::RpcRequest rpc_request;
+//   rpc_request.key = can_device::SET_READY_NEXT;
+//   rpc_request.value = mode;
+//   return can_sender_->send_command_can_rpc_request(rpc_request);
+// }
+
+bool tita_robot::set_motors_sdk(bool if_sdk)
+{
+  can_device::RpcRequest rpc_request;
+  rpc_request.key = can_device::SET_READY_NEXT;
+  rpc_request.value = READY_WAITING;
+  bool return_ok = can_sender_->send_command_can_rpc_request(rpc_request);
+  std::this_thread::sleep_for(std::chrono::microseconds(100));
+  if (if_sdk) {
+    rpc_request.value = FORCE_DIRECT;
+  } else {
+    rpc_request.value = AUTO_LOCOMOTION;
+  }
+  return_ok &= can_sender_->send_command_can_rpc_request(rpc_request);
+  return return_ok;
+}
+
+bool tita_robot::set_rc_input(ChannelInput input)
+{
+  can_device::ChannelInput can_input;
+  can_input.forward = input.forward;
+  can_input.yaw = input.yaw;
+  can_input.pitch = input.pitch;
+  can_input.roll = input.roll;
+  can_input.height = input.height;
+  can_input.split = input.split;
+  can_input.tilt = input.tilt;
+  can_input.forward_accel = input.forward_accel;
+  can_input.yaw_accel = input.yaw_accel;
+  return can_sender_->send_command_can_channel_input(can_input);
+}
+
+bool tita_robot::set_robot_stand(bool stand)
+{
+  can_device::RpcRequest rpc_request;
+  rpc_request.key = can_device::SET_STAND_MODE;
+  rpc_request.value = !stand ? 0x01U : 0x02U;
+  return can_sender_->send_command_can_rpc_request(rpc_request);
+}
+
+bool tita_robot::set_robot_jump(bool jump)
+{
+  can_device::RpcRequest rpc_request;
+  rpc_request.key = can_device::SET_JUMP;
+  rpc_request.value = !jump ? 0x01U : 0x02U;
+  return can_sender_->send_command_can_rpc_request(rpc_request);
+}
+
+bool tita_robot::set_robot_stop()
+{
+  can_device::RpcRequest rpc_request;
+  rpc_request.value = 0x01U;
+  rpc_request.key = can_device::SET_STAND_MODE;
+  bool return_ok = can_sender_->send_command_can_rpc_request(rpc_request);
+  std::this_thread::sleep_for(std::chrono::microseconds(200));
+  rpc_request.value = 0x02U;
+  rpc_request.key = can_device::SET_JUMP;
+  return_ok &= can_sender_->send_command_can_rpc_request(rpc_request);
+  return true;
+}

--- a/rl_sar/src/rl_sar/package.ros2.xml
+++ b/rl_sar/src/rl_sar/package.ros2.xml
@@ -11,6 +11,7 @@
     <buildtool_depend>ament_cmake</buildtool_depend>
     <depend>rclcpp</depend>
     <depend>std_msgs</depend>
+    <depend>diagnostic_msgs</depend>
     <depend>gazebo_ros</depend>
     <depend>yaml-cpp</depend>
     <depend>robot_msgs</depend>
@@ -20,6 +21,7 @@
     <depend>joint_state_controller</depend>
     <depend>robot_state_publisher</depend>
     <depend>rospy</depend>
+    <depend>tita_system_interfaces</depend>
 
     <export>
         <build_type>ament_cmake</build_type>

--- a/rl_sar/src/rl_sar/scripts/can_setup_8m_master.sh
+++ b/rl_sar/src/rl_sar/scripts/can_setup_8m_master.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Define the file name
+FILE_NAME="/home/robot/tita_ros2_open/nohup.out"
+
+# Check if the file exists
+if [ -f "$FILE_NAME" ]; then
+    echo "The file '$FILE_NAME' exists."
+    rm "$FILE_NAME"
+        if [ $? -eq 0 ]; then
+            echo "The file '$FILE_NAME' has been successfully removed."
+        fi
+fi
+
+sudo systemctl stop tita-bringup.service
+sudo ip link set can0 down
+sudo ip link set can0 up type can bitrate 1000000 sample-point 0.80 dbitrate 8000000 dsample-point 0.80 fd on restart-ms 100
+sudo ifconfig can0 txqueuelen 1000
+cd tita_ros2_open
+source /opt/ros/humble/setup.bash && source install/setup.bash
+nohup ros2 launch titati_bringup quadruped_controller.launch.py &

--- a/rl_sar/src/rl_sar/scripts/can_setup_8m_slave.sh
+++ b/rl_sar/src/rl_sar/scripts/can_setup_8m_slave.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Define the file name
+FILE_NAME="/home/robot/tita_ros2_open/nohup.out"
+
+# Check if the file exists
+if [ -f "$FILE_NAME" ]; then
+    echo "The file '$FILE_NAME' exists."
+    rm "$FILE_NAME"
+        if [ $? -eq 0 ]; then
+            echo "The file '$FILE_NAME' has been successfully removed."
+        fi
+fi
+
+sudo systemctl stop tita-bringup.service
+sudo ip link set can0 down
+sudo ip link set can0 up type can bitrate 1000000 sample-point 0.80 dbitrate 8000000 dsample-point 0.80 fd on restart-ms 100
+sudo ifconfig can0 txqueuelen 1000
+cd tita_ros2_open
+source /opt/ros/humble/setup.bash && source install/setup.bash
+nohup ros2 launch titati_bringup quadruped_slave_controller.launch.py &

--- a/rl_sar/src/rl_sar/src/rl_real_titati.cpp
+++ b/rl_sar/src/rl_sar/src/rl_real_titati.cpp
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2024-2025 Ziqi Fan
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "rl_real_titati.hpp"
+
+RL_Real::RL_Real()
+#if defined(USE_ROS2) && defined(USE_ROS)
+    : rclcpp::Node("rl_real_node")
+#endif
+{
+#if defined(USE_ROS1) && defined(USE_ROS)
+    ros::NodeHandle nh;
+    this->cmd_vel_subscriber = nh.subscribe<geometry_msgs::Twist>("/cmd_vel", 10, &RL_Real::CmdvelCallback, this);
+#elif defined(USE_ROS2) && defined(USE_ROS)
+    this->cmd_vel_subscriber = this->create_subscription<geometry_msgs::msg::Twist>(
+        "/cmd_vel", rclcpp::SystemDefaultsQoS(),
+        [this](const geometry_msgs::msg::Twist::SharedPtr msg) { this->CmdvelCallback(msg); });
+#endif
+
+    this->ang_vel_type = "ang_vel_body";
+    this->robot_name = "titati";
+    this->ReadYamlBase(this->robot_name);
+
+    if (FSMManager::GetInstance().IsTypeSupported(this->robot_name))
+    {
+        auto fsm_ptr = FSMManager::GetInstance().CreateFSM(this->robot_name, this);
+        if (fsm_ptr)
+        {
+            this->fsm = *fsm_ptr;
+        }
+    }
+    else
+    {
+        std::cout << LOGGER::ERROR << "No FSM registered for robot: " << this->robot_name << std::endl;
+    }
+
+    torch::autograd::GradMode::set_enabled(false);
+    torch::set_num_threads(4);
+
+    robot_ = std::make_unique<tita_robot>(this->params.num_of_dofs);
+    force_direct_manager_.start();
+    robot_->set_motors_sdk(true);
+
+    this->InitOutputs();
+    this->InitControl();
+
+    this->loop_keyboard = std::make_shared<LoopFunc>("loop_keyboard", 0.05, std::bind(&RL_Real::KeyboardInterface, this));
+    this->loop_control = std::make_shared<LoopFunc>("loop_control", this->params.dt, std::bind(&RL_Real::RobotControl, this));
+    this->loop_rl = std::make_shared<LoopFunc>("loop_rl", this->params.dt * this->params.decimation, std::bind(&RL_Real::RunModel, this));
+    this->loop_keyboard->start();
+    this->loop_control->start();
+    this->loop_rl->start();
+}
+
+RL_Real::~RL_Real()
+{
+    this->loop_keyboard->shutdown();
+    this->loop_control->shutdown();
+    this->loop_rl->shutdown();
+
+    if (robot_)
+    {
+        robot_->set_target_joint_t(std::vector<double>(this->params.num_of_dofs, 0.0));
+        robot_->set_motors_sdk(false);
+    }
+    force_direct_manager_.stop();
+
+    std::cout << LOGGER::INFO << "RL_Real exit" << std::endl;
+}
+
+void RL_Real::GetState(RobotState<double> *state)
+{
+    auto joint_pos = robot_->get_joint_q();
+    auto joint_vel = robot_->get_joint_v();
+    auto joint_tau = robot_->get_joint_t();
+    auto imu_quat = robot_->get_imu_quaternion();
+    auto imu_acc = robot_->get_imu_acceleration();
+    auto imu_gyro = robot_->get_imu_angular_velocity();
+
+    state->imu.quaternion[0] = imu_quat[3];
+    state->imu.quaternion[1] = imu_quat[0];
+    state->imu.quaternion[2] = imu_quat[1];
+    state->imu.quaternion[3] = imu_quat[2];
+
+    for (int i = 0; i < 3; ++i)
+    {
+        state->imu.gyroscope[i] = imu_gyro[i];
+        state->imu.accelerometer[i] = imu_acc[i];
+    }
+
+    for (int i = 0; i < this->params.num_of_dofs; ++i)
+    {
+        state->motor_state.q[i] = joint_pos[i];
+        state->motor_state.dq[i] = joint_vel[i];
+        state->motor_state.tau_est[i] = joint_tau[i];
+    }
+}
+
+void RL_Real::SetCommand(const RobotCommand<double> *command)
+{
+    std::vector<double> target_q(this->params.num_of_dofs, 0.0);
+    std::vector<double> target_dq(this->params.num_of_dofs, 0.0);
+    std::vector<double> target_kp(this->params.num_of_dofs, 0.0);
+    std::vector<double> target_kd(this->params.num_of_dofs, 0.0);
+    std::vector<double> target_tau(this->params.num_of_dofs, 0.0);
+
+    for (int i = 0; i < this->params.num_of_dofs; ++i)
+    {
+        target_q[i] = command->motor_command.q[i];
+        target_dq[i] = command->motor_command.dq[i];
+        target_kp[i] = command->motor_command.kp[i];
+        target_kd[i] = command->motor_command.kd[i];
+        target_tau[i] = command->motor_command.tau[i];
+    }
+
+    robot_->set_target_joint_mit(target_q, target_dq, target_kp, target_kd, target_tau);
+}
+
+void RL_Real::RobotControl()
+{
+    this->motiontime++;
+
+    if (this->control.current_keyboard == Input::Keyboard::W)
+    {
+        this->control.x += 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::S)
+    {
+        this->control.x -= 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::A)
+    {
+        this->control.y += 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::D)
+    {
+        this->control.y -= 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::Q)
+    {
+        this->control.yaw += 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::E)
+    {
+        this->control.yaw -= 0.1;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::Space)
+    {
+        this->control.x = 0;
+        this->control.y = 0;
+        this->control.yaw = 0;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+    if (this->control.current_keyboard == Input::Keyboard::N || this->control.current_gamepad == Input::Gamepad::X)
+    {
+        this->control.navigation_mode = !this->control.navigation_mode;
+        std::cout << std::endl << LOGGER::INFO << "Navigation mode: " << (this->control.navigation_mode ? "ON" : "OFF") << std::endl;
+        this->control.current_keyboard = this->control.last_keyboard;
+    }
+
+    this->GetState(&this->robot_state);
+    this->StateController(&this->robot_state, &this->robot_command);
+    this->SetCommand(&this->robot_command);
+}
+
+void RL_Real::RunModel()
+{
+    if (this->rl_init_done)
+    {
+        this->episode_length_buf += 1;
+        this->obs.ang_vel = torch::tensor(this->robot_state.imu.gyroscope).unsqueeze(0);
+        if (this->control.navigation_mode)
+        {
+#if !defined(USE_CMAKE) && defined(USE_ROS)
+            this->obs.commands = torch::tensor({{this->cmd_vel.linear.x, this->cmd_vel.linear.y, this->cmd_vel.angular.z}});
+#endif
+        }
+        else
+        {
+            this->obs.commands = torch::tensor({{this->control.x, this->control.y, this->control.yaw}});
+        }
+        this->obs.base_quat = torch::tensor(this->robot_state.imu.quaternion).unsqueeze(0);
+        this->obs.dof_pos = torch::tensor(this->robot_state.motor_state.q).narrow(0, 0, this->params.num_of_dofs).unsqueeze(0);
+        this->obs.dof_vel = torch::tensor(this->robot_state.motor_state.dq).narrow(0, 0, this->params.num_of_dofs).unsqueeze(0);
+
+        this->obs.actions = this->Forward();
+        this->ComputeOutput(this->obs.actions, this->output_dof_pos, this->output_dof_vel, this->output_dof_tau);
+
+        if (this->output_dof_pos.defined() && this->output_dof_pos.numel() > 0)
+        {
+            output_dof_pos_queue.push(this->output_dof_pos);
+        }
+        if (this->output_dof_vel.defined() && this->output_dof_vel.numel() > 0)
+        {
+            output_dof_vel_queue.push(this->output_dof_vel);
+        }
+        if (this->output_dof_tau.defined() && this->output_dof_tau.numel() > 0)
+        {
+            output_dof_tau_queue.push(this->output_dof_tau);
+        }
+
+        this->TorqueProtect(this->output_dof_tau);
+    }
+}
+
+torch::Tensor RL_Real::Forward()
+{
+    torch::autograd::GradMode::set_enabled(false);
+
+    torch::Tensor clamped_obs = this->ComputeObservation();
+
+    torch::Tensor actions;
+    if (!this->params.observations_history.empty())
+    {
+        this->history_obs_buf.insert(clamped_obs);
+        this->history_obs = this->history_obs_buf.get_obs_vec(this->params.observations_history);
+        actions = this->model.forward({this->history_obs}).toTensor();
+    }
+    else
+    {
+        actions = this->model.forward({clamped_obs}).toTensor();
+    }
+
+    if (this->params.clip_actions_upper.numel() != 0 && this->params.clip_actions_lower.numel() != 0)
+    {
+        return torch::clamp(actions, this->params.clip_actions_lower, this->params.clip_actions_upper);
+    }
+    else
+    {
+        return actions;
+    }
+}
+
+#if defined(USE_ROS1) && defined(USE_ROS)
+void RL_Real::CmdvelCallback(const geometry_msgs::Twist::ConstPtr &msg)
+{
+    this->cmd_vel = *msg;
+}
+#elif defined(USE_ROS2) && defined(USE_ROS)
+void RL_Real::CmdvelCallback(const geometry_msgs::msg::Twist::SharedPtr msg)
+{
+    this->cmd_vel = *msg;
+}
+#endif

--- a/rl_sar/src/rl_sar/src/titati_battery_device.cpp
+++ b/rl_sar/src/rl_sar/src/titati_battery_device.cpp
@@ -1,0 +1,232 @@
+#include <chrono>
+#include <limits>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "diagnostic_msgs/msg/diagnostic_array.hpp"
+#include "diagnostic_msgs/msg/key_value.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "tita_system_interfaces/srv/power_heart_beat_srv.hpp"
+#include "tita_system_interfaces/srv/power_self_test_srv.hpp"
+#include "tita_system_interfaces/srv/power_state_set_srv.hpp"
+#include "titati/battery_device/power_management_sender.hpp"
+#include "titati/battery_device/power_management_types.hpp"
+
+namespace
+{
+using diagnostic_msgs::msg::KeyValue;
+
+std::optional<std::string> find_value(const std::vector<KeyValue> & values, const std::string & key)
+{
+  for (const auto & kv : values) {
+    if (kv.key == key) {
+      return kv.value;
+    }
+  }
+  return std::nullopt;
+}
+
+bool parse_int8(const std::optional<std::string> & text, int8_t & out)
+{
+  if (!text) {
+    return false;
+  }
+  try {
+    const auto value = std::stoi(*text);
+    if (value < -128 || value > 127) {
+      return false;
+    }
+    out = static_cast<int8_t>(value);
+    return true;
+  } catch (...) {
+    return false;
+  }
+}
+
+bool parse_uint16(const std::optional<std::string> & text, uint16_t & out)
+{
+  if (!text) {
+    return false;
+  }
+  try {
+    const auto value = std::stoul(*text);
+    if (value > std::numeric_limits<uint16_t>::max()) {
+      return false;
+    }
+    out = static_cast<uint16_t>(value);
+    return true;
+  } catch (...) {
+    return false;
+  }
+}
+
+bool parse_uint8(const std::optional<std::string> & text, uint8_t & out)
+{
+  uint16_t temp = 0U;
+  if (!parse_uint16(text, temp)) {
+    return false;
+  }
+  if (temp > std::numeric_limits<uint8_t>::max()) {
+    return false;
+  }
+  out = static_cast<uint8_t>(temp);
+  return true;
+}
+}  // namespace
+
+class TitatiBatteryDeviceNode : public rclcpp::Node
+{
+public:
+  explicit TitatiBatteryDeviceNode(const rclcpp::NodeOptions & options)
+  : rclcpp::Node("battery_device_node", options)
+  {
+    using std::placeholders::_1;
+    using std::placeholders::_2;
+
+    power_state_service_ = this->create_service<tita_system_interfaces::srv::PowerStateSetSrv>(
+      "system/power_supply/power_state_set_srv",
+      std::bind(&TitatiBatteryDeviceNode::handle_power_state_set, this, _1, _2));
+
+    power_heartbeat_service_ = this->create_service<tita_system_interfaces::srv::PowerHeartBeatSrv>(
+      "system/power_supply/power_heart_beat_srv",
+      std::bind(&TitatiBatteryDeviceNode::handle_power_heartbeat, this, _1, _2));
+
+    power_self_test_service_ = this->create_service<tita_system_interfaces::srv::PowerSelfTestSrv>(
+      "system/power_supply/power_self_test_srv",
+      std::bind(&TitatiBatteryDeviceNode::handle_power_self_test, this, _1, _2));
+
+    heartbeat_timer_ = this->create_wall_timer(
+      std::chrono::seconds(1), std::bind(&TitatiBatteryDeviceNode::send_periodic_heartbeat, this));
+
+    RCLCPP_INFO(this->get_logger(), "Titati battery_device service bridge started");
+  }
+
+private:
+  void handle_power_state_set(
+    const tita_system_interfaces::srv::PowerStateSetSrv::Request::SharedPtr request,
+    tita_system_interfaces::srv::PowerStateSetSrv::Response::SharedPtr response)
+  {
+    titati::battery::PowerStateCommand command{};
+
+    if (request && !request->power_state_set.status.empty()) {
+      const auto & values = request->power_state_set.status.front().values;
+
+      if (!parse_int8(find_value(values, "power_5v"), command.power_5v)) {
+        RCLCPP_WARN_THROTTLE(
+          this->get_logger(), *this->get_clock(), 2000,
+          "Failed to parse power_5v from diagnostic request, defaulting to %d", command.power_5v);
+      }
+      if (!parse_int8(find_value(values, "power_12v"), command.power_12v)) {
+        RCLCPP_WARN_THROTTLE(
+          this->get_logger(), *this->get_clock(), 2000,
+          "Failed to parse power_12v from diagnostic request, defaulting to %d", command.power_12v);
+      }
+      if (!parse_int8(find_value(values, "power_24v"), command.power_24v)) {
+        RCLCPP_WARN_THROTTLE(
+          this->get_logger(), *this->get_clock(), 2000,
+          "Failed to parse power_24v from diagnostic request, defaulting to %d", command.power_24v);
+      }
+      if (!parse_int8(find_value(values, "power_motor_48v"), command.power_motor_48v)) {
+        RCLCPP_WARN_THROTTLE(
+          this->get_logger(), *this->get_clock(), 2000,
+          "Failed to parse power_motor_48v from diagnostic request, defaulting to %d",
+          command.power_motor_48v);
+      }
+      if (!parse_int8(find_value(values, "power_extern_48v"), command.power_extern_48v)) {
+        RCLCPP_WARN_THROTTLE(
+          this->get_logger(), *this->get_clock(), 2000,
+          "Failed to parse power_extern_48v from diagnostic request, defaulting to %d",
+          command.power_extern_48v);
+      }
+
+      if (!parse_uint16(find_value(values, "power_5v_operation_delay_ms"), command.power_5v_delay_ms)) {
+        RCLCPP_WARN_THROTTLE(
+          this->get_logger(), *this->get_clock(), 2000,
+          "Failed to parse power_5v_operation_delay_ms, defaulting to %u", command.power_5v_delay_ms);
+      }
+      if (!parse_uint16(find_value(values, "power_12v_operation_delay_ms"), command.power_12v_delay_ms)) {
+        RCLCPP_WARN_THROTTLE(
+          this->get_logger(), *this->get_clock(), 2000,
+          "Failed to parse power_12v_operation_delay_ms, defaulting to %u", command.power_12v_delay_ms);
+      }
+      if (!parse_uint16(find_value(values, "power_24v_operation_delay_ms"), command.power_24v_delay_ms)) {
+        RCLCPP_WARN_THROTTLE(
+          this->get_logger(), *this->get_clock(), 2000,
+          "Failed to parse power_24v_operation_delay_ms, defaulting to %u", command.power_24v_delay_ms);
+      }
+      if (!parse_uint16(
+          find_value(values, "power_motor_48v_operation_delay_ms"), command.power_motor_48v_delay_ms)) {
+        RCLCPP_WARN_THROTTLE(
+          this->get_logger(), *this->get_clock(), 2000,
+          "Failed to parse power_motor_48v_operation_delay_ms, defaulting to %u",
+          command.power_motor_48v_delay_ms);
+      }
+      if (!parse_uint16(
+          find_value(values, "power_extern_48v_operation_delay_ms"), command.power_extern_48v_delay_ms)) {
+        RCLCPP_WARN_THROTTLE(
+          this->get_logger(), *this->get_clock(), 2000,
+          "Failed to parse power_extern_48v_operation_delay_ms, defaulting to %u",
+          command.power_extern_48v_delay_ms);
+      }
+    }
+
+    sender_.send_state(command);
+    response->success = true;
+  }
+
+  void handle_power_heartbeat(
+    const tita_system_interfaces::srv::PowerHeartBeatSrv::Request::SharedPtr request,
+    tita_system_interfaces::srv::PowerHeartBeatSrv::Response::SharedPtr response)
+  {
+    titati::battery::PowerHeartbeat heartbeat{};
+    heartbeat.cur_mode = 0x00U;
+
+    if (request && !request->power_heart_beat.status.empty()) {
+      const auto & values = request->power_heart_beat.status.front().values;
+      (void)parse_uint8(find_value(values, "get_right_battery_history_info"), heartbeat.right_history);
+      (void)parse_uint8(find_value(values, "get_left_battery_history_info"), heartbeat.left_history);
+    }
+
+    sender_.send_heartbeat(heartbeat);
+    response->success = true;
+  }
+
+  void handle_power_self_test(
+    const tita_system_interfaces::srv::PowerSelfTestSrv::Request::SharedPtr request,
+    tita_system_interfaces::srv::PowerSelfTestSrv::Response::SharedPtr response)
+  {
+    (void)request;
+    titati::battery::PowerSelfTestReport report{};
+    report.rst = 0x1FULL;
+    report.app_version = 0x2FU;
+    report.build_timestamp = 0x3FU;
+
+    sender_.send_self_test(report);
+    response->success = true;
+  }
+
+  void send_periodic_heartbeat()
+  {
+    titati::battery::PowerHeartbeat heartbeat{};
+    heartbeat.cur_mode = 0x00U;
+    sender_.send_heartbeat(heartbeat);
+  }
+
+  titati::battery::PowerManagementSender sender_;
+
+  rclcpp::Service<tita_system_interfaces::srv::PowerStateSetSrv>::SharedPtr power_state_service_;
+  rclcpp::Service<tita_system_interfaces::srv::PowerHeartBeatSrv>::SharedPtr power_heartbeat_service_;
+  rclcpp::Service<tita_system_interfaces::srv::PowerSelfTestSrv>::SharedPtr power_self_test_service_;
+  rclcpp::TimerBase::SharedPtr heartbeat_timer_;
+};
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<TitatiBatteryDeviceNode>(rclcpp::NodeOptions{});
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}

--- a/rl_sar/src/rl_sar/src/titati_motor_test.cpp
+++ b/rl_sar/src/rl_sar/src/titati_motor_test.cpp
@@ -1,0 +1,176 @@
+/*
+ * Simple Titati motor exerciser.
+ */
+
+#include <chrono>
+#include <csignal>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "titati/force_direct_manager.hpp"
+#include "titati/tita_robot/tita_robot.hpp"
+
+namespace
+{
+volatile std::sig_atomic_t g_running = 1;
+
+void signal_handler(int)
+{
+    g_running = 0;
+}
+
+struct Options
+{
+    size_t joint = 0;
+    std::string mode = "torque";
+    double value = 0.0;
+    double kp = 0.0;
+    double kd = 0.0;
+    double duration = 2.0;
+};
+
+void print_usage()
+{
+    std::cout << "Usage: titati_motor_test [--joint <index>] [--mode torque|mit] [--value <v>] [--kp <kp>] [--kd <kd>] [--duration <s>]" << std::endl;
+    std::cout << "  --joint     Joint index [0-15] (default: 0)" << std::endl;
+    std::cout << "  --mode      Control mode: torque (Nm) or mit (rad) (default: torque)" << std::endl;
+    std::cout << "  --value     Torque (Nm) in torque mode, position (rad) in MIT mode" << std::endl;
+    std::cout << "  --kp        MIT proportional gain (used only in MIT mode)" << std::endl;
+    std::cout << "  --kd        MIT derivative gain (used only in MIT mode)" << std::endl;
+    std::cout << "  --duration  Command duration in seconds (default: 2.0)" << std::endl;
+}
+
+bool parse_arguments(int argc, char **argv, Options &opts)
+{
+    for (int i = 1; i < argc; ++i)
+    {
+        std::string arg = argv[i];
+        if (arg == "--joint" && i + 1 < argc)
+        {
+            opts.joint = static_cast<size_t>(std::stoul(argv[++i]));
+        }
+        else if (arg == "--mode" && i + 1 < argc)
+        {
+            opts.mode = argv[++i];
+        }
+        else if (arg == "--value" && i + 1 < argc)
+        {
+            opts.value = std::stod(argv[++i]);
+        }
+        else if (arg == "--kp" && i + 1 < argc)
+        {
+            opts.kp = std::stod(argv[++i]);
+        }
+        else if (arg == "--kd" && i + 1 < argc)
+        {
+            opts.kd = std::stod(argv[++i]);
+        }
+        else if (arg == "--duration" && i + 1 < argc)
+        {
+            opts.duration = std::stod(argv[++i]);
+        }
+        else if (arg == "--help" || arg == "-h")
+        {
+            print_usage();
+            return false;
+        }
+        else
+        {
+            std::cerr << "Unknown argument: " << arg << std::endl;
+            print_usage();
+            return false;
+        }
+    }
+
+    if (opts.mode != "torque" && opts.mode != "mit")
+    {
+        std::cerr << "Invalid mode: " << opts.mode << std::endl;
+        return false;
+    }
+    if (opts.joint >= 16)
+    {
+        std::cerr << "Joint index out of range: " << opts.joint << std::endl;
+        return false;
+    }
+    return true;
+}
+
+}  // namespace
+
+int main(int argc, char **argv)
+{
+    Options opts;
+    if (!parse_arguments(argc, argv, opts))
+    {
+        return 1;
+    }
+
+    std::signal(SIGINT, signal_handler);
+    std::signal(SIGTERM, signal_handler);
+
+    titati::ForceDirectManager manager;
+    manager.start();
+
+    tita_robot robot(16);
+    robot.set_motors_sdk(true);
+
+    std::cout << "Starting Titati motor test on joint " << opts.joint
+              << " using mode " << opts.mode << "." << std::endl;
+
+    auto start = std::chrono::steady_clock::now();
+    auto next_print = start;
+
+    while (g_running)
+    {
+        auto now = std::chrono::steady_clock::now();
+        double elapsed = std::chrono::duration<double>(now - start).count();
+
+        if (elapsed <= opts.duration)
+        {
+            if (opts.mode == "torque")
+            {
+                std::vector<double> torques(16, 0.0);
+                torques[opts.joint] = opts.value;
+                robot.set_target_joint_t(torques);
+            }
+            else
+            {
+                std::vector<double> q(16, 0.0), dq(16, 0.0), kp(16, 0.0), kd(16, 0.0), tau(16, 0.0);
+                q[opts.joint] = opts.value;
+                kp[opts.joint] = opts.kp;
+                kd[opts.joint] = opts.kd;
+                robot.set_target_joint_mit(q, dq, kp, kd, tau);
+            }
+        }
+        else
+        {
+            std::vector<double> zero(16, 0.0);
+            robot.set_target_joint_t(zero);
+            g_running = 0;
+        }
+
+        if (now >= next_print)
+        {
+            auto positions = robot.get_joint_q();
+            auto velocities = robot.get_joint_v();
+            auto torques = robot.get_joint_t();
+            std::cout << std::fixed << std::setprecision(3);
+            std::cout << "q[" << opts.joint << "]=" << positions[opts.joint]
+                      << " rad, dq=" << velocities[opts.joint]
+                      << " rad/s, tau=" << torques[opts.joint] << " Nm" << std::endl;
+            next_print = now + std::chrono::milliseconds(200);
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    robot.set_target_joint_t(std::vector<double>(16, 0.0));
+    robot.set_motors_sdk(false);
+    manager.stop();
+
+    std::cout << "Test finished." << std::endl;
+    return 0;
+}

--- a/rl_sar/src/rl_sar/src/titati_router_watchdog.cpp
+++ b/rl_sar/src/rl_sar/src/titati_router_watchdog.cpp
@@ -1,0 +1,35 @@
+#include <csignal>
+#include <iostream>
+#include <thread>
+
+#include "titati/force_direct_manager.hpp"
+
+namespace
+{
+volatile std::sig_atomic_t g_running = 1;
+
+void signal_handler(int)
+{
+    g_running = 0;
+}
+}
+
+int main()
+{
+    std::signal(SIGINT, signal_handler);
+    std::signal(SIGTERM, signal_handler);
+
+    titati::ForceDirectManager manager;
+    manager.start();
+
+    std::cout << "Titati CAN-FD router watchdog started. Press Ctrl+C to exit." << std::endl;
+
+    while (g_running)
+    {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+
+    manager.stop();
+    std::cout << "Watchdog stopped." << std::endl;
+    return 0;
+}

--- a/rl_sar/src/tita_system_interfaces/CMakeLists.txt
+++ b/rl_sar/src/tita_system_interfaces/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.5)
+project(tita_system_interfaces VERSION 3.0.0)
+
+if($ENV{ROS_DISTRO} MATCHES "noetic")
+  find_package(catkin REQUIRED COMPONENTS
+    diagnostic_msgs
+    message_generation
+  )
+
+  add_service_files(
+    FILES
+      PowerHeartBeatSrv.srv
+      PowerSelfTestSrv.srv
+      PowerStateSetSrv.srv
+  )
+
+  generate_messages(
+    DEPENDENCIES
+      diagnostic_msgs
+  )
+
+  catkin_package(
+    CATKIN_DEPENDS
+      diagnostic_msgs
+      message_runtime
+  )
+elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+  find_package(ament_cmake REQUIRED)
+  find_package(rosidl_default_generators REQUIRED)
+  find_package(diagnostic_msgs REQUIRED)
+
+  rosidl_generate_interfaces(${PROJECT_NAME}
+    "srv/PowerHeartBeatSrv.srv"
+    "srv/PowerSelfTestSrv.srv"
+    "srv/PowerStateSetSrv.srv"
+    DEPENDENCIES diagnostic_msgs
+  )
+
+  ament_export_dependencies(rosidl_default_runtime)
+  ament_package()
+else()
+  message(FATAL_ERROR "Unsupported ROS distribution: $ENV{ROS_DISTRO}")
+endif()

--- a/rl_sar/src/tita_system_interfaces/package.ros1.xml
+++ b/rl_sar/src/tita_system_interfaces/package.ros1.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>tita_system_interfaces</name>
+  <version>3.0.0</version>
+  <description>System service interfaces for Titati hardware.</description>
+
+  <maintainer email="fanziqi614@gmail.com">Ziqi Fan</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>diagnostic_msgs</build_depend>
+  <build_depend>message_generation</build_depend>
+  <exec_depend>diagnostic_msgs</exec_depend>
+  <exec_depend>message_runtime</exec_depend>
+</package>

--- a/rl_sar/src/tita_system_interfaces/package.ros2.xml
+++ b/rl_sar/src/tita_system_interfaces/package.ros2.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>tita_system_interfaces</name>
+  <version>3.0.0</version>
+  <description>System service interfaces for Titati hardware.</description>
+
+  <maintainer email="fanziqi614@gmail.com">Ziqi Fan</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>diagnostic_msgs</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rl_sar/src/tita_system_interfaces/srv/PowerHeartBeatSrv.srv
+++ b/rl_sar/src/tita_system_interfaces/srv/PowerHeartBeatSrv.srv
@@ -1,0 +1,3 @@
+diagnostic_msgs/DiagnosticArray power_heart_beat
+---
+bool success

--- a/rl_sar/src/tita_system_interfaces/srv/PowerSelfTestSrv.srv
+++ b/rl_sar/src/tita_system_interfaces/srv/PowerSelfTestSrv.srv
@@ -1,0 +1,3 @@
+diagnostic_msgs/DiagnosticArray power_self_test
+---
+bool success

--- a/rl_sar/src/tita_system_interfaces/srv/PowerStateSetSrv.srv
+++ b/rl_sar/src/tita_system_interfaces/srv/PowerStateSetSrv.srv
@@ -1,0 +1,3 @@
+diagnostic_msgs/DiagnosticArray power_state_set
+---
+bool success


### PR DESCRIPTION
## Summary
- add the tita_system_interfaces ROS package with Titati power management services required by the CAN-FD router
- implement a CAN power management sender and ROS2 battery_device node so the master answers self-test and heartbeat requests
- wire the new helper into the build and document starting the battery service before the router watchdog

## Testing
- ./build.sh -m *(fails: Torch_DIR not set in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c1e0a8a883219d5efe8aa952552f