### PR TITLE
Fix titati LoopFunc shutdown and FSM queue usage

### DIFF
--- a/rl_sar/src/rl_sar/library/core/loop/loop.hpp
+++ b/rl_sar/src/rl_sar/library/core/loop/loop.hpp
@@ -36,7 +36,6 @@ public:
         {
             _thread = std::thread(&LoopFunc::loop, this);
         }
-        _thread.detach();
     }
 
     void shutdown()

--- a/rl_sar/src/rl_sar/policy/titati/fsm.hpp
+++ b/rl_sar/src/rl_sar/policy/titati/fsm.hpp
@@ -253,11 +253,11 @@ public:
             {
                 if (_output_dof_pos.defined() && _output_dof_pos.numel() > 0)
                 {
-                    fsm_command->motor_command.q[i] = rl.output_dof_pos[0][i].item<double>();
+                    fsm_command->motor_command.q[i] = _output_dof_pos[0][i].item<double>();
                 }
                 if (_output_dof_vel.defined() && _output_dof_vel.numel() > 0)
                 {
-                    fsm_command->motor_command.dq[i] = rl.output_dof_vel[0][i].item<double>();
+                    fsm_command->motor_command.dq[i] = _output_dof_vel[0][i].item<double>();
                 }
                 // 使用 RL 模式的 Kp/Kd
                 fsm_command->motor_command.kp[i] = rl.params.rl_kp[0][i].item<double>();

--- a/rl_sar/src/rl_sar/src/rl_real_titati.cpp
+++ b/rl_sar/src/rl_sar/src/rl_real_titati.cpp
@@ -76,6 +76,7 @@ RL_Real::RL_Real()
 
 RL_Real::~RL_Real()
 {
+    // shutdown() blocks until the associated loop thread exits to avoid races
     this->loop_keyboard->shutdown();
     this->loop_control->shutdown();
     this->loop_rl->shutdown();


### PR DESCRIPTION
## Summary
- keep LoopFunc threads joinable so shutdown waits for loops to exit
- document blocking shutdown in RL_Real titati destructor
- consume titati locomotion queue outputs directly to avoid data races

## Testing
- not run (not available in environment)

------
https://chatgpt.com/codex/tasks/task_e_68d82f2984b48321838d08a83a21dc05