### PR TITLE
Update CAN utils include paths

### DIFF
--- a/rl_sar/src/rl_sar/library/hardware/titati/battery_device/include/battery_device/power_management.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/battery_device/include/battery_device/power_management.hpp
@@ -26,7 +26,7 @@
 #include <vector>
 
 #include "battery_device/power_management_info.hpp"
-#include "protocol/can_utils.hpp"
+#include "titati/protocol/can_utils.hpp"
 
 namespace tita
 {

--- a/rl_sar/src/rl_sar/library/hardware/titati/battery_device/include/battery_device/update_battery_info.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/battery_device/include/battery_device/update_battery_info.hpp
@@ -27,7 +27,7 @@
 #include <vector>
 
 #include "battery_device/battery_info.hpp"
-#include "protocol/can_utils.hpp"
+#include "titati/protocol/can_utils.hpp"
 namespace tita
 {
 namespace battery_device

--- a/rl_sar/src/rl_sar/library/hardware/titati/battery_device/include/battery_device/update_power_info.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/battery_device/include/battery_device/update_power_info.hpp
@@ -28,7 +28,7 @@
 
 #include "battery_device/battery_info.hpp"
 #include "battery_device/power_management_info.hpp"
-#include "protocol/can_utils.hpp"
+#include "titati/protocol/can_utils.hpp"
 namespace tita
 {
 namespace battery_device

--- a/rl_sar/src/rl_sar/library/hardware/titati/battery_device/src/update_battery_info.cpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/battery_device/src/update_battery_info.cpp
@@ -14,7 +14,7 @@
 
 #include "battery_device/update_battery_info.hpp"
 
-#include "protocol/can_utils.hpp"
+#include "titati/protocol/can_utils.hpp"
 
 namespace tita
 {

--- a/rl_sar/src/rl_sar/library/hardware/titati/battery_device/src/update_power_info.cpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/battery_device/src/update_power_info.cpp
@@ -14,7 +14,7 @@
 
 #include "battery_device/update_power_info.hpp"
 
-#include "protocol/can_utils.hpp"
+#include "titati/protocol/can_utils.hpp"
 
 namespace tita
 {

--- a/rl_sar/src/rl_sar/library/hardware/titati/canfd_router/include/titati_canfd_router/canfd_router_can_receive_api.hpp
+++ b/rl_sar/src/rl_sar/library/hardware/titati/canfd_router/include/titati_canfd_router/canfd_router_can_receive_api.hpp
@@ -25,7 +25,7 @@
 #include <thread>
 #include <vector>
 
-#include "protocol/can_utils.hpp"
+#include "titati/protocol/can_utils.hpp"
 
 namespace can_device
 {

--- a/titati_control/src/tita_hardware_ros2_control/battery_device/include/battery_device/power_management.hpp
+++ b/titati_control/src/tita_hardware_ros2_control/battery_device/include/battery_device/power_management.hpp
@@ -26,7 +26,7 @@
 #include <vector>
 
 #include "battery_device/power_management_info.hpp"
-#include "protocol/can_utils.hpp"
+#include "titati/protocol/can_utils.hpp"
 
 namespace tita
 {

--- a/titati_control/src/tita_hardware_ros2_control/battery_device/include/battery_device/update_battery_info.hpp
+++ b/titati_control/src/tita_hardware_ros2_control/battery_device/include/battery_device/update_battery_info.hpp
@@ -27,7 +27,7 @@
 #include <vector>
 
 #include "battery_device/battery_info.hpp"
-#include "protocol/can_utils.hpp"
+#include "titati/protocol/can_utils.hpp"
 namespace tita
 {
 namespace battery_device

--- a/titati_control/src/tita_hardware_ros2_control/battery_device/include/battery_device/update_power_info.hpp
+++ b/titati_control/src/tita_hardware_ros2_control/battery_device/include/battery_device/update_power_info.hpp
@@ -28,7 +28,7 @@
 
 #include "battery_device/battery_info.hpp"
 #include "battery_device/power_management_info.hpp"
-#include "protocol/can_utils.hpp"
+#include "titati/protocol/can_utils.hpp"
 namespace tita
 {
 namespace battery_device

--- a/titati_control/src/tita_hardware_ros2_control/battery_device/src/update_battery_info.cpp
+++ b/titati_control/src/tita_hardware_ros2_control/battery_device/src/update_battery_info.cpp
@@ -14,7 +14,7 @@
 
 #include "battery_device/update_battery_info.hpp"
 
-#include "protocol/can_utils.hpp"
+#include "titati/protocol/can_utils.hpp"
 
 namespace tita
 {

--- a/titati_control/src/tita_hardware_ros2_control/battery_device/src/update_power_info.cpp
+++ b/titati_control/src/tita_hardware_ros2_control/battery_device/src/update_power_info.cpp
@@ -14,7 +14,7 @@
 
 #include "battery_device/update_power_info.hpp"
 
-#include "protocol/can_utils.hpp"
+#include "titati/protocol/can_utils.hpp"
 
 namespace tita
 {

--- a/titati_control/src/tita_hardware_ros2_control/tita_robot/include/tita_robot/can_receiver.hpp
+++ b/titati_control/src/tita_hardware_ros2_control/tita_robot/include/tita_robot/can_receiver.hpp
@@ -27,7 +27,7 @@
 #include <thread>
 #include <vector>
 
-#include "protocol/can_utils.hpp"
+#include "titati/protocol/can_utils.hpp"
 namespace can_device
 {
 #define PACKED __attribute__((__packed__))

--- a/titati_control/src/tita_hardware_ros2_control/tita_robot/include/tita_robot/can_sender.hpp
+++ b/titati_control/src/tita_hardware_ros2_control/tita_robot/include/tita_robot/can_sender.hpp
@@ -26,7 +26,7 @@
 #include <utility>
 #include <vector>
 
-#include "protocol/can_utils.hpp"
+#include "titati/protocol/can_utils.hpp"
 
 namespace can_device
 {

--- a/titati_control/src/titati_locomotion/titati_canfd_router/include/titati_canfd_router/canfd_router_can_receive_api.hpp
+++ b/titati_control/src/titati_locomotion/titati_canfd_router/include/titati_canfd_router/canfd_router_can_receive_api.hpp
@@ -25,7 +25,7 @@
 #include <thread>
 #include <vector>
 
-#include "protocol/can_utils.hpp"
+#include "titati/protocol/can_utils.hpp"
 
 namespace can_device
 {


### PR DESCRIPTION
## Summary
- point CAN router and battery device headers to the relocated titati/protocol CAN utilities
- update related ROS2 control headers and sources to use the same include path

## Testing
- ./rl_sar/build.sh -m *(fails: ament_cmake not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d816085bfc832188fede3436fa1c1b