### PR TITLE
Support minimal Titati-only build

### DIFF
--- a/rl_sar/build.sh
+++ b/rl_sar/build.sh
@@ -404,7 +404,9 @@ main() {
     fi
 
     if [ "$minimal_mode" = true ]; then
+        export RL_SAR_BUILD_MINIMAL=1
         run_ros_build "${MINIMAL_TITATI_PACKAGES[@]}"
+        unset RL_SAR_BUILD_MINIMAL
     else
         run_ros_build "${packages[@]}"
     fi

--- a/rl_sar/build.sh
+++ b/rl_sar/build.sh
@@ -163,16 +163,16 @@ clean_workspace() {
     else
         print_info "Removing symlinks for specific packages..."
         for package_name in "${packages[@]}"; do
-            package_dir=$(find src -name "$package_name" -type d | head -n 1)
-            if [ -n "$package_dir" ]; then
-                if [ -L "$package_dir/package.xml" ]; then
-                    rm -f "$package_dir/package.xml"
-                    print_success "Removed symlink from $package_name"
-                else
-                    print_warning "No symlink found for $package_name"
-                fi
-            else
+            local package_dir
+            if ! package_dir=$(locate_package_dir "$package_name"); then
                 print_error "Package '$package_name' not found in src directory"
+                continue
+            fi
+            if [ -L "$package_dir/package.xml" ]; then
+                rm -f "$package_dir/package.xml"
+                print_success "Removed symlink from $package_name"
+            else
+                print_warning "No symlink found for $package_name"
             fi
         done
     fi
@@ -197,8 +197,9 @@ clean_existing_symlinks() {
         print_info "Removing existing symlinks for specified packages..."
         removed_packages=()
         for package_name in "${packages[@]}"; do
-            package_dir=$(find src -name "$package_name" -type d | head -n 1)
-            if [ -n "$package_dir" ] && [ -L "$package_dir/package.xml" ]; then
+            local package_dir
+            package_dir=$(locate_package_dir "$package_name") || continue
+            if [ -L "$package_dir/package.xml" ]; then
                 rm -f "$package_dir/package.xml"
                 removed_packages+=("$package_name")
             fi
@@ -242,6 +243,30 @@ detect_incompatible_build_artifacts() {
     else
         print_success "No incompatible build artifacts found"
     fi
+}
+
+locate_package_dir() {
+    local package_name="$1"
+    local manifest
+
+    manifest=$(find src -type f -name "package.ros1.xml" -path "*/${package_name}/package.ros1.xml" -print -quit)
+    if [ -z "$manifest" ]; then
+        manifest=$(find src -type f -name "package.ros2.xml" -path "*/${package_name}/package.ros2.xml" -print -quit)
+    fi
+
+    if [ -n "$manifest" ]; then
+        dirname "$manifest"
+        return 0
+    fi
+
+    local fallback
+    fallback=$(find src -type d -name "$package_name" -print -quit)
+    if [ -n "$fallback" ]; then
+        echo "$fallback"
+        return 0
+    fi
+
+    return 1
 }
 
 create_symlinks_for_package() {
@@ -318,8 +343,8 @@ create_symlinks_for_specific_packages() {
 
     created_packages=()
     for package_name in "${packages[@]}"; do
-        package_dir=$(find src -name "$package_name" -type d | head -n 1)
-        if [ -n "$package_dir" ] && create_symlinks_for_package "$package_dir"; then
+        local package_dir
+        if package_dir=$(locate_package_dir "$package_name") && create_symlinks_for_package "$package_dir"; then
             created_packages+=("$package_name")
         fi
     done

--- a/rl_sar/src/rl_sar/CMakeLists.txt
+++ b/rl_sar/src/rl_sar/CMakeLists.txt
@@ -26,6 +26,20 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+set(RL_SAR_BUILD_MINIMAL OFF)
+if(DEFINED ENV{RL_SAR_BUILD_MINIMAL})
+    string(TOLOWER "$ENV{RL_SAR_BUILD_MINIMAL}" RL_SAR_BUILD_MINIMAL_STR)
+    if(RL_SAR_BUILD_MINIMAL_STR STREQUAL "1"
+        OR RL_SAR_BUILD_MINIMAL_STR STREQUAL "true"
+        OR RL_SAR_BUILD_MINIMAL_STR STREQUAL "on"
+        OR RL_SAR_BUILD_MINIMAL_STR STREQUAL "yes")
+        set(RL_SAR_BUILD_MINIMAL ON)
+    endif()
+endif()
+if(RL_SAR_BUILD_MINIMAL)
+    message(STATUS "Titati minimal build enabled: skipping simulation and non-Titati robot targets")
+endif()
+
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif()
@@ -60,22 +74,30 @@ if(NOT USE_CMAKE)
         )
     elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
         find_package(ament_cmake REQUIRED)
-        find_package(joint_state_broadcaster REQUIRED)
-        find_package(robot_state_publisher REQUIRED)
         find_package(rclcpp REQUIRED)
-        find_package(gazebo_ros REQUIRED)
         find_package(std_msgs REQUIRED)
         find_package(robot_msgs REQUIRED)
         find_package(robot_joint_controller REQUIRED)
-        find_package(rclpy REQUIRED)
-        find_package(gazebo_msgs REQUIRED)
-        find_package(std_srvs REQUIRED)
         find_package(geometry_msgs REQUIRED)
         find_package(titati_can_driver REQUIRED)
+        if(NOT RL_SAR_BUILD_MINIMAL)
+            find_package(joint_state_broadcaster REQUIRED)
+            find_package(robot_state_publisher REQUIRED)
+            find_package(gazebo_ros REQUIRED)
+            find_package(rclpy REQUIRED)
+            find_package(gazebo_msgs REQUIRED)
+            find_package(std_srvs REQUIRED)
+        else()
+            message(STATUS "Skipping Gazebo ROS dependencies for Titati minimal build")
+        endif()
         ament_package()
     endif()
-    add_compile_options(${GAZEBO_CXX_FLAGS})
-    find_package(gazebo REQUIRED)
+    if(NOT RL_SAR_BUILD_MINIMAL)
+        add_compile_options(${GAZEBO_CXX_FLAGS})
+        find_package(gazebo REQUIRED)
+    else()
+        message(STATUS "Skipping Gazebo core libraries for Titati minimal build")
+    endif()
 endif()
 
 find_package(Torch REQUIRED)
@@ -86,57 +108,59 @@ find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
 link_directories(/usr/local/lib)
 include_directories(${YAML_CPP_INCLUDE_DIR})
 
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
-    message(STATUS "Current system architecture: ${CMAKE_SYSTEM_PROCESSOR}")
-    set(ARCH_DIR "aarch64")
-    set(UNITREE_LIB "libunitree_legged_sdk_arm64")
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64")
-message(STATUS "Current system architecture: ${CMAKE_SYSTEM_PROCESSOR}")
-    set(ARCH_DIR "x86_64")
-    set(UNITREE_LIB "libunitree_legged_sdk_amd64")
-else()
-    message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
-endif()
+if(NOT RL_SAR_BUILD_MINIMAL)
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
+        message(STATUS "Current system architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+        set(ARCH_DIR "aarch64")
+        set(UNITREE_LIB "libunitree_legged_sdk_arm64")
+    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64")
+        message(STATUS "Current system architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+        set(ARCH_DIR "x86_64")
+        set(UNITREE_LIB "libunitree_legged_sdk_amd64")
+    else()
+        message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+    endif()
 
-# unitree_legged_sdk-3.2
-add_library(unitree_legged_sdk SHARED IMPORTED)
-set_target_properties(unitree_legged_sdk PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/unitree_legged_sdk-3.2/include"
-    IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/unitree_legged_sdk-3.2/lib/${UNITREE_LIB}.so"
-)
-set(UNITREE_A1_LIBS Threads::Threads unitree_legged_sdk lcm)
-if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-    file(GLOB GLOB_UNITREE_LEGGED_SDK "${CMAKE_CURRENT_SOURCE_DIR}/library/unitree_legged_sdk-3.2/lib/${UNITREE_LIB}.so")
-    install(FILES
-        ${GLOB_UNITREE_LEGGED_SDK}
-        DESTINATION lib/
+    # unitree_legged_sdk-3.2
+    add_library(unitree_legged_sdk SHARED IMPORTED)
+    set_target_properties(unitree_legged_sdk PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/unitree_legged_sdk-3.2/include"
+        IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/unitree_legged_sdk-3.2/lib/${UNITREE_LIB}.so"
     )
-endif()
+    set(UNITREE_A1_LIBS Threads::Threads unitree_legged_sdk lcm)
+    if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+        file(GLOB GLOB_UNITREE_LEGGED_SDK "${CMAKE_CURRENT_SOURCE_DIR}/library/unitree_legged_sdk-3.2/lib/${UNITREE_LIB}.so")
+        install(FILES
+            ${GLOB_UNITREE_LEGGED_SDK}
+            DESTINATION lib/
+        )
+    endif()
 
-# unitree_sdk2-2.0.0
-set(BUILD_EXAMPLES OFF CACHE BOOL "Disable examples build for unitree_sdk2" FORCE)
-add_subdirectory(library/thirdparty/unitree_sdk2-2.0.0)
+    # unitree_sdk2-2.0.0
+    set(BUILD_EXAMPLES OFF CACHE BOOL "Disable examples build for unitree_sdk2" FORCE)
+    add_subdirectory(library/thirdparty/unitree_sdk2-2.0.0)
 
-# l4w4_sdk
-add_library(l4w4_sdk INTERFACE)
-target_include_directories(l4w4_sdk INTERFACE
-    library/thirdparty/l4w4_sdk
-)
-target_link_libraries(l4w4_sdk INTERFACE Threads::Threads)
-
-# Lite3_MotionSDK
-add_library(lite3_motionsdk SHARED IMPORTED)
-set_target_properties(lite3_motionsdk PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/include"
-    IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/lib/libdeeprobotics_legged_sdk_${ARCH_DIR}.so"
-)
-set(LITE3_REAL_LIBS Threads::Threads lite3_motionsdk)
-if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-    file(GLOB GLOB_LITE3_SDK_SO "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/lib/libdeeprobotics_legged_sdk_${ARCH_DIR}.so")
-    install(FILES
-        ${GLOB_LITE3_SDK_SO}
-        DESTINATION lib/
+    # l4w4_sdk
+    add_library(l4w4_sdk INTERFACE)
+    target_include_directories(l4w4_sdk INTERFACE
+        library/thirdparty/l4w4_sdk
     )
+    target_link_libraries(l4w4_sdk INTERFACE Threads::Threads)
+
+    # Lite3_MotionSDK
+    add_library(lite3_motionsdk SHARED IMPORTED)
+    set_target_properties(lite3_motionsdk PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/include"
+        IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/lib/libdeeprobotics_legged_sdk_${ARCH_DIR}.so"
+    )
+    set(LITE3_REAL_LIBS Threads::Threads lite3_motionsdk)
+    if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+        file(GLOB GLOB_LITE3_SDK_SO "${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/Lite3_MotionSDK/lib/libdeeprobotics_legged_sdk_${ARCH_DIR}.so")
+        install(FILES
+            ${GLOB_LITE3_SDK_SO}
+            DESTINATION lib/
+        )
+    endif()
 endif()
 
 # Retroid Gamepad
@@ -197,7 +221,7 @@ if(NOT USE_CMAKE)
     endif()
 endif()
 
-if(NOT USE_CMAKE)
+if(NOT USE_CMAKE AND NOT RL_SAR_BUILD_MINIMAL)
     add_executable(rl_sim src/rl_sim.cpp)
     target_link_libraries(rl_sim
         rl_sdk
@@ -225,104 +249,106 @@ if(NOT USE_CMAKE)
     endif()
 endif()
 
-add_executable(rl_real_a1 src/rl_real_a1.cpp)
-target_link_libraries(rl_real_a1
-    ${UNITREE_A1_LIBS}
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
-if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_a1 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_a1
-            rclcpp
-            geometry_msgs
-        )
-        install(TARGETS rl_real_a1 DESTINATION lib/${PROJECT_NAME})
+if(NOT RL_SAR_BUILD_MINIMAL)
+    add_executable(rl_real_a1 src/rl_real_a1.cpp)
+    target_link_libraries(rl_real_a1
+        ${UNITREE_A1_LIBS}
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_a1 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_a1
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_a1 DESTINATION lib/${PROJECT_NAME})
+        endif()
     endif()
-endif()
 
-add_executable(rl_real_lite3
-    src/rl_real_lite3.cpp
-    ${GAMEPAD_SRC}
-)
-target_link_libraries(rl_real_lite3
-    ${LITE3_REAL_LIBS}
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
-target_include_directories(rl_real_lite3 PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/gamepad/include
-)
-if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_lite3 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_lite3
-            rclcpp
-            geometry_msgs
-        )
-        install(TARGETS rl_real_lite3 DESTINATION lib/${PROJECT_NAME})
+    add_executable(rl_real_lite3
+        src/rl_real_lite3.cpp
+        ${GAMEPAD_SRC}
+    )
+    target_link_libraries(rl_real_lite3
+        ${LITE3_REAL_LIBS}
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    target_include_directories(rl_real_lite3 PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/library/thirdparty/gamepad/include
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_lite3 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_lite3
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_lite3 DESTINATION lib/${PROJECT_NAME})
+        endif()
     endif()
-endif()
 
-add_executable(rl_real_go2 src/rl_real_go2.cpp)
-target_link_libraries(rl_real_go2
-    unitree_sdk2
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
-if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_go2 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_go2
-            rclcpp
-            geometry_msgs
-        )
-        install(TARGETS rl_real_go2 DESTINATION lib/${PROJECT_NAME})
+    add_executable(rl_real_go2 src/rl_real_go2.cpp)
+    target_link_libraries(rl_real_go2
+        unitree_sdk2
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_go2 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_go2
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_go2 DESTINATION lib/${PROJECT_NAME})
+        endif()
     endif()
-endif()
 
-add_executable(rl_real_g1 src/rl_real_g1.cpp)
-target_link_libraries(rl_real_g1
-    unitree_sdk2
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
-if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_g1 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_g1
-            rclcpp
-            geometry_msgs
-        )
-        install(TARGETS rl_real_g1 DESTINATION lib/${PROJECT_NAME})
+    add_executable(rl_real_g1 src/rl_real_g1.cpp)
+    target_link_libraries(rl_real_g1
+        unitree_sdk2
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_g1 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_g1
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_g1 DESTINATION lib/${PROJECT_NAME})
+        endif()
     endif()
-endif()
 
-add_executable(rl_real_l4w4 src/rl_real_l4w4.cpp)
-target_link_libraries(rl_real_l4w4
-    l4w4_sdk
-    rl_sdk
-    observation_buffer
-    yaml-cpp
-)
-if(NOT USE_CMAKE)
-    if($ENV{ROS_DISTRO} MATCHES "noetic")
-        target_link_libraries(rl_real_l4w4 ${catkin_LIBRARIES})
-    elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
-        ament_target_dependencies(rl_real_l4w4
-            rclcpp
-            geometry_msgs
-        )
-        install(TARGETS rl_real_l4w4 DESTINATION lib/${PROJECT_NAME})
+    add_executable(rl_real_l4w4 src/rl_real_l4w4.cpp)
+    target_link_libraries(rl_real_l4w4
+        l4w4_sdk
+        rl_sdk
+        observation_buffer
+        yaml-cpp
+    )
+    if(NOT USE_CMAKE)
+        if($ENV{ROS_DISTRO} MATCHES "noetic")
+            target_link_libraries(rl_real_l4w4 ${catkin_LIBRARIES})
+        elseif($ENV{ROS_DISTRO} MATCHES "foxy|humble")
+            ament_target_dependencies(rl_real_l4w4
+                rclcpp
+                geometry_msgs
+            )
+            install(TARGETS rl_real_l4w4 DESTINATION lib/${PROJECT_NAME})
+        endif()
     endif()
 endif()
 
@@ -360,7 +386,7 @@ if(NOT USE_CMAKE)
     endif()
 endif()
 
-if(NOT USE_CMAKE)
+if(NOT USE_CMAKE AND NOT RL_SAR_BUILD_MINIMAL)
     if($ENV{ROS_DISTRO} MATCHES "foxy|humble")
         install(
             DIRECTORY launch worlds policy

--- a/rl_sar/src/rl_sar/package.ros2.xml
+++ b/rl_sar/src/rl_sar/package.ros2.xml
@@ -20,6 +20,7 @@
     <depend>joint_state_controller</depend>
     <depend>robot_state_publisher</depend>
     <depend>rospy</depend>
+    <depend>titati_can_driver</depend>
 
     <export>
         <build_type>ament_cmake</build_type>


### PR DESCRIPTION
## Summary
- add a build flag that disables Gazebo and non-Titati targets when running the minimal hardware build
- gate Unitree/Lite3 integrations and simulation executables behind the new flag while keeping rl_real_titati enabled
- declare the titati_can_driver dependency so the hardware executable can resolve the driver when built via colcon

## Testing
- not run (ROS/colcon tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d8a94a0aa88321885a0de222996c8f